### PR TITLE
chore: replace GCP Cloud Run references with Cloudflare Tunnel

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -96,13 +96,14 @@ jobs:
           exit 1
 
   # ===========================================
-  # Deploy to GCP Cloud Run
+  # Deploy job (DISABLED - GCP Cloud Run decommissioned)
+  # Biometric processor now deploys via Cloudflare Tunnel on local GPU
   # ===========================================
   deploy:
     name: Deploy to Cloud Run
     runs-on: ubuntu-latest
     needs: docker-build
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: false  # Disabled: GCP Cloud Run deployment decommissioned
 
     permissions:
       contents: 'read'

--- a/CLEANUP_PLAN.md
+++ b/CLEANUP_PLAN.md
@@ -34,7 +34,7 @@ biometric-processor/
 │   │
 │   ├── 3-deployment/
 │   │   ├── DEPLOYMENT_GUIDE.md
-│   │   ├── GCP_DEPLOYMENT.md
+│   │   ├── HETZNER_DEPLOYMENT.md
 │   │   └── DATABASE_SETUP.md
 │   │
 │   ├── 4-testing/

--- a/docs/1-getting-started/QUICK_TEST_GUIDE.md
+++ b/docs/1-getting-started/QUICK_TEST_GUIDE.md
@@ -1,7 +1,9 @@
 # Quick Test Guide for Deployed API
 
+> **Note:** The GCP Cloud Run deployment (`biometric-api-902542798396.europe-west1.run.app`) is no longer active. The biometric-processor now runs locally via WSL2 and is exposed via Cloudflare Tunnel at `https://bpa-fivucsas.rollingcatsoftware.com`. Replace all URLs below with the Cloudflare Tunnel URL when the tunnel is running, or `http://localhost:8001` for local testing.
+
 Since you have access to the deployed API at:
-**https://biometric-api-902542798396.europe-west1.run.app**
+**https://bpa-fivucsas.rollingcatsoftware.com** (or `http://localhost:8001` locally)
 
 Here are quick tests you can run from your browser or terminal.
 

--- a/docs/2-api-documentation/API_REFERENCE.md
+++ b/docs/2-api-documentation/API_REFERENCE.md
@@ -13,7 +13,7 @@
 | Metric | Status | Details |
 |--------|--------|---------|
 | **Project Completion** | 100% | All MVP features implemented |
-| **Production Deployment** | ✅ DEPLOYED | GCP Cloud Run (europe-west1) |
+| **Production Deployment** | ⏳ PENDING | Cloudflare Tunnel (bpa-fivucsas.rollingcatsoftware.com) |
 | **Recent Testing** | ⚠️ PARTIAL | Local testing completed, deployment inaccessible from this environment |
 | **Critical Bugs Fixed** | ✅ 6/6 | All December 27 bugs resolved |
 | **Infrastructure** | ✅ COMPLETE | CI/CD, monitoring, database setup |
@@ -32,24 +32,24 @@ The biometric processor API is **fully functional** based on local testing compl
 
 ## Deployment Information
 
-### GCP Cloud Run Deployment
+> **Note:** The GCP Cloud Run deployment (December 2025) is no longer active. See `DEPLOYMENT_CHALLENGES.md` for historical details. Current deployment target is WSL2/local GPU via Cloudflare Tunnel.
+
+### Current Deployment Target
 
 | Resource | Details |
 |----------|---------|
-| **Service URL** | https://biometric-api-902542798396.europe-west1.run.app |
-| **Region** | europe-west1 |
-| **Status** | ✅ Deployed (Dec 28, 2025) |
-| **Resources** | 2 CPU, 2GB RAM |
-| **Database** | PostgreSQL 15 + pgvector (Cloud SQL) |
-| **Cache** | Redis 7.0 (Memorystore) |
-| **Monitoring** | Cloud Monitoring + Uptime Checks (5-min interval) |
+| **Service URL** | https://bpa-fivucsas.rollingcatsoftware.com (Cloudflare Tunnel) |
+| **Local URL** | http://localhost:8001 |
+| **Status** | ⏳ Pending (tunnel setup required) |
+| **Resources** | Local GPU (NVIDIA GTX 1650, 4GB VRAM) |
+| **Database** | PostgreSQL 16 + pgvector (local Docker) |
+| **Cache** | Redis 7 (local Docker) |
 
-### Deployment History
+### Deployment History (Historical)
 
-- **7 revision attempts** before successful deployment
+- **7 GCP Cloud Run revision attempts** before successful deployment (Dec 2025, now decommissioned)
 - **All dependency issues resolved** (NumPy 2.x, Keras 3.x, OpenGL, lightphe, prometheus_client)
 - **Database pgvector extension** successfully enabled via Cloud Run Job
-- **CI/CD pipelines** fully operational
 
 ---
 

--- a/docs/DEPLOYMENT_CHALLENGES.md
+++ b/docs/DEPLOYMENT_CHALLENGES.md
@@ -1,5 +1,7 @@
 # GCP Cloud Run Deployment Challenges & Resolution
 
+> **Historical document:** This records issues from the December 2025 GCP Cloud Run deployment, which is no longer in use. The biometric-processor now targets local/WSL2 deployment via Cloudflare Tunnel. See `deploy/laptop-gpu/` for current deployment scripts.
+
 This document records the issues encountered during deployment to Google Cloud Platform Cloud Run on 2025-12-28, along with the infrastructure improvements implemented to prevent future issues.
 
 ## Executive Summary

--- a/requirements-gcp.txt
+++ b/requirements-gcp.txt
@@ -1,5 +1,5 @@
-# GCP Cloud Run - CPU-only ML dependencies
-# Optimized for Cloud Run's buildpack system
+# CPU-only ML dependencies (historical: originally for GCP Cloud Run)
+# Now used as reference for CPU-only deployment without GPU
 
 # ===========================================
 # Core API Framework

--- a/scripts/docker-build-test.ps1
+++ b/scripts/docker-build-test.ps1
@@ -1,5 +1,5 @@
 # Local Docker Build Test Script (PowerShell)
-# Run this before pushing to GCP to catch dependency issues early
+# Run this before deployment to catch dependency issues early
 
 $ErrorActionPreference = "Stop"
 
@@ -75,5 +75,5 @@ docker rm -f $CONTAINER_NAME
 
 Write-Host "==========================================" -ForegroundColor Green
 Write-Host "ALL TESTS PASSED!" -ForegroundColor Green
-Write-Host "Safe to deploy to GCP Cloud Run" -ForegroundColor Green
+Write-Host "Safe to deploy via Cloudflare Tunnel" -ForegroundColor Green
 Write-Host "==========================================" -ForegroundColor Green

--- a/scripts/docker-build-test.sh
+++ b/scripts/docker-build-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Local Docker Build Test Script
-# Run this before pushing to GCP to catch dependency issues early
+# Run this before deployment to catch dependency issues early
 
 set -e
 
@@ -73,5 +73,5 @@ docker rm -f $CONTAINER_NAME
 
 echo "=========================================="
 echo "ALL TESTS PASSED!"
-echo "Safe to deploy to GCP Cloud Run"
+echo "Safe to deploy via Cloudflare Tunnel"
 echo "=========================================="


### PR DESCRIPTION
## Summary
- Disabled GCP deploy job in CI/CD (`if: false`)
- Updated deployment docs: GCP Cloud Run → Cloudflare Tunnel from local GPU
- Updated docker-build-test scripts, CLEANUP_PLAN, API_REFERENCE, QUICK_TEST_GUIDE
- Added historical note to DEPLOYMENT_CHALLENGES.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)