### PR TITLE
feat(config): startup validator rejects GPU-needing ML choices on CPU box

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,11 +1,36 @@
 """Application configuration with Pydantic validation."""
 
+import logging
 import os
 from pathlib import Path
 from typing import List, Literal, Optional
 
-from pydantic import AliasChoices, Field, field_validator
+from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings
+
+_logger = logging.getLogger(__name__)
+
+# Backends/models that effectively require a GPU on commodity CPU boxes
+# (e.g. Hetzner CX43). These fall in two tiers:
+#   HARD: refuse to boot under default config — operator must consciously
+#         opt in via ALLOW_HEAVY_ML=true on a GPU host.
+#   SOFT: warn-only. Production currently runs Facenet512 on CPU (CX43) and
+#         it is stable, just slower. Hard-failing would break prod boot.
+HEAVY_DETECTION_BACKENDS_HARD: frozenset = frozenset({
+    "retinaface",
+    "yolov8",
+    "yolov11n",
+    "yolov11s",
+    "yolov12n",
+})
+HEAVY_RECOGNITION_MODELS_HARD: frozenset = frozenset({
+    "ArcFace",
+    "VGG-Face",
+    "GhostFaceNet",
+})
+HEAVY_RECOGNITION_MODELS_SOFT: frozenset = frozenset({
+    "Facenet512",
+})
 
 # Repo root resolved once for default model paths (biometric-processor/).
 _REPO_ROOT = Path(__file__).parent.parent.parent
@@ -74,6 +99,20 @@ class Settings(BaseSettings):
     ] = Field(default="Facenet")
 
     MODEL_DEVICE: Literal["cpu", "cuda"] = Field(default="cpu")
