### PR TITLE
chore: address Copilot post-merge findings on PR #63 (round 5)

### DIFF
--- a/app/application/use_cases/check_liveness.py
+++ b/app/application/use_cases/check_liveness.py
@@ -128,10 +128,13 @@ class CheckLivenessUseCase:
         t0 = time.perf_counter()
         liveness_result = await self._liveness_detector.check_liveness(face_region)
         liveness_ms = (time.perf_counter() - t0) * 1000
-        total_ms = (time.perf_counter() - t_start) * 1000
+        # Copilot post-merge round 5: rename `total` to `total_until_liveness`
+        # because there is still substantial work after this point (signal-metrics,
+        # DeepFace veto, calibration payload). True end-to-end is logged at return.
+        total_until_liveness_ms = (time.perf_counter() - t_start) * 1000
         logger.info(
             f"face/liveness: decode={decode_ms:.0f}ms detect={detect_ms:.0f}ms "
-            f"liveness={liveness_ms:.0f}ms total={total_ms:.0f}ms "
+            f"liveness={liveness_ms:.0f}ms total_until_liveness={total_until_liveness_ms:.0f}ms "
             f"backend={settings.get_liveness_backend()}"
         )
         signal_metrics = extract_face_signal_metrics(
@@ -312,11 +315,13 @@ class CheckLivenessUseCase:
             },
         )
 
+        total_ms = (time.perf_counter() - t_start) * 1000
         logger.info(
             f"Liveness check completed: "
             f"is_live={liveness_result.is_live}, "
             f"score={liveness_result.score:.1f}, "
-            f"challenge={liveness_result.challenge}"
+            f"challenge={liveness_result.challenge}, "
+            f"total={total_ms:.0f}ms"
         )
 
         return liveness_result

--- a/app/core/container.py
+++ b/app/core/container.py
@@ -929,19 +929,42 @@ def initialize_dependencies() -> None:
     # so the cost is paid once by the operator, never by an end user.
     # Failures are non-fatal — verification still works, just slower
     # on the first call.
-    if settings.get_liveness_backend() in ("uniface", "hybrid"):
+    # Copilot post-merge round 5 (PR #63):
+    # - Warm the *same* long-lived detector instance returned by
+    #   `get_liveness_detector()` rather than constructing a throw-away
+    #   MiniFASNet, so the per-instance `self._model` is loaded before any
+    #   user traffic arrives.
+    # - Log skipped backends so operators can confirm the skip was intentional.
+    # - Use `exc_info=True` to keep traceback visible while staying non-fatal.
+    _liveness_backend = settings.get_liveness_backend()
+    if _liveness_backend in ("uniface", "hybrid"):
         try:
-            logger.info("Pre-loading UniFace MiniFASNet (anti-spoof)...")
-            from uniface.spoofing import MiniFASNet  # noqa: WPS433
-            MiniFASNet()
-            logger.info("UniFace MiniFASNet pre-loaded")
+            logger.info("Pre-loading UniFace MiniFASNet on cached liveness detector...")
+            liveness_detector = get_liveness_detector()
+            warm_hook = getattr(liveness_detector, "warm_model_sync", None)
+            if callable(warm_hook):
+                warm_hook()
+                logger.info("UniFace MiniFASNet pre-loaded")
+            else:
+                logger.info(
+                    "Liveness detector does not expose UniFace warm-up hook; "
+                    "skipping explicit MiniFASNet pre-load."
+                )
         except ImportError:
             logger.warning(
                 "uniface package not installed — skipping MiniFASNet warm-up. "
                 "First /verify call will pay the cold-start cost."
             )
         except Exception as e:  # pragma: no cover — defensive only
-            logger.warning(f"UniFace warm-up failed (non-fatal): {e}")
+            logger.warning(
+                f"UniFace warm-up failed (non-fatal): {e}",
+                exc_info=True,
+            )
+    else:
+        logger.info(
+            f"Liveness backend '{_liveness_backend}' does not require UniFace warm-up; "
+            f"skipping MiniFASNet pre-load."
+        )
 
     # Pre-load voice model (numba-free MFCC+torch embedder)
     logger.info("Pre-loading speaker embedder...")

--- a/app/infrastructure/ml/liveness/uniface_liveness_detector.py
+++ b/app/infrastructure/ml/liveness/uniface_liveness_detector.py
@@ -119,6 +119,38 @@ class UniFaceLivenessDetector(ILivenessDetector):
                 logger.error(f"Failed to load MiniFASNet model: {e}", exc_info=True)
                 raise LivenessCheckError(f"Failed to initialize MiniFASNet: {e}")
 
+    def warm_model_sync(self) -> None:
+        """Synchronously preload the MiniFASNet model on this detector instance.
+
+        Intended for application startup (`initialize_dependencies`) before
+        the asyncio event loop is running. By loading the model directly onto
+        `self._model`, the same long-lived detector instance returned by
+        `get_liveness_detector()` skips the lazy-load on the first
+        `check_liveness()` call.
+
+        Copilot post-merge round 5 (PR #63): the previous warm-up created a
+        throw-away MiniFASNet, which only helped if `uniface` cached global
+        state — it did NOT prepopulate the per-instance `self._model`.
+
+        Raises:
+            LivenessCheckError: If uniface is not installed or model fails to load.
+        """
+        if self._model is not None:
+            return
+        try:
+            from uniface.spoofing import MiniFASNet
+            self._model = MiniFASNet()
+            logger.info("UniFace MiniFASNet model pre-loaded (sync warm-up)")
+        except ImportError as e:
+            logger.error(f"uniface package not installed: {e}")
+            raise LivenessCheckError(
+                "uniface package is required for UniFace liveness detection. "
+                "Install it with: pip install 'uniface>=3.0.0'"
+            )
+        except Exception as e:
+            logger.error(f"Failed to pre-load MiniFASNet model: {e}", exc_info=True)
+            raise LivenessCheckError(f"Failed to initialize MiniFASNet: {e}")
+
     async def check_liveness(self, image: np.ndarray) -> LivenessResult:
         """Check if image shows a live person using MiniFASNet.
 


### PR DESCRIPTION
## Summary

Four Copilot review findings from PR #63 post-merge:

- **container.py warm-up** now loads MiniFASNet onto the long-lived
  detector instance via the new `UniFaceLivenessDetector.warm_model_sync()`,
  instead of constructing a throw-away `MiniFASNet()` whose state was never
  preserved on the actual detector returned to request handlers.
- **Skipped backends now log** (info-level) so operators can confirm the
  warm-up was intentionally skipped for non-uniface/hybrid backends.
- **Generic warm-up exception** uses `exc_info=True` so the traceback is
  captured for diagnosis while staying non-fatal at startup.
- **`check_liveness.py` timing** — renamed mid-flow log to
  `total_until_liveness` and added a true end-to-end `total` on the final
  completion log. The previous `total=...` was misleading because
  signal-metrics, DeepFace veto, and calibration logging all run after.

## Test plan

- [x] `python3 -m py_compile` on all three touched files: PASS
- [ ] Operator: confirm `Liveness backend 'X' does not require UniFace
      warm-up; skipping MiniFASNet pre-load.` shows up in startup logs
      when `LIVENESS_BACKEND=texture`.
- [ ] Operator: confirm `UniFace MiniFASNet pre-loaded` shows up at
      startup when `LIVENESS_BACKEND=uniface`, and no `_ensure_model_loaded`
      log appears on the first `/verify` after restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)