### PR TITLE
chore(ml): gate demographics router behind DEMOGRAPHICS_ROUTER_ENABLED flag (default off)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -377,7 +377,21 @@ class Settings(BaseSettings):
         return limits.get(endpoint_type, self.RATE_LIMIT_PER_MINUTE)
 
     # Demographics Analysis
-    DEMOGRAPHICS_ENABLED: bool = Field(default=True)
+    # NOTE (FINDINGS_2026-04-25 B2): the demographics router is OFF by default.
+    # web-app has zero callers for /api/v1/demographics/*, and DeepFace.analyze
+    # would lazy-load 4 extra models (age + gender + race + emotion, ~400 MB
+    # resident on CPU box) the first time it is hit.  Hetzner CX43 is at 94%
+    # memory; we don't want a stray demo client to swing it into OOM.  Operators
+    # who actually need demographics must opt in via DEMOGRAPHICS_ROUTER_ENABLED=true.
+    DEMOGRAPHICS_ROUTER_ENABLED: bool = Field(
+        default=False,
+        description=(
+            "Enable /api/v1/demographics/* routes. Off by default — frontend "
+            "doesn't call this; loading age/gender/race/emotion models wastes "
+            "~400 MB."
+        ),
+    )
+    DEMOGRAPHICS_ENABLED: bool = Field(default=True)  # legacy flag, retained for back-compat
     DEMOGRAPHICS_INCLUDE_RACE: bool = Field(default=False)  # Privacy consideration
     DEMOGRAPHICS_INCLUDE_EMOTION: bool = Field(default=True)
 

--- a/app/main.py
+++ b/app/main.py
@@ -225,7 +225,17 @@ app.include_router(verification_pipeline.router, prefix=API_PREFIX)
 # New feature routes
 app.include_router(quality.router, prefix=API_PREFIX)
 app.include_router(multi_face.router, prefix=API_PREFIX)
-app.include_router(demographics.router, prefix=API_PREFIX)
+# Demographics router is gated behind DEMOGRAPHICS_ROUTER_ENABLED (default off).
+# See FINDINGS_2026-04-25 B2: web-app has zero callers and DeepFace.analyze
+# would lazy-load 4 extra age/gender/race/emotion models (~400 MB) on first hit.
+if settings.DEMOGRAPHICS_ROUTER_ENABLED:
+    app.include_router(demographics.router, prefix=API_PREFIX)
+    logger.info("Demographics router enabled (DEMOGRAPHICS_ROUTER_ENABLED=true)")
+else:
+    logger.info(
+        "Demographics router DISABLED (DEMOGRAPHICS_ROUTER_ENABLED=false). "
+        "Set DEMOGRAPHICS_ROUTER_ENABLED=true to enable /api/v1/demographics/*."
+    )
 app.include_router(landmarks.router, prefix=API_PREFIX)
 app.include_router(comparison.router, prefix=API_PREFIX)
 app.include_router(similarity_matrix.router, prefix=API_PREFIX)

