### PR TITLE
fix(copilot): I-prefix + drop dead test helpers (round 4 on PR #61)

### DIFF
--- a/app/domain/interfaces/thread_pool_executor.py
+++ b/app/domain/interfaces/thread_pool_executor.py
@@ -15,7 +15,7 @@ from typing import Any, Awaitable, Callable, Protocol, TypeVar
 T = TypeVar("T")
 
 
-class ThreadPoolExecutorPort(Protocol):
+class IThreadPoolExecutorPort(Protocol):
     """Awaitable run_blocking-style executor port.
 
     Concrete implementations include `ThreadPoolManager` (production,

--- a/app/infrastructure/ml/quality/quality_assessor.py
+++ b/app/infrastructure/ml/quality/quality_assessor.py
@@ -7,7 +7,7 @@ import cv2
 import numpy as np
 
 from app.domain.entities.quality_assessment import QualityAssessment
-from app.domain.interfaces.thread_pool_executor import ThreadPoolExecutorPort
+from app.domain.interfaces.thread_pool_executor import IThreadPoolExecutorPort
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ class QualityAssessor:
         blur_threshold: float = 100.0,
         min_face_size: int = 80,
         quality_threshold: float = 70.0,
-        thread_pool: Optional[ThreadPoolExecutorPort] = None,
+        thread_pool: Optional[IThreadPoolExecutorPort] = None,
     ) -> None:
         """Initialize quality assessor.
 

--- a/tests/unit/infrastructure/test_uniface_liveness_detector.py
+++ b/tests/unit/infrastructure/test_uniface_liveness_detector.py
@@ -40,30 +40,24 @@ async def test_concurrent_ensure_model_loaded_constructs_once(monkeypatch):
     # so the test does not require the real `uniface` package on PYTHONPATH.
     fake_spoofing = types.ModuleType("uniface.spoofing")
 
-    async def _slow_construct():
-        # Simulate a real model-load latency (~50ms) so concurrent callers
-        # genuinely overlap inside the lock-protected section.
-        await asyncio.sleep(0.05)
-        return _fake_model_factory()
-
-    # The detector calls `MiniFASNet()` synchronously inside the locked
-    # section. We can't make that async, so we substitute a callable that
-    # blocks briefly to widen the race window.
-    def _blocking_construct():
-        # tiny synchronous sleep — `time.sleep` on an event loop is bad in
-        # general but here it widens the window for the bug to manifest if
-        # the lock were ever removed.
-        import time
-        time.sleep(0.02)
-        return _fake_model_factory()
-
-    fake_spoofing.MiniFASNet = _blocking_construct
+    fake_spoofing.MiniFASNet = _fake_model_factory
     monkeypatch.setitem(sys.modules, "uniface", types.ModuleType("uniface"))
     monkeypatch.setitem(sys.modules, "uniface.spoofing", fake_spoofing)
 
     detector = UniFaceLivenessDetector(liveness_threshold=70.0)
 
-    # Fire 5 concurrent first-callers.
+    # Fire 5 concurrent first-callers. Each call hits `await self._lock`
+    # before touching `self._model`, so the lock + double-checked-loading
+    # path serialises the 5 coroutines: only the first one observes
+    # `_model is None` and constructs; the other 4 wake on the released
+    # lock and short-circuit on the non-None re-check.
+    #
+    # Note on test scope: this asserts the LOCK guard. We intentionally
+    # don't try to "widen the race window" with `time.sleep` inside the
+    # synchronous MiniFASNet() factory — that sleep would block the event
+    # loop and prove nothing about the asyncio.Lock semantics under test.
+    # The lock is what matters, and gather + lock + non-None re-check
+    # together guarantee call_count == 1.
     results = await asyncio.gather(
         *(detector._ensure_model_loaded() for _ in range(5))
     )


### PR DESCRIPTION
## Three Copilot post-merge findings on PR #61

1. `ThreadPoolExecutorPort` renamed to `IThreadPoolExecutorPort` — matches the `I<Name>` convention in `app/domain/interfaces/` (cf `IQualityAssessor`, `ICardTypeDetector`). File name stays `thread_pool_executor.py` (existing convention is unprefixed snake_case files + I-prefixed classes). Single consumer (`QualityAssessor`) updated.

2. `_slow_construct` was defined but never used — removed.

3. `_blocking_construct` used `time.sleep` inside `@pytest.mark.asyncio`. Sync sleep blocks the event loop and proves nothing about `asyncio.Lock` semantics. Removed; comment now explains what the test actually validates (the lock + double-checked-loading path, which is sufficient because gather + await on lock + non-None re-check guarantee `call_count == 1` regardless of construction latency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)