### PR TITLE
docs: strip iOS/macOS from forward roadmap (out of scope, no Apple hardware)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog - Biometric Processor
 
+## [Unreleased]
+
+### Docs — 2026-04-26 (iOS / macOS scope dropped — no-op for this repo)
+- Parent FIVUCSAS scope updated 2026-04-26 to permanently drop iOS / iPadOS / macOS (no Apple hardware available). This repo's `README.md`, `ROADMAP.md`, and `CHANGELOG.md` had no forward-looking iOS/macOS content; macOS-as-developer-environment install instructions for Redis and PostgreSQL in `README.md` are unaffected. No code or config changes required.
+
 ## [2026-04-19] Audit remediation
 
 Remediation for findings from `docs/audits/AUDIT_2026-04-19.md` (Audit 2 — ML


### PR DESCRIPTION
## Summary

Apple platforms (iOS / iPadOS / macOS) are permanently out of scope as of 2026-04-26 — no Apple hardware available for development, signing, or testing.

**This is a no-op PR for biometric-processor.** Coordinated with the same-named PRs landing on parent FIVUCSAS, web-app, and identity-core-api. Audited this repo's forward-looking docs (`README.md`, `ROADMAP.md`, `CHANGELOG.md`) and found no iOS/macOS scope to strip — the only macOS references in `README.md` are dev-environment install instructions for Redis and PostgreSQL on macOS, which are unrelated to product scope.

## Files touched

- **CHANGELOG.md** — single `[Unreleased]` entry under a new `### Docs` heading, documenting that the parent-repo scope decision was reviewed for this microservice and required no doc changes here.

## Intentionally LEFT unchanged

- README.md macOS dev-environment install instructions (Redis + PostgreSQL via Homebrew). These are guidance for a contributor running macOS — not product-feature scope.
- No code or configuration changes.
- No CHANGELOG history rewriting.

## Test plan

- [ ] Maintainer confirms no forward-looking iOS/macOS scope in this repo's `README.md` or `ROADMAP.md`.
- [ ] Docs-only PR; no CI gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)