+
+    # Startup safety gate for GPU-needing ML choices.
+    # Default False so a CPU-only host (e.g. Hetzner CX43) cannot accidentally
+    # be launched with retinaface / yolo* / ArcFace / VGG-Face / GhostFaceNet
+    # backends that are unusably slow without a GPU. Operators on a GPU host
+    # must explicitly set ALLOW_HEAVY_ML=true.
+    ALLOW_HEAVY_ML: bool = Field(
+        default=False,
+        description=(
+            "Set to True only on a host with a CUDA-capable GPU. When False "
+            "(default), startup will refuse heavy detection/recognition models "
+            "that need GPU for sane latency."
+        ),
+    )
 
     # Anti-Spoofing (DeepFace 0.0.98+ built-in)
     ANTI_SPOOFING_ENABLED: bool = Field(
@@ -659,6 +698,56 @@ class Settings(BaseSettings):
         if v <= warning:
             raise ValueError("critical threshold must be greater than warning threshold")
         return v
+
+    @model_validator(mode="after")
+    def validate_ml_cpu_safety(self) -> "Settings":
+        """Refuse to boot with GPU-needing ML choices on a CPU-only host.
+
+        Addresses FINDINGS_2026-04-25 B1. Splits heavy backends/models into:
+          - HARD-fail (raise ValueError): retinaface, yolo*, ArcFace,
+            VGG-Face, GhostFaceNet — unusable without a GPU.
+          - SOFT-warn (log only): Facenet512 — technically CPU-runnable but
+            slow; production currently runs this config on CX43, so we must
+            not crash boot.
+
+        The check is bypassed entirely when ALLOW_HEAVY_ML=True, which the
+        operator should set only on a GPU host.
+        """
+        if self.ALLOW_HEAVY_ML:
+            return self
+
+        backend = self.FACE_DETECTION_BACKEND
+        model = self.FACE_RECOGNITION_MODEL
+
+        if backend in HEAVY_DETECTION_BACKENDS_HARD:
+            raise ValueError(
+                f"FACE_DETECTION_BACKEND='{backend}' requires a GPU for "
+                f"acceptable latency on this server. Either pick a "
+                f"CPU-friendly backend (e.g. 'opencv', 'ssd', 'mediapipe', "
+                f"'centerface') or set ALLOW_HEAVY_ML=true if this host has "
+                f"a CUDA-capable GPU."
+            )
+
+        if model in HEAVY_RECOGNITION_MODELS_HARD:
+            raise ValueError(
+                f"FACE_RECOGNITION_MODEL='{model}' requires a GPU for "
+                f"acceptable latency on this server. Either pick a "
+                f"CPU-friendly model (e.g. 'Facenet', 'OpenFace', 'SFace', "
+                f"'Dlib') or set ALLOW_HEAVY_ML=true if this host has a "
+                f"CUDA-capable GPU."
+            )
+
+        if model in HEAVY_RECOGNITION_MODELS_SOFT:
+            _logger.warning(
+                "FACE_RECOGNITION_MODEL='%s' is CPU-runnable but noticeably "
+                "slower than 'Facenet'. Boot continues because production "
+                "currently uses this config. Set ALLOW_HEAVY_ML=true to "
+                "silence this warning on a GPU host, or switch to 'Facenet' "
+                "for a CPU-friendly default.",
+                model,
+            )
+
+        return self
 
     model_config = {
         "env_file": ".env",

--- a/tests/unit/test_config_validator.py
+++ b/tests/unit/test_config_validator.py
@@ -1,0 +1,106 @@
+"""Tests for the CPU-safety startup validator on Settings.
+
+Covers FINDINGS_2026-04-25 B1: refuse to boot with GPU-needing ML choices
+on a CPU-only host (e.g. Hetzner CX43) unless the operator explicitly sets
+ALLOW_HEAVY_ML=true.
+
+Notes:
+- Pydantic v2 wraps validator errors in ``ValidationError``. The original
+  ``ValueError`` we raise is preserved as the underlying cause / message,
+  so we accept either when asserting "raises".
+- ``Facenet512`` is the SOFT-tier recognition model: prod currently runs
+  it on CPU, so it must warn-log but NOT crash boot.
+"""
+
+import logging
+
+import pytest
+from pydantic import ValidationError
+
+from app.core.config import Settings
+
+
+def _make(**overrides) -> Settings:
+    """Build a Settings instance, ignoring any ambient .env file.
+
+    We pass overrides directly (kwargs take priority over env), and we also
+    explicitly clear _env_file so a developer's .env can't accidentally
+    flip the test's expected outcome.
+    """
+    return Settings(_env_file=None, **overrides)
+
+
+class TestConfigValidatorCpuSafety:
+    """Startup validator: GPU-needing ML choices on CPU box."""
+
+    def test_default_config_loads_cleanly(self):
+        """Default config (opencv + Facenet) must load without raising."""
+        s = _make()
+        assert s.FACE_DETECTION_BACKEND == "opencv"
+        assert s.FACE_RECOGNITION_MODEL == "Facenet"
+        assert s.ALLOW_HEAVY_ML is False
+
+    def test_retinaface_without_allow_heavy_ml_raises(self):
+        """Heavy detection backend must fail fast on a CPU box."""
+        with pytest.raises((ValidationError, ValueError)) as exc_info:
+            _make(FACE_DETECTION_BACKEND="retinaface")
+        msg = str(exc_info.value)
+        assert "FACE_DETECTION_BACKEND" in msg
+        assert "ALLOW_HEAVY_ML" in msg
+
+    @pytest.mark.parametrize("backend", [
+        "yolov8", "yolov11n", "yolov11s", "yolov12n",
+    ])
+    def test_yolo_backends_raise(self, backend):
+        """All YOLO detector variants are GPU-only by default."""
+        with pytest.raises((ValidationError, ValueError)):
+            _make(FACE_DETECTION_BACKEND=backend)
+
+    @pytest.mark.parametrize("model", ["ArcFace", "VGG-Face", "GhostFaceNet"])
+    def test_heavy_recognition_models_raise(self, model):
+        """ArcFace / VGG-Face / GhostFaceNet must hard-fail on CPU."""
+        with pytest.raises((ValidationError, ValueError)) as exc_info:
+            _make(FACE_RECOGNITION_MODEL=model)
+        msg = str(exc_info.value)
+        assert "FACE_RECOGNITION_MODEL" in msg
+
+    def test_allow_heavy_ml_unblocks_retinaface(self):
+        """Operator opt-in must permit heavy backends."""
+        s = _make(FACE_DETECTION_BACKEND="retinaface", ALLOW_HEAVY_ML=True)
+        assert s.FACE_DETECTION_BACKEND == "retinaface"
+        assert s.ALLOW_HEAVY_ML is True
+
+    def test_allow_heavy_ml_unblocks_arcface(self):
+        """Operator opt-in must permit heavy recognition models."""
+        s = _make(FACE_RECOGNITION_MODEL="ArcFace", ALLOW_HEAVY_ML=True)
+        assert s.FACE_RECOGNITION_MODEL == "ArcFace"
+
+    def test_facenet512_warns_but_does_not_crash(self, caplog):
+        """SOFT tier: Facenet512 boots (prod uses it) but emits a WARN."""
+        with caplog.at_level(logging.WARNING, logger="app.core.config"):
+            s = _make(FACE_RECOGNITION_MODEL="Facenet512")
+        assert s.FACE_RECOGNITION_MODEL == "Facenet512"
+        assert any(
+            "Facenet512" in record.message and record.levelno == logging.WARNING
+            for record in caplog.records
+        ), f"expected a WARNING about Facenet512, got: {caplog.records!r}"
+
+    def test_prod_current_config_does_not_crash(self):
+        """Smoke: prod compose hardcodes Facenet512 + opencv. Must boot."""
+        s = _make(
+            FACE_DETECTION_BACKEND="opencv",
+            FACE_RECOGNITION_MODEL="Facenet512",
+        )
+        assert s.FACE_DETECTION_BACKEND == "opencv"
+        assert s.FACE_RECOGNITION_MODEL == "Facenet512"
+
+    def test_facenet512_with_allow_heavy_ml_no_warning(self, caplog):
+        """When operator opted in, no warning is emitted."""
+        with caplog.at_level(logging.WARNING, logger="app.core.config"):
+            s = _make(FACE_RECOGNITION_MODEL="Facenet512", ALLOW_HEAVY_ML=True)
+        assert s.FACE_RECOGNITION_MODEL == "Facenet512"
+        # no warning expected on opt-in path
+        assert not any(
+            "Facenet512" in r.message and r.levelno == logging.WARNING
+            for r in caplog.records
+        )


### PR DESCRIPTION
## Summary

Adds a startup config validator on `Settings` that fails fast (or warn-logs, depending on tier) when the service is launched with backends/models that need a GPU for sane latency on a commodity CPU host (Hetzner CX43). Addresses **FINDINGS_2026-04-25 B1**.

## What changed

- New env var `ALLOW_HEAVY_ML: bool = False`. Operators must explicitly set this on a GPU host.
- New Pydantic v2 `@model_validator(mode='after')` `validate_ml_cpu_safety` on `Settings`.

### Tiers

**HARD-fail (raises ValueError at startup, names the offending env var):**
- Detection: `retinaface`, `yolov8`, `yolov11n`, `yolov11s`, `yolov12n`
- Recognition: `ArcFace`, `VGG-Face`, `GhostFaceNet`

**SOFT-warn (log-only, boot continues):**
- Recognition: `Facenet512`

The Facenet512 SOFT path exists because **production currently runs `Facenet512 + opencv` on CX43** (per `docker-compose.prod.yml` hardcode) and is stable, just slower than `Facenet`. Hard-failing here would break prod boot. The warning tells operators to either set `ALLOW_HEAVY_ML=true` to silence it (GPU host) or switch to `Facenet`.

When `ALLOW_HEAVY_ML=true`, the validator is bypassed entirely.

## Tests

`tests/unit/test_config_validator.py` (14 cases, all passing locally):
- Default config (`opencv` + `Facenet`) loads cleanly.
- `retinaface` raises without `ALLOW_HEAVY_ML=true`.
- All four YOLO variants raise.
- `ArcFace`, `VGG-Face`, `GhostFaceNet` raise.
- `ALLOW_HEAVY_ML=true` unblocks both detection and recognition heavies.
- `Facenet512` emits a WARNING but does not crash.
- Prod-current (`opencv` + `Facenet512`) boots cleanly.
- `Facenet512 + ALLOW_HEAVY_ML=true` is silent (no warning).

```
$ pytest tests/unit/test_config_validator.py -v
======================= 14 passed, 15 warnings in 0.25s =======================
```

## Boot smoke check (prod-current config)

```
$ FACE_RECOGNITION_MODEL=Facenet512 FACE_DETECTION_BACKEND=opencv python3 -c "from app.core.config import Settings; Settings(_env_file=None); print('BOOT OK')"
WARNING:app.core.config:FACE_RECOGNITION_MODEL='Facenet512' is CPU-runnable but noticeably slower than 'Facenet'. Boot continues because production currently uses this config...
BOOT OK
```

## Test plan

- [ ] Reviewer: confirm tier split matches your expectation (Facenet512 SOFT vs HARD).
- [ ] On staging/prod, confirm the existing `Facenet512 + opencv` configuration boots and only emits a WARN (not a hard error).
- [ ] Optional: try setting `FACE_DETECTION_BACKEND=retinaface` in `.env` and confirm the service refuses to boot with a clear error message naming `ALLOW_HEAVY_ML`.