--- a/tests/unit/test_demographics_gating.py
+++ b/tests/unit/test_demographics_gating.py
@@ -1,0 +1,115 @@
+"""Tests for demographics router feature-flag gating.
+
+Covers FINDINGS_2026-04-25 B2: the /api/v1/demographics/* routes must be
+disabled by default and only registered when DEMOGRAPHICS_ROUTER_ENABLED=true.
+
+Rationale: web-app has zero callers for this endpoint, and DeepFace.analyze
+lazy-loads 4 extra models (age/gender/race/emotion, ~400 MB) the first time
+it is hit. Hetzner CX43 prod is memory-constrained; we don't want a stray
+caller to swing it into OOM.
+
+Implementation note: we don't import ``app.main`` directly, because that
+module wires up the full container, GPU detection, lifespan handlers, and
+real ML preloading.  Instead we replicate the small gating block under test
+on a fresh ``FastAPI`` instance.  This mirrors what main.py does at module
+load and keeps the test fast and isolated.
+"""
+
+import importlib
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+API_PREFIX = "/api/v1"
+
+
+def _try_import_demographics_router():
+    """Import the demographics route module if heavy ML deps are present.
+
+    Importing ``app.api.routes.demographics`` transitively pulls cv2 and
+    DeepFace via ``app.core.container``.  In a stripped-down dev env those
+    may be missing — return None so the route-registration tests skip
+    cleanly while the Settings-default tests below keep running.
+    """
+    try:
+        return importlib.import_module("app.api.routes.demographics")
+    except ImportError as e:  # pragma: no cover - exercised only in light envs
+        pytest.skip(f"heavy ML deps not installed: {e}")
+
+
+def _build_app(*, demographics_enabled: bool) -> FastAPI:
+    """Build a minimal FastAPI app with the same gating logic as main.py."""
+    app = FastAPI()
+    if demographics_enabled:
+        demographics = _try_import_demographics_router()
+        app.include_router(demographics.router, prefix=API_PREFIX)
+    return app
+
+
+class TestDemographicsRouterGating:
+    """B2: demographics router must be off by default."""
+
+    def test_router_absent_when_disabled(self):
+        """With the flag OFF, /api/v1/demographics/analyze must 404."""
+        app = _build_app(demographics_enabled=False)
+        client = TestClient(app)
+
+        # POST is the real verb; we don't even need a valid file because the
+        # route doesn't exist — FastAPI must answer 404 before any handler runs.
+        resp = client.post(f"{API_PREFIX}/demographics/analyze")
+        assert resp.status_code == 404, (
+            f"expected 404 (route not registered) but got {resp.status_code}: "
+            f"{resp.text[:200]}"
+        )
+
+        # OpenAPI schema must NOT advertise the path either, so SDK generators
+        # and Swagger consumers can't accidentally call it.
+        schema = client.get("/openapi.json").json()
+        assert f"{API_PREFIX}/demographics/analyze" not in schema.get("paths", {})
+
+    def test_router_present_when_enabled(self):
+        """With the flag ON, /api/v1/demographics/analyze must be registered.
+
+        We don't actually invoke the analyzer (would load ~400 MB of DeepFace
+        weights); we just confirm FastAPI knows about the path.
+        """
+        app = _build_app(demographics_enabled=True)
+        client = TestClient(app)
+
+        schema = client.get("/openapi.json").json()
+        assert f"{API_PREFIX}/demographics/analyze" in schema.get("paths", {}), (
+            "demographics route should be registered when "
+            "DEMOGRAPHICS_ROUTER_ENABLED=true"
+        )
+
+        # POST without a file: FastAPI's validation layer answers 422
+        # (missing required form field), proving the route IS wired up
+        # — anything other than 404 confirms registration.
+        resp = client.post(f"{API_PREFIX}/demographics/analyze")
+        assert resp.status_code != 404, (
+            "route should exist when flag is on; got 404 which means it wasn't registered"
+        )
+
+
+class TestDemographicsRouterEnabledDefault:
+    """The Settings default for DEMOGRAPHICS_ROUTER_ENABLED must be False."""
+
+    def test_default_is_false(self):
+        """Settings() default must NOT enable the demographics router."""
+        from app.core.config import Settings
+
+        # Build a Settings instance ignoring any ambient .env file
+        s = Settings(_env_file=None)
+        assert s.DEMOGRAPHICS_ROUTER_ENABLED is False, (
+            "DEMOGRAPHICS_ROUTER_ENABLED must default to False — see "
+            "FINDINGS_2026-04-25 B2"
+        )
+
+    def test_explicit_true_is_respected(self):
+        """Operators can opt in via env/kwarg."""
+        from app.core.config import Settings
+
+        s = Settings(_env_file=None, DEMOGRAPHICS_ROUTER_ENABLED=True)
+        assert s.DEMOGRAPHICS_ROUTER_ENABLED is True


### PR DESCRIPTION
## Summary
Closes **B2** from `FINDINGS_2026-04-25_DEEP_DIVE.md`.

The `/api/v1/demographics/analyze` route in `app/api/routes/demographics.py` calls `DeepFace.analyze` with `age + gender + emotion` (and optionally `race`) actions, which lazy-loads ~400 MB of additional model weights on first request.  web-app has **zero callers** for this endpoint (verified by grep).  Hetzner CX43 prod is at 94% memory; we don't want a stray demo client to swing it into OOM.

## Changes
- Add `DEMOGRAPHICS_ROUTER_ENABLED: bool = Field(default=False)` to `Settings` in `app/core/config.py`.
- Gate the demographics router include in `app/main.py` behind that flag, with an info-log line on both branches so operators can see at boot which way the gate is set.
- Retain the legacy `DEMOGRAPHICS_ENABLED` field for back-compat (it was unreferenced anywhere in code, but keeping it avoids breaking any `.env.prod` that already sets it).
- Add `tests/unit/test_demographics_gating.py`: asserts the route 404s and is absent from `/openapi.json` when disabled, is registered when enabled, and that the `Settings` default is `False`.

## Why Path A (router gating) and not Path B (lazy-load only)
DeepFace already lazy-loads the age/gender/race/emotion weights on the first `DeepFace.analyze` call — they are NOT loaded at import time or in `DeepFaceDemographicsAnalyzer.__init__`, and the analyzer is NOT pre-loaded by `initialize_dependencies()` in `app/core/container.py`.  So Path B's "make it lazy" is already the status quo; the real win is preventing the *first* call from happening at all, which Path A delivers by removing the route registration.

## Memory savings
~400 MB resident on the `biometric-api` container as long as the flag stays off — comfortably below the 4 model weights (Age + Gender + Race + Emotion) that DeepFace would otherwise pull on the first hit.

## Test plan
- [x] `python -m py_compile app/main.py app/core/config.py tests/unit/test_demographics_gating.py` — clean
- [x] `pytest tests/unit/test_demographics_gating.py tests/unit/test_config_validator.py -q` — 17 passed, 1 skipped (the "router present when enabled" assertion skips in light dev envs that lack cv2; runs in CI where ML deps are installed)
- [ ] Deploy to prod with `DEMOGRAPHICS_ROUTER_ENABLED` unset → confirm `/api/v1/demographics/analyze` returns 404 and DeepFace age/gender/race/emotion models do NOT appear in `/proc/$pid/maps`
- [ ] Confirm existing `/api/v1/biometric/*` endpoints (face/voice/etc.) still pass smoke tests — they share DeepFace face-recognition imports but not the demographics actions, so should be untouched