### PR TITLE
fix: address Copilot post-merge findings on PR #59, PR #60

### DIFF
--- a/app/core/container.py
+++ b/app/core/container.py
@@ -160,6 +160,10 @@ def get_quality_assessor() -> IQualityAssessor:
         blur_threshold=settings.BLUR_THRESHOLD,
         min_face_size=settings.MIN_FACE_SIZE,
         quality_threshold=settings.QUALITY_THRESHOLD,
+        # P2.11: inject the shared pool explicitly instead of re-resolving
+        # `get_thread_pool` from inside the assessor — keeps infrastructure
+        # decoupled from the container (Copilot post-merge PR #59).
+        thread_pool=get_thread_pool(),
     )
 
 

--- a/app/domain/interfaces/thread_pool_executor.py
+++ b/app/domain/interfaces/thread_pool_executor.py
@@ -1,0 +1,33 @@
+"""Domain port for offloading blocking calls to a thread pool.
+
+A minimal Protocol so infrastructure components can request a
+`run_blocking(func, *args, **kwargs) -> awaitable T` adapter without
+importing from `app.core.container`. Eliminates the infrastructure→
+container coupling that Copilot flagged on PR #59 and makes
+QualityAssessor / friends trivially unit-testable: a fake executor
+that calls the function synchronously is a 4-line stub.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Protocol, TypeVar
+
+T = TypeVar("T")
+
+
+class ThreadPoolExecutorPort(Protocol):
+    """Awaitable run_blocking-style executor port.
+
+    Concrete implementations include `ThreadPoolManager` (production,
+    in `app.infrastructure.async_execution`) and any synchronous test
+    double that satisfies the same shape.
+    """
+
+    def run_blocking(
+        self,
+        func: Callable[..., T],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Awaitable[T]:
+        """Execute a blocking callable off the event loop and return its result."""
+        ...

--- a/app/infrastructure/ml/card_type/yolo_card_type_detector.py
+++ b/app/infrastructure/ml/card_type/yolo_card_type_detector.py
@@ -51,11 +51,17 @@ _CARD_TYPE_KEYWORDS: dict[str, list[str]] = {
     ],
 }
 
-# Pairs that are commonly confused — OCR validation triggers for these
-_CONFUSABLE_PAIRS: set[frozenset[str]] = {
-    frozenset({"ogrenci_karti", "akademisyen_karti"}),
-    frozenset({"tc_kimlik", "ehliyet"}),
-}
+# NOTE: a `_CONFUSABLE_PAIRS` constant used to live here, gating OCR
+# validation to a small whitelist of confusable card-type pairs. OCR is
+# now run on every detection (see `_ocr_validate` below), so the pair
+# whitelist is gone.
+
+# Sentinel values returned by `_ocr_validate` to signal that no OCR
+# keyword evidence backs the YOLO class. Both should be treated identically
+# by the borderline-reject path. `OCR_UNAVAILABLE` is reported when the
+# OCR step itself failed (Tesseract missing/timeout); `NO_EVIDENCE` is
+# reported when OCR ran but produced no matching keywords.
+_OCR_NO_EVIDENCE: frozenset[str] = frozenset({"no_evidence", "ocr_unavailable"})
 
 # Default model path relative to this file.
 # best_fp16.onnx (FP16 ONNX, 50MB) is used instead of best.onnx (FP32, 103MB).
@@ -99,6 +105,7 @@ class YOLOCardTypeDetector(ICardTypeDetector):
     - ehliyet: Driver's License
     - pasaport: Passport
     - ogrenci_karti: Student Card
+    - akademisyen_karti: Academic Staff Card
     """
 
     def __init__(
@@ -176,9 +183,7 @@ class YOLOCardTypeDetector(ICardTypeDetector):
         # Per USER-BUG-2 the small dataset can hand back a confidently-wrong
         # class for any pair; OCR keyword evidence (when text is legible) is
         # a more reliable disambiguator than the YOLO confidence alone.
-        corrected_name, ocr_evidence = self._ocr_validate(
-            image, class_name, confidence
-        )
+        corrected_name, ocr_evidence = self._ocr_validate(image, class_name)
         if corrected_name != class_name:
             logger.info(
                 f"OCR corrected card type: {class_name} -> {corrected_name} "
@@ -192,10 +197,13 @@ class YOLOCardTypeDetector(ICardTypeDetector):
                     break
 
         # Reject borderline calls. If YOLO confidence is below 0.75 AND OCR
-        # produced no supporting evidence for the class, the call is likely
-        # a guess — return detected=False so the UI prompts manual select
-        # rather than committing to the wrong class.
-        if confidence < 0.75 and ocr_evidence == "no_evidence":
+        # produced no supporting evidence for the class (either no keyword
+        # hits OR OCR itself was unavailable), the call is likely a guess —
+        # return detected=False so the UI prompts manual select rather than
+        # committing to the wrong class. Both `no_evidence` and
+        # `ocr_unavailable` are treated identically per the `_ocr_validate`
+        # docstring.
+        if confidence < 0.75 and ocr_evidence in _OCR_NO_EVIDENCE:
             logger.info(
                 f"Rejecting borderline detection: class={class_name}, "
                 f"confidence={confidence:.2f}, OCR found no supporting keywords"
@@ -215,7 +223,7 @@ class YOLOCardTypeDetector(ICardTypeDetector):
         )
 
     def _ocr_validate(
-        self, image: np.ndarray, yolo_class: str, confidence: float
+        self, image: np.ndarray, yolo_class: str
     ) -> tuple[str, str]:
         """Use OCR to validate or correct the YOLO classification.
 

--- a/app/infrastructure/ml/liveness/uniface_liveness_detector.py
+++ b/app/infrastructure/ml/liveness/uniface_liveness_detector.py
@@ -72,13 +72,18 @@ class UniFaceLivenessDetector(ILivenessDetector):
             f"liveness_threshold={liveness_threshold}"
         )
 
-    async def _ensure_model_loaded(self) -> None:
+    async def _ensure_model_loaded(self) -> "MiniFASNet":
         """Lazy-load the MiniFASNet model on first use (async, thread-safe).
 
         Uses canonical double-checked locking: an unlocked fast-path read
         when the model is already loaded, then a lock-protected re-check
         before construction so only one coroutine ever instantiates the
         model.
+
+        Returns the loaded model directly so callers don't have to deal
+        with `Optional[MiniFASNet]` at the call site (Copilot post-merge
+        finding on PR #59 — `.predict(...)` was failing mypy because
+        `self._model` stayed typed `Optional` after the await).
 
         This avoids importing uniface at module level, which allows
         the application to start even if uniface is not installed
@@ -89,23 +94,26 @@ class UniFaceLivenessDetector(ILivenessDetector):
         """
         # Fast path — already loaded, no lock needed
         if self._model is not None:
-            return
+            return self._model
 
         async with self._model_lock:
             # Re-check after acquiring the lock: another coroutine may have
             # finished loading while we were awaiting the lock.
             if self._model is not None:
-                return
+                return self._model
 
             try:
                 from uniface.spoofing import MiniFASNet
                 self._model = MiniFASNet()
                 logger.info("UniFace MiniFASNet model loaded successfully")
+                return self._model
             except ImportError as e:
                 logger.error(f"uniface package not installed: {e}")
+                # Version pin must match requirements.txt — keeping these
+                # in sync was a Copilot post-merge finding on PR #59.
                 raise LivenessCheckError(
                     "uniface package is required for UniFace liveness detection. "
-                    "Install it with: pip install uniface>=0.1.0"
+                    "Install it with: pip install 'uniface>=3.0.0'"
                 )
             except Exception as e:
                 logger.error(f"Failed to load MiniFASNet model: {e}", exc_info=True)
@@ -130,8 +138,10 @@ class UniFaceLivenessDetector(ILivenessDetector):
             if image is None or image.size == 0:
                 raise LivenessCheckError("Invalid input image")
 
-            # Ensure model is loaded (async, thread-safe lazy init)
-            await self._ensure_model_loaded()
+            # Ensure model is loaded (async, thread-safe lazy init).
+            # Bind the loaded model to a local so `.predict(...)` below is
+            # typed as `MiniFASNet`, not `Optional[MiniFASNet]`.
+            model = await self._ensure_model_loaded()
 
             # Convert BGR to RGB (UniFace expects RGB)
             image_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
@@ -145,7 +155,7 @@ class UniFaceLivenessDetector(ILivenessDetector):
             # is honored (was asyncio.to_thread, which uses the default executor).
             from app.core.container import get_thread_pool
             raw_prediction = await get_thread_pool().run_blocking(
-                self._model.predict, image_rgb, bbox
+                model.predict, image_rgb, bbox
             )
             predictions = self._normalize_predictions(raw_prediction)
 

--- a/app/infrastructure/ml/quality/quality_assessor.py
+++ b/app/infrastructure/ml/quality/quality_assessor.py
@@ -1,11 +1,13 @@
 """Image quality assessment implementation."""
 
 import logging
+from typing import Optional
 
 import cv2
 import numpy as np
 
 from app.domain.entities.quality_assessment import QualityAssessment
+from app.domain.interfaces.thread_pool_executor import ThreadPoolExecutorPort
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +31,7 @@ class QualityAssessor:
         blur_threshold: float = 100.0,
         min_face_size: int = 80,
         quality_threshold: float = 70.0,
+        thread_pool: Optional[ThreadPoolExecutorPort] = None,
     ) -> None:
         """Initialize quality assessor.
 
@@ -36,10 +39,18 @@ class QualityAssessor:
             blur_threshold: Minimum acceptable blur score (Laplacian variance)
             min_face_size: Minimum acceptable face size in pixels
             quality_threshold: Minimum overall quality score (0-100)
+            thread_pool: Executor port used to offload the blocking quality
+                pipeline off the event loop. Injected by the DI container in
+                production (see `app.core.container.get_quality_assessor`).
+                If omitted, `assess(...)` falls back to the project's default
+                container-resolved pool — a deferred lookup kept only as a
+                last-resort safety net so existing call sites without DI
+                continue to work.
         """
         self._blur_threshold = blur_threshold
         self._min_face_size = min_face_size
         self._quality_threshold = quality_threshold
+        self._thread_pool = thread_pool
 
         logger.info(
             f"Initialized QualityAssessor: "
@@ -63,10 +74,15 @@ class QualityAssessor:
         Returns:
             QualityAssessment with quality metrics
         """
-        # Local import to avoid a circular module-load between
-        # app.core.container and infrastructure.ml.quality at import time.
-        from app.core.container import get_thread_pool
-        return await get_thread_pool().run_blocking(self._assess_sync, face_image)
+        pool = self._thread_pool
+        if pool is None:
+            # Safety net for legacy callers that constructed QualityAssessor
+            # without injecting a pool. Prefer injection — see __init__ docs.
+            # Local import keeps a static infrastructure→container coupling
+            # out of the import graph (Copilot post-merge finding on PR #59).
+            from app.core.container import get_thread_pool
+            pool = get_thread_pool()
+        return await pool.run_blocking(self._assess_sync, face_image)
 
     def _assess_sync(self, face_image: np.ndarray) -> QualityAssessment:
         """Synchronous quality assessment (executed off the event loop).

--- a/tests/unit/infrastructure/test_uniface_liveness_detector.py
+++ b/tests/unit/infrastructure/test_uniface_liveness_detector.py
@@ -1,0 +1,100 @@
+"""Unit tests for UniFaceLivenessDetector concurrency.
+
+Covers the async-lock + double-checked-locking concurrency in
+`_ensure_model_loaded` introduced in PR #57 / hardened in PR #59.
+Without the lock, fan-in concurrent first calls would each hit the
+import path and instantiate the heavy MiniFASNet ONNX model multiple
+times (10x in the worst case → cold-start GC pressure + 10x ONNX
+session memory).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.infrastructure.ml.liveness.uniface_liveness_detector import (
+    UniFaceLivenessDetector,
+)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_ensure_model_loaded_constructs_once(monkeypatch):
+    """5 concurrent first-callers must result in exactly one MiniFASNet()."""
+    # Track every call to MiniFASNet().
+    call_count = 0
+
+    def _fake_model_factory():
+        nonlocal call_count
+        call_count += 1
+        # Yield to the loop so other coroutines have a chance to race.
+        # If the lock is missing they'll each see _model is None and
+        # call MiniFASNet() before the first construction completes.
+        return MagicMock(name=f"MiniFASNet#{call_count}")
+
+    # Stub `from uniface.spoofing import MiniFASNet`. We inject a fake module
+    # so the test does not require the real `uniface` package on PYTHONPATH.
+    fake_spoofing = types.ModuleType("uniface.spoofing")
+
+    async def _slow_construct():
+        # Simulate a real model-load latency (~50ms) so concurrent callers
+        # genuinely overlap inside the lock-protected section.
+        await asyncio.sleep(0.05)
+        return _fake_model_factory()
+
+    # The detector calls `MiniFASNet()` synchronously inside the locked
+    # section. We can't make that async, so we substitute a callable that
+    # blocks briefly to widen the race window.
+    def _blocking_construct():
+        # tiny synchronous sleep — `time.sleep` on an event loop is bad in
+        # general but here it widens the window for the bug to manifest if
+        # the lock were ever removed.
+        import time
+        time.sleep(0.02)
+        return _fake_model_factory()
+
+    fake_spoofing.MiniFASNet = _blocking_construct
+    monkeypatch.setitem(sys.modules, "uniface", types.ModuleType("uniface"))
+    monkeypatch.setitem(sys.modules, "uniface.spoofing", fake_spoofing)
+
+    detector = UniFaceLivenessDetector(liveness_threshold=70.0)
+
+    # Fire 5 concurrent first-callers.
+    results = await asyncio.gather(
+        *(detector._ensure_model_loaded() for _ in range(5))
+    )
+
+    # Bug-fix assertion: only ONE MiniFASNet instantiation, regardless of
+    # the 5 concurrent calls.
+    assert call_count == 1, (
+        f"Expected exactly 1 MiniFASNet() construction, got {call_count} — "
+        "the async-lock double-checked-locking guard is broken."
+    )
+
+    # All 5 callers must observe the same loaded model instance.
+    assert all(r is detector._model for r in results)
+    assert detector._model is not None
+
+
+@pytest.mark.asyncio
+async def test_ensure_model_loaded_returns_loaded_model_directly(monkeypatch):
+    """`_ensure_model_loaded` returns the model so callers don't need an
+    Optional cast at the call site (Copilot PR #59 finding)."""
+    fake_spoofing = types.ModuleType("uniface.spoofing")
+    fake_spoofing.MiniFASNet = lambda: MagicMock(name="MiniFASNet-typing-test")
+    monkeypatch.setitem(sys.modules, "uniface", types.ModuleType("uniface"))
+    monkeypatch.setitem(sys.modules, "uniface.spoofing", fake_spoofing)
+
+    detector = UniFaceLivenessDetector()
+    model = await detector._ensure_model_loaded()
+
+    assert model is not None
+    assert model is detector._model
+
+    # Second call (fast path) must also return the same model.
+    model2 = await detector._ensure_model_loaded()
+    assert model2 is model

--- a/tests/unit/infrastructure/test_yolo_card_type_detector.py
+++ b/tests/unit/infrastructure/test_yolo_card_type_detector.py
@@ -1,0 +1,146 @@
+"""Unit tests for YOLOCardTypeDetector — always-on OCR + borderline reject.
+
+Mocks the YOLO model and Tesseract so the test does not require the model
+weights, ONNX runtime, or a Tesseract install. Exercises three paths:
+
+1. plain detection at high confidence (>=0.75) → returned as-is, no reject.
+2. OCR-driven class switch (YOLO bbox vs OCR keyword evidence disagree).
+3. borderline reject when YOLO confidence is below 0.75 and OCR produced
+   no supporting keywords. Includes the case where OCR itself was
+   unavailable (Tesseract missing/timeout) — that path must reject too,
+   matching the `_ocr_validate` docstring contract.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from app.infrastructure.ml.card_type.yolo_card_type_detector import (
+    YOLOCardTypeDetector,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _box(class_id: int, confidence: float) -> SimpleNamespace:
+    """Mimic an ultralytics Box object: `.cls[0]` and `.conf[0]`."""
+    return SimpleNamespace(cls=[class_id], conf=[confidence])
+
+
+def _yolo_result(boxes: list[SimpleNamespace]) -> SimpleNamespace:
+    """Mimic an ultralytics Results object with `.boxes`."""
+    return SimpleNamespace(boxes=boxes)
+
+
+CLASS_NAMES = {
+    0: "tc_kimlik",
+    1: "ehliyet",
+    2: "pasaport",
+    3: "ogrenci_karti",
+    4: "akademisyen_karti",
+}
+
+
+@pytest.fixture
+def detector() -> YOLOCardTypeDetector:
+    """A detector whose lazy-loaded model has been pre-stubbed.
+
+    We bypass the real `_get_model()` (which would call ultralytics) by
+    pre-assigning `_model` to a Mock with `.names` and a `__call__` that
+    returns a list of result objects.
+    """
+    det = YOLOCardTypeDetector(model_path="unused.onnx", confidence_threshold=0.65)
+    fake_model = MagicMock()
+    fake_model.names = CLASS_NAMES
+    det._model = fake_model
+    return det
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_high_confidence_detection_returned_as_is(detector: YOLOCardTypeDetector):
+    """confidence >= 0.75 + matching OCR keywords → detected, no reject."""
+    detector._model.return_value = [_yolo_result([_box(0, 0.92)])]
+
+    # OCR returns text containing TC Kimlik keywords → evidence='self'
+    image = np.zeros((640, 640, 3), dtype=np.uint8)
+    with patch(
+        "pytesseract.image_to_string",
+        return_value="TURKIYE CUMHURIYETI KIMLIK NO 12345678901",
+    ):
+        result = detector.detect(image)
+
+    assert result.detected is True
+    assert result.class_name == "tc_kimlik"
+    assert result.confidence == pytest.approx(0.92)
+
+
+def test_ocr_drives_class_switch(detector: YOLOCardTypeDetector):
+    """YOLO predicts ehliyet but OCR text screams ogrenci_karti → switch."""
+    detector._model.return_value = [_yolo_result([_box(1, 0.80)])]  # ehliyet
+
+    image = np.zeros((640, 640, 3), dtype=np.uint8)
+    with patch(
+        "pytesseract.image_to_string",
+        return_value="OGRENCI KIMLIK KARTI FAKULTE BOLUM OGR. NO 1234",
+    ):
+        result = detector.detect(image)
+
+    assert result.detected is True
+    # Class flipped to whichever has more keyword hits — ogrenci_karti.
+    assert result.class_name == "ogrenci_karti"
+
+
+def test_borderline_reject_when_no_ocr_evidence(detector: YOLOCardTypeDetector):
+    """conf < 0.75 + OCR ran but no keyword hits → detected=False."""
+    detector._model.return_value = [_yolo_result([_box(0, 0.70)])]
+
+    image = np.zeros((640, 640, 3), dtype=np.uint8)
+    # Random text with none of the keyword patterns.
+    with patch("pytesseract.image_to_string", return_value="LOREM IPSUM DOLOR"):
+        result = detector.detect(image)
+
+    assert result.detected is False
+
+
+def test_borderline_reject_when_ocr_unavailable(detector: YOLOCardTypeDetector):
+    """conf < 0.75 + Tesseract import/timeout error → detected=False.
+
+    Pre-fix this path returned `ocr_unavailable` and bypassed the
+    borderline reject because the check only looked for `no_evidence`.
+    """
+    detector._model.return_value = [_yolo_result([_box(0, 0.70)])]
+
+    image = np.zeros((640, 640, 3), dtype=np.uint8)
+    with patch(
+        "pytesseract.image_to_string", side_effect=RuntimeError("tesseract missing")
+    ):
+        result = detector.detect(image)
+
+    assert result.detected is False
+
+
+def test_no_detection_when_below_confidence_threshold(detector: YOLOCardTypeDetector):
+    """All raw detections below 0.65 → no_card path returns detected=False."""
+    detector._model.return_value = [_yolo_result([_box(0, 0.30)])]
+
+    image = np.zeros((640, 640, 3), dtype=np.uint8)
+    result = detector.detect(image)
+
+    assert result.detected is False
+
+
+def test_supported_card_types_includes_akademisyen():
+    """Class-level docstring fix sanity check: list MUST include akademisyen_karti."""
+    det = YOLOCardTypeDetector(model_path="unused.onnx")
+    assert "akademisyen_karti" in det.get_supported_card_types()


### PR DESCRIPTION
## Summary

Addresses 9 Copilot post-merge findings across two recently merged PRs.

### PR #60 — \`yolo_card_type_detector.py\` (5 findings)

- **OCR-unavailable bypassed reject**: borderline-reject path checked only \`ocr_evidence == \"no_evidence\"\`, so a low-confidence call where Tesseract was missing/timed out (\`ocr_unavailable\`) committed to the YOLO guess. Now both sentinels reject identically via a \`_OCR_NO_EVIDENCE\` frozenset.
- **Dead parameter**: \`_ocr_validate(...)\` accepted a \`confidence\` arg it never read. Dropped from signature + call site.
- **Dead constant + stale comment**: \`_CONFUSABLE_PAIRS\` (and the \"OCR triggers for these pairs\" comment) was unreferenced after OCR went unconditional. Removed.
- **Docstring drift**: class-level \"Supported Card Types\" list omitted \`akademisyen_karti\` even though \`get_supported_card_types()\` returns it. Aligned.
- **Coverage gap**: added \`test_yolo_card_type_detector.py\` covering high-conf detection, OCR-driven class switch, OCR-no-evidence reject, AND the previously-uncovered OCR-unavailable reject. Mocks ultralytics + Tesseract so no weights/install required.

### PR #59 — \`uniface_liveness_detector.py\` + \`quality_assessor.py\` (4 findings)

- **Infra→container coupling**: \`QualityAssessor\` imported \`get_thread_pool\` from \`app.core.container\` inside \`assess(...)\`. Introduced \`ThreadPoolExecutorPort\` Protocol in \`app/domain/interfaces/\`, wired it via constructor, and have the DI container inject the singleton at construction time. Container-resolved fallback retained as a safety net.
- **Optional after await**: \`self._model.predict(...)\` failed mypy because \`_ensure_model_loaded\` left the field typed \`Optional[MiniFASNet]\`. Changed the method to return the loaded model and bound it to a local at the call site.
- **Version-pin drift**: ImportError guidance said \`uniface>=0.1.0\` but requirements.txt pins \`uniface>=3.0.0\`. Aligned the error message.
- **Coverage gap**: added \`test_uniface_liveness_detector.py\` firing 5 concurrent first-callers and asserting \`MiniFASNet()\` is invoked exactly once. Uses \`monkeypatch.setitem(sys.modules, …)\` to fake \`uniface.spoofing\` — no real uniface install required.

## Test plan

- [x] \`python3 -m py_compile\` clean on every modified file
- [ ] \`pytest tests/unit/infrastructure/test_yolo_card_type_detector.py tests/unit/infrastructure/test_uniface_liveness_detector.py\` (run in env with pytest-asyncio + numpy)
- [ ] Smoke-check production: borderline cards with poor OCR should now show \"manual select\" UI prompt instead of being mis-classified