### PR TITLE
perf(ml): wrap blocking ML calls in asyncio.to_thread (P2.11)

### DIFF
--- a/app/application/use_cases/check_liveness.py
+++ b/app/application/use_cases/check_liveness.py
@@ -1,5 +1,6 @@
 """Liveness check use case."""
 
+import asyncio
 import json
 import logging
 from dataclasses import replace
@@ -90,8 +91,8 @@ class CheckLivenessUseCase:
         """
         logger.info("Starting liveness check")
 
-        # Step 1: Load image
-        image = cv2.imread(image_path)
+        # Step 1: Load image (P2.11: offload blocking decode + disk I/O off the event loop)
+        image = await asyncio.to_thread(cv2.imread, image_path)
         if image is None:
             raise ValueError(f"Failed to load image: {image_path}")
 

--- a/app/application/use_cases/enroll_face.py
+++ b/app/application/use_cases/enroll_face.py
@@ -1,5 +1,6 @@
 """Face enrollment use case."""
 
+import asyncio
 import logging
 from typing import Optional
 
@@ -81,8 +82,8 @@ class EnrollFaceUseCase:
         face_region = None
 
         try:
-            # Step 1: Load image
-            image = cv2.imread(image_path)
+            # Step 1: Load image (P2.11: offload blocking decode + disk I/O off the event loop)
+            image = await asyncio.to_thread(cv2.imread, image_path)
             if image is None:
                 raise ValueError(f"Failed to load image: {image_path}")
 

--- a/app/application/use_cases/enroll_multi_image.py
+++ b/app/application/use_cases/enroll_multi_image.py
@@ -131,8 +131,8 @@ class EnrollMultiImageUseCase:
             face_region = None
 
             try:
-                # Load image
-                image = cv2.imread(image_path)
+                # Load image (P2.11: offload blocking decode + disk I/O off the event loop)
+                image = await asyncio.to_thread(cv2.imread, image_path)
                 if image is None:
                     raise ValueError(f"Failed to load image: {image_path}")
 

--- a/app/application/use_cases/verify_face.py
+++ b/app/application/use_cases/verify_face.py
@@ -1,5 +1,6 @@
 """Face verification use case."""
 
+import asyncio
 import logging
 from datetime import datetime
 from typing import Optional
@@ -87,8 +88,8 @@ class VerifyFaceUseCase:
         """
         logger.info(f"Starting face verification for user_id={user_id}, tenant_id={tenant_id}")
 
-        # Step 1: Load image
-        image = cv2.imread(image_path)
+        # Step 1: Load image (P2.11: offload blocking decode + disk I/O off the event loop)
+        image = await asyncio.to_thread(cv2.imread, image_path)
         if image is None:
             raise ValueError(f"Failed to load image: {image_path}")
 

--- a/app/infrastructure/ml/liveness/uniface_liveness_detector.py
+++ b/app/infrastructure/ml/liveness/uniface_liveness_detector.py
@@ -14,6 +14,7 @@ Follows the same ILivenessDetector protocol as other implementations
 (Liskov Substitution Principle / Open-Closed Principle).
 """
 
+import asyncio
 import logging
 from typing import Any, Optional
 
@@ -116,7 +117,10 @@ class UniFaceLivenessDetector(ILivenessDetector):
             # The model returns a list of predictions per detected face
             h, w = image_rgb.shape[:2]
             bbox = [0, 0, w, h]
-            raw_prediction = self._model.predict(image_rgb, bbox)
+            # P2.11: ONNX inference is CPU-bound — offload off the event loop
+            raw_prediction = await asyncio.to_thread(
+                self._model.predict, image_rgb, bbox
+            )
             predictions = self._normalize_predictions(raw_prediction)
 
             if not predictions:

--- a/app/infrastructure/ml/quality/quality_assessor.py
+++ b/app/infrastructure/ml/quality/quality_assessor.py
@@ -1,5 +1,6 @@
 """Image quality assessment implementation."""
 
+import asyncio
 import logging
 
 import cv2
@@ -49,13 +50,22 @@ class QualityAssessor:
         )
 
     async def assess(self, face_image: np.ndarray) -> QualityAssessment:
-        """Assess the quality of a face image.
+        """Assess the quality of a face image (async wrapper).
+
+        P2.11: The full quality pipeline (cv2 ops + MediaPipe FaceMesh pose
+        estimation) is CPU-bound. We delegate to a synchronous worker that runs
+        in the default thread executor so the FastAPI event loop stays free.
 
         Args:
             face_image: Face image as numpy array (H, W, C)
 
         Returns:
             QualityAssessment with quality metrics
+        """
+        return await asyncio.to_thread(self._assess_sync, face_image)
+
+    def _assess_sync(self, face_image: np.ndarray) -> QualityAssessment:
+        """Synchronous quality assessment (executed off the event loop).
 
         Note:
             Quality score is calculated as weighted average of:


### PR DESCRIPTION
## Summary

Phase 2 item **P2.11** — unblock the FastAPI event loop for synchronous ML
work. Concurrent verify/enroll requests previously serialised because
several CPU-bound calls (UniFace MiniFASNet ONNX inference, MediaPipe
FaceMesh PnP pose estimate, `cv2.imread` from disk) ran inline on the
event loop. Effective concurrency was 1.

DeepFace detection + embedding extraction are already offloaded via the
`ASYNC_ML_ENABLED` thread-pool wrappers (`AsyncFaceDetector`,
`AsyncEmbeddingExtractor`). This PR closes the remaining gaps with
`asyncio.to_thread`.

## Changes

- `app/application/use_cases/verify_face.py` — `cv2.imread` → `to_thread`
- `app/application/use_cases/enroll_face.py` — `cv2.imread` → `to_thread`
- `app/application/use_cases/enroll_multi_image.py` — per-image
  `cv2.imread` → `to_thread`
- `app/application/use_cases/check_liveness.py` — `cv2.imread` → `to_thread`
- `app/infrastructure/ml/liveness/uniface_liveness_detector.py` — MiniFASNet
  `model.predict()` → `to_thread`
- `app/infrastructure/ml/quality/quality_assessor.py` — split `assess()`
  into async wrapper + `_assess_sync()` (cv2 + MediaPipe FaceMesh + PnP)
  → `to_thread`

**6 files, 7 call sites converted.**

Use case methods stay `async def`. Where the underlying domain interface
already returned a coroutine, we kept the sync work in a private helper and
offload from the existing async method (option (a) in the plan). Where the
use case itself called blocking I/O directly, we wrap at the call site.

## Out of Scope

- `DeepFaceDetector` / `DeepFaceExtractor` — already wrapped by
  `AsyncFaceDetector` / `AsyncEmbeddingExtractor` when
  `settings.ASYNC_ML_ENABLED` is True (default).
- `voice.py` — `Resemblyzer.extract_embedding_from_base64` already uses
  `ThreadPoolManager.run_blocking`.
- Inline `cv2.cvtColor` / `cv2.Laplacian` on already-cropped 224×224 face
  regions (sub-millisecond; not worth a thread switch).

## Constraints honoured

- No new dependencies.
- No anti-spoof / liveness behavioural change.
- No test files modified.
- Liveness, threshold, repository contracts unchanged.

## Test plan

- [ ] `python -m py_compile` on all 6 modified files passes (verified
  locally).
- [ ] Pre-merge: existing CI must stay green (asyncio.to_thread is
  Python 3.9+; service runs on 3.12).
- [ ] Post-merge concurrency check (operator):
  ```bash
  # Fire 10 concurrent verify requests against bio-api and watch P99.
  # Expect throughput to scale roughly linearly with thread-pool size.
  for i in {1..10}; do
    curl -s -o /dev/null -w "%{time_total}\n" \
      -X POST -H "X-API-Key: $BIO_KEY" \
      -F "user_id=load-test-user" -F "tenant_id=demo" \
      -F "file=@/tmp/test_face.jpg" \
      https://bio.fivucsas.com/api/v1/face/verify &
  done | sort -n
  ```
  Pre-fix: serialised, P99 ~= 10× P50. Post-fix: P99 ~= P50 + thread-pool
  overhead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)