### PR TITLE
fix: Copilot post-merge findings on PR #57 + #58

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Biometric Processor is the AI/ML microservice for the **FIVUCSAS** biometric ide
 **Scope:**
 
 - **Face** — enroll, verify, search, liveness, quality, demographics, landmarks, comparison (DeepFace / MediaPipe / YOLO)
-- **Voice** — enroll, verify (MFCC + Torch speaker embeddings; Resemblyzer removed due to numba conflict)
+- **Voice** — enroll, verify (Resemblyzer GE2E 256-dim speaker embeddings, centroid-based; librosa pinned to 0.9.2 to avoid the numba/Python 3.12 import-time crash)
 - **Verification pipeline** — YOLO-based document detection + TD1/TD3 MRZ parser + Tesseract TC Kimlik OCR + selfie-to-document cosine matching + server-authoritative liveness verdict
 - **Client-side ML observations** — `client_embedding_observations` table (log-only per D2 design lock; never trusted for auth)
 

--- a/app/infrastructure/ml/liveness/uniface_liveness_detector.py
+++ b/app/infrastructure/ml/liveness/uniface_liveness_detector.py
@@ -16,7 +16,7 @@ Follows the same ILivenessDetector protocol as other implementations
 
 import asyncio
 import logging
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import cv2
 import numpy as np
@@ -24,6 +24,12 @@ import numpy as np
 from app.domain.entities.liveness_result import LivenessResult
 from app.domain.exceptions.liveness_errors import LivenessCheckError
 from app.domain.interfaces.liveness_detector import ILivenessDetector
+
+if TYPE_CHECKING:
+    # Type-only import: keeps graceful-degradation behavior at runtime
+    # (uniface may not be installed) while letting static analysers see the
+    # real .predict() signature on self._model.
+    from uniface.spoofing import MiniFASNet
 
 logger = logging.getLogger(__name__)
 
@@ -54,15 +60,25 @@ class UniFaceLivenessDetector(ILivenessDetector):
                 Scores above this threshold are considered live.
         """
         self._liveness_threshold = liveness_threshold
-        self._model: Optional[object] = None
+        self._model: Optional["MiniFASNet"] = None
+        # Per-instance async lock guarding lazy model construction. Multiple
+        # concurrent check_liveness() coroutines (each offloading via
+        # asyncio.to_thread) would otherwise race in _ensure_model_loaded
+        # and instantiate MiniFASNet twice (Copilot post-merge PR #57).
+        self._model_lock: asyncio.Lock = asyncio.Lock()
 
         logger.info(
             f"UniFaceLivenessDetector initialized: "
             f"liveness_threshold={liveness_threshold}"
         )
 
-    def _ensure_model_loaded(self) -> None:
-        """Lazy-load the MiniFASNet model on first use.
+    async def _ensure_model_loaded(self) -> None:
+        """Lazy-load the MiniFASNet model on first use (async, thread-safe).
+
+        Uses canonical double-checked locking: an unlocked fast-path read
+        when the model is already loaded, then a lock-protected re-check
+        before construction so only one coroutine ever instantiates the
+        model.
 
         This avoids importing uniface at module level, which allows
         the application to start even if uniface is not installed
@@ -71,22 +87,29 @@ class UniFaceLivenessDetector(ILivenessDetector):
         Raises:
             LivenessCheckError: If uniface is not installed or model fails to load
         """
+        # Fast path — already loaded, no lock needed
         if self._model is not None:
             return
 
-        try:
-            from uniface.spoofing import MiniFASNet
-            self._model = MiniFASNet()
-            logger.info("UniFace MiniFASNet model loaded successfully")
-        except ImportError as e:
-            logger.error(f"uniface package not installed: {e}")
-            raise LivenessCheckError(
-                "uniface package is required for UniFace liveness detection. "
-                "Install it with: pip install uniface>=0.1.0"
-            )
-        except Exception as e:
-            logger.error(f"Failed to load MiniFASNet model: {e}", exc_info=True)
-            raise LivenessCheckError(f"Failed to initialize MiniFASNet: {e}")
+        async with self._model_lock:
+            # Re-check after acquiring the lock: another coroutine may have
+            # finished loading while we were awaiting the lock.
+            if self._model is not None:
+                return
+
+            try:
+                from uniface.spoofing import MiniFASNet
+                self._model = MiniFASNet()
+                logger.info("UniFace MiniFASNet model loaded successfully")
+            except ImportError as e:
+                logger.error(f"uniface package not installed: {e}")
+                raise LivenessCheckError(
+                    "uniface package is required for UniFace liveness detection. "
+                    "Install it with: pip install uniface>=0.1.0"
+                )
+            except Exception as e:
+                logger.error(f"Failed to load MiniFASNet model: {e}", exc_info=True)
+                raise LivenessCheckError(f"Failed to initialize MiniFASNet: {e}")
 
     async def check_liveness(self, image: np.ndarray) -> LivenessResult:
         """Check if image shows a live person using MiniFASNet.
@@ -107,8 +130,8 @@ class UniFaceLivenessDetector(ILivenessDetector):
             if image is None or image.size == 0:
                 raise LivenessCheckError("Invalid input image")
 
-            # Ensure model is loaded
-            self._ensure_model_loaded()
+            # Ensure model is loaded (async, thread-safe lazy init)
+            await self._ensure_model_loaded()
 
             # Convert BGR to RGB (UniFace expects RGB)
             image_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
@@ -118,7 +141,10 @@ class UniFaceLivenessDetector(ILivenessDetector):
             h, w = image_rgb.shape[:2]
             bbox = [0, 0, w, h]
             # P2.11: ONNX inference is CPU-bound — offload off the event loop
-            raw_prediction = await asyncio.to_thread(
+            # via the project's shared ThreadPoolManager so ML_THREAD_POOL_SIZE
+            # is honored (was asyncio.to_thread, which uses the default executor).
+            from app.core.container import get_thread_pool
+            raw_prediction = await get_thread_pool().run_blocking(
                 self._model.predict, image_rgb, bbox
             )
             predictions = self._normalize_predictions(raw_prediction)

--- a/app/infrastructure/ml/quality/quality_assessor.py
+++ b/app/infrastructure/ml/quality/quality_assessor.py
@@ -1,6 +1,5 @@
 """Image quality assessment implementation."""
 
-import asyncio
 import logging
 
 import cv2
@@ -54,7 +53,9 @@ class QualityAssessor:
 
         P2.11: The full quality pipeline (cv2 ops + MediaPipe FaceMesh pose
         estimation) is CPU-bound. We delegate to a synchronous worker that runs
-        in the default thread executor so the FastAPI event loop stays free.
+        on the project's shared ThreadPoolManager so ML_THREAD_POOL_SIZE is
+        honored (Copilot post-merge PR #57: previously asyncio.to_thread used
+        the event loop's default executor, which ignores our pool sizing).
 
         Args:
             face_image: Face image as numpy array (H, W, C)
@@ -62,7 +63,10 @@ class QualityAssessor:
         Returns:
             QualityAssessment with quality metrics
         """
-        return await asyncio.to_thread(self._assess_sync, face_image)
+        # Local import to avoid a circular module-load between
+        # app.core.container and infrastructure.ml.quality at import time.
+        from app.core.container import get_thread_pool
+        return await get_thread_pool().run_blocking(self._assess_sync, face_image)
 
     def _assess_sync(self, face_image: np.ndarray) -> QualityAssessment:
         """Synchronous quality assessment (executed off the event loop).


### PR DESCRIPTION
## Summary

Four Copilot review findings against PRs #57 and #58, fixed in three commits.

### PR #57 — `uniface_liveness_detector.py`
- **A. `_model` typing** — was `Optional[object]`, but call sites use
  `.predict()`. Now uses a `TYPE_CHECKING` import of
  `uniface.spoofing.MiniFASNet` so static analyzers see the real
  signature while runtime keeps the lazy import (graceful degradation
  when `uniface` is not installed).
- **B. Lazy-load race** — `_ensure_model_loaded` had an unsynchronized
  None-check, so two concurrent `check_liveness` coroutines (each
  off-loading via `asyncio.to_thread`) could both instantiate
  `MiniFASNet()`. Added a per-instance `asyncio.Lock` and switched to
  the canonical double-checked locking pattern (fast-path → acquire →
  re-check → construct). `_ensure_model_loaded` is now `async` and
  awaited from `check_liveness`. Only one call site, no API leakage.

### PR #57 — `quality_assessor.py`
- **C. ThreadPoolManager bypass** — `assess()` used `asyncio.to_thread`,
  which routes to the event loop's default executor and silently ignores
  `ML_THREAD_POOL_SIZE`. Switched to
  `get_thread_pool().run_blocking(...)`, the same path
  `async_face_detector` and `async_embedding_extractor` already use, so
  the pool size set at startup governs all CPU-bound ML work uniformly.
  `uniface_liveness_detector.py`'s ONNX inference call is migrated for
  the same reason.

### PR #58 — `README.md`
- **D. Voice claim** — README said *"Resemblyzer removed due to numba
  conflict; MFCC + Torch embeddings"*, but `SpeakerEmbedder` and the
  voice routes still use Resemblyzer's GE2E `VoiceEncoder` (256-dim).
  The numba conflict was resolved by pinning `librosa==0.9.2` (per the
  module docstring), not by removing Resemblyzer. Line corrected.

## Verification

- `python3 -m py_compile` on both modified Python files: OK.
- AST parse: OK.
- `pytest` could not run in this environment (system Python lacks `cv2`
  / `numpy` — repo runs inside Docker). Existing `test_quality_assessor.py`
  is `async`-aware via `pytest-asyncio` and will exercise the new
  `run_blocking` path unchanged.

## Test plan

- [ ] CI runs `pytest` against `tests/unit/infrastructure/test_quality_assessor.py`
- [ ] In dev, hit `/api/v1/liveness` concurrently from 2 clients to
      smoke-test the lock (only one `"UniFace MiniFASNet model loaded
      successfully"` line should appear).
- [ ] Confirm `mypy` / Pylance no longer warns on `self._model.predict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)