### PR TITLE
perf(bio-warmup): pre-load UniFace at startup + per-stage timing logs (USER-BUG-7)

### DIFF
--- a/app/application/use_cases/check_liveness.py
+++ b/app/application/use_cases/check_liveness.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import logging
+import time
 from dataclasses import replace
 from typing import Any
 
@@ -91,14 +92,21 @@ class CheckLivenessUseCase:
         """
         logger.info("Starting liveness check")
 
+        # USER-BUG-7 (2026-05-01): per-stage timing for slow-verify reports.
+        t_start = time.perf_counter()
+
         # Step 1: Load image (P2.11: offload blocking decode + disk I/O off the event loop)
+        t0 = time.perf_counter()
         image = await asyncio.to_thread(cv2.imread, image_path)
         if image is None:
             raise ValueError(f"Failed to load image: {image_path}")
+        decode_ms = (time.perf_counter() - t0) * 1000
 
         # Step 2: Detect face (to ensure there's a face before liveness check)
         logger.debug("Step 1/2: Detecting face...")
+        t0 = time.perf_counter()
         detection = await self._detector.detect(image)
+        detect_ms = (time.perf_counter() - t0) * 1000
 
         logger.debug(f"Face detected with confidence: {detection.confidence:.2f}")
 
@@ -117,7 +125,15 @@ class CheckLivenessUseCase:
                 },
             )
 
+        t0 = time.perf_counter()
         liveness_result = await self._liveness_detector.check_liveness(face_region)
+        liveness_ms = (time.perf_counter() - t0) * 1000
+        total_ms = (time.perf_counter() - t_start) * 1000
+        logger.info(
+            f"face/liveness: decode={decode_ms:.0f}ms detect={detect_ms:.0f}ms "
+            f"liveness={liveness_ms:.0f}ms total={total_ms:.0f}ms "
+            f"backend={settings.get_liveness_backend()}"
+        )
         signal_metrics = extract_face_signal_metrics(
             face_region_bgr=face_region,
             landmark_detector=self._landmark_detector,

--- a/app/application/use_cases/verify_face.py
+++ b/app/application/use_cases/verify_face.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import time
 from datetime import datetime
 from typing import Optional
 
@@ -88,10 +89,19 @@ class VerifyFaceUseCase:
         """
         logger.info(f"Starting face verification for user_id={user_id}, tenant_id={tenant_id}")
 
+        # USER-BUG-7 (2026-05-01): per-stage timing so future cold-start
+        # regressions are diagnosable from the logs without extra tooling.
+        # All durations are wall-clock milliseconds; the final `total` line
+        # is what surfaces in slow-verify reports.
+        stage_ms: dict[str, float] = {}
+        t_start = time.perf_counter()
+
         # Step 1: Load image (P2.11: offload blocking decode + disk I/O off the event loop)
+        t0 = time.perf_counter()
         image = await asyncio.to_thread(cv2.imread, image_path)
         if image is None:
             raise ValueError(f"Failed to load image: {image_path}")
+        stage_ms["decode"] = (time.perf_counter() - t0) * 1000
 
         # Step 2: Detect face
         # Client pre-crops to 224×224 — detection only as fallback.
@@ -99,7 +109,9 @@ class VerifyFaceUseCase:
         # is fast (<10ms) because there is only one face region covering most of
         # the frame. Full-frame detection (640×480+) previously cost 200-730ms.
         logger.debug("Step 1/5: Detecting face...")
+        t0 = time.perf_counter()
         detection = await self._detector.detect(image)
+        stage_ms["detect"] = (time.perf_counter() - t0) * 1000
 
         # Step 3: Extract face region
         logger.debug("Step 2/6: Extracting face region...")
@@ -108,7 +120,9 @@ class VerifyFaceUseCase:
         # Step 4: Quality gate (reject poor images before expensive comparison)
         if self._quality_assessor is not None:
             logger.debug("Step 3/6: Assessing image quality...")
+            t0 = time.perf_counter()
             quality = await self._quality_assessor.assess(face_region)
+            stage_ms["quality"] = (time.perf_counter() - t0) * 1000
 
             if quality.score < self.VERIFICATION_QUALITY_THRESHOLD:
                 issues = quality.get_issues(
@@ -128,11 +142,15 @@ class VerifyFaceUseCase:
 
         # Step 5: Extract embedding from new image
         logger.debug("Step 4/6: Extracting embedding...")
+        t0 = time.perf_counter()
         new_embedding = await self._extractor.extract(face_region)
+        stage_ms["embed"] = (time.perf_counter() - t0) * 1000
 
         # Step 6: Retrieve stored embedding
         logger.debug("Step 5/6: Retrieving stored embedding...")
+        t0 = time.perf_counter()
         stored_embedding = await self._repository.find_by_user_id(user_id, tenant_id)
+        stage_ms["fetch"] = (time.perf_counter() - t0) * 1000
 
         if stored_embedding is None:
             logger.warning(f"No embedding found for user_id={user_id}")
@@ -163,11 +181,12 @@ class VerifyFaceUseCase:
         verified = distance < threshold
         confidence = self._similarity_calculator.get_confidence(distance)
 
+        total_ms = (time.perf_counter() - t_start) * 1000
+        timing_summary = " ".join(f"{k}={v:.0f}ms" for k, v in stage_ms.items())
         logger.info(
-            f"Verification completed: user_id={user_id}, "
-            f"verified={verified}, "
-            f"distance={distance:.4f}, "
-            f"confidence={confidence:.4f}, "
+            f"face/verify: {timing_summary} total={total_ms:.0f}ms "
+            f"user_id={user_id} verified={verified} "
+            f"distance={distance:.4f} confidence={confidence:.4f} "
             f"threshold={threshold}"
         )
 

--- a/app/core/container.py
+++ b/app/core/container.py
@@ -922,6 +922,27 @@ def initialize_dependencies() -> None:
     get_similarity_calculator()
     get_liveness_detector()
 
+    # USER-BUG-7 (2026-05-01): UniFace MiniFASNet is lazy-loaded on first
+    # /verify request via UniFaceLivenessDetector._ensure_model_loaded().
+    # That puts a ~1-2 s ONNX session-init cost on the user's first face
+    # verify after a deploy / container restart. Warm it here at startup
+    # so the cost is paid once by the operator, never by an end user.
+    # Failures are non-fatal — verification still works, just slower
+    # on the first call.
+    if settings.get_liveness_backend() in ("uniface", "hybrid"):
+        try:
+            logger.info("Pre-loading UniFace MiniFASNet (anti-spoof)...")
+            from uniface.spoofing import MiniFASNet  # noqa: WPS433
+            MiniFASNet()
+            logger.info("UniFace MiniFASNet pre-loaded")
+        except ImportError:
+            logger.warning(
+                "uniface package not installed — skipping MiniFASNet warm-up. "
+                "First /verify call will pay the cold-start cost."
+            )
+        except Exception as e:  # pragma: no cover — defensive only
+            logger.warning(f"UniFace warm-up failed (non-fatal): {e}")
+
     # Pre-load voice model (numba-free MFCC+torch embedder)
     logger.info("Pre-loading speaker embedder...")
     get_speaker_embedder()


### PR DESCRIPTION
## Summary
Cold-start fix for `/verify` and `/liveness`:

- **`app/core/container.py`**: warm `uniface.spoofing.MiniFASNet` in `initialize_dependencies()`. Previously the ONNX session was lazy-loaded on the first `/verify` call via `UniFaceLivenessDetector._ensure_model_loaded`, putting a ~1-2 s init cost on whichever end-user happened to be the first verifier after a deploy or container restart. Now paid once at FastAPI startup. Failures are non-fatal — the lazy path still runs as a fallback.
- **`verify_face.py`**: per-stage timing (decode / detect / quality / embed / fetch) and a single summary log line per request: `face/verify: decode=12ms detect=80ms quality=18ms embed=240ms fetch=22ms total=372ms ...`. Future slow-verify reports can pinpoint the bottleneck without extra tooling.
- **`check_liveness.py`**: same idea — `face/liveness: decode=8ms detect=70ms liveness=380ms total=458ms backend=uniface`.

**Estimated improvement**: first `/verify` after deploy goes from ~3-4 s to ~700-900 ms once the lazy MiniFASNet load is moved to startup. Subsequent calls were already warm (asyncio.Lock + double-checked-loading from PR #59 still applies as the safety net).

Pairs with frontend preload PR: Rollingcat-Software/web-app#58.

## Test plan
- [ ] Restart `biometric-api` container; verify startup log shows `Pre-loading UniFace MiniFASNet...` followed by `UniFace MiniFASNet pre-loaded`
- [ ] First `POST /api/v1/face/verify` after restart returns in <1 s (previously 3-4 s)
- [ ] Logs show per-stage breakdown: `face/verify: decode=... detect=... embed=... total=...`
- [ ] `LIVENESS_BACKEND=texture` (non-uniface) deployments skip warm-up cleanly with log line

🤖 Generated with [Claude Code](https://claude.com/claude-code)