### PR TITLE
chore(copilot-round-8): UniFace warm-up correctness + cached singleton + tests

### DIFF
--- a/app/core/container.py
+++ b/app/core/container.py
@@ -41,6 +41,7 @@ from app.core.config import settings
 from app.domain.interfaces.card_type_detector import ICardTypeDetector
 from app.domain.interfaces.embedding_extractor import IEmbeddingExtractor
 from app.domain.interfaces.embedding_repository import IEmbeddingRepository
+from app.domain.exceptions.liveness_errors import LivenessCheckError
 from app.domain.interfaces.event_bus import IEventBus
 from app.domain.interfaces.active_liveness_session_repository import IActiveLivenessSessionRepository
 
@@ -929,17 +930,27 @@ def initialize_dependencies() -> None:
     # so the cost is paid once by the operator, never by an end user.
     # Failures are non-fatal — verification still works, just slower
     # on the first call.
-    # Copilot post-merge round 5 (PR #63):
-    # - Warm the *same* long-lived detector instance returned by
-    #   `get_liveness_detector()` rather than constructing a throw-away
-    #   MiniFASNet, so the per-instance `self._model` is loaded before any
-    #   user traffic arrives.
-    # - Log skipped backends so operators can confirm the skip was intentional.
-    # - Use `exc_info=True` to keep traceback visible while staying non-fatal.
+    # Copilot post-merge round 8 (PR #64):
+    # - `get_liveness_detector()` is intentionally NOT cached (the
+    #   enhanced/hybrid detectors keep per-session blink state which must
+    #   not leak across requests). The fix lives one layer down:
+    #   `UniFaceLivenessDetector` resolves MiniFASNet through a
+    #   module-level `lru_cache` (`_get_shared_minifasnet`), so warming
+    #   any single instance primes the shared ONNX session for every
+    #   later instance — including the inner detector inside
+    #   `HybridLivenessDetector`.
+    # - `warm_model_sync()` already wraps `ImportError` in
+    #   `LivenessCheckError`, so the outer `except ImportError` was
+    #   unreachable. We catch `LivenessCheckError` instead and walk
+    #   `__cause__` to keep the operator-facing log accurate.
+    # - HybridLivenessDetector now exposes its own `warm_model_sync()`
+    #   forwarding to the inner UniFace, so hybrid mode actually warms.
     _liveness_backend = settings.get_liveness_backend()
     if _liveness_backend in ("uniface", "hybrid"):
         try:
-            logger.info("Pre-loading UniFace MiniFASNet on cached liveness detector...")
+            logger.info(
+                "Pre-loading UniFace MiniFASNet (process-wide shared ONNX session)..."
+            )
             liveness_detector = get_liveness_detector()
             warm_hook = getattr(liveness_detector, "warm_model_sync", None)
             if callable(warm_hook):
@@ -950,11 +961,21 @@ def initialize_dependencies() -> None:
                     "Liveness detector does not expose UniFace warm-up hook; "
                     "skipping explicit MiniFASNet pre-load."
                 )
-        except ImportError:
-            logger.warning(
-                "uniface package not installed — skipping MiniFASNet warm-up. "
-                "First /verify call will pay the cold-start cost."
-            )
+        except LivenessCheckError as e:
+            # `warm_model_sync()` wraps the underlying failure in
+            # LivenessCheckError. Walk `__cause__` to recover the original
+            # exception class so the operator-facing log is accurate.
+            cause = e.__cause__
+            if isinstance(cause, ImportError):
+                logger.warning(
+                    "uniface package not installed — skipping MiniFASNet warm-up. "
+                    "First /verify call will pay the cold-start cost."
+                )
+            else:
+                logger.warning(
+                    f"UniFace warm-up failed (non-fatal): {e}",
+                    exc_info=True,
+                )
         except Exception as e:  # pragma: no cover — defensive only
             logger.warning(
                 f"UniFace warm-up failed (non-fatal): {e}",

--- a/app/infrastructure/ml/liveness/hybrid_liveness_detector.py
+++ b/app/infrastructure/ml/liveness/hybrid_liveness_detector.py
@@ -44,6 +44,18 @@ class HybridLivenessDetector(ILivenessDetector):
             liveness_threshold=liveness_threshold,
         )
 
+    def warm_model_sync(self) -> None:
+        """Forward sync warm-up to the inner UniFace detector.
+
+        Copilot post-merge round 8 (PR #64): with `LIVENESS_BACKEND=hybrid`
+        the warm-up hook in `initialize_dependencies()` previously fell
+        through the `getattr(..., "warm_model_sync", None)` branch and
+        logged "skipping explicit MiniFASNet pre-load", because
+        HybridLivenessDetector did not expose the hook. The inner
+        UniFace detector still owns the ONNX session, so we just forward.
+        """
+        self._uniface.warm_model_sync()
+
     async def check_liveness(self, image: np.ndarray) -> LivenessResult:
         enhanced_result = await self._enhanced.check_liveness(image)
         if enhanced_result.details.get("screen_replay_hard_veto"):

--- a/app/infrastructure/ml/liveness/uniface_liveness_detector.py
+++ b/app/infrastructure/ml/liveness/uniface_liveness_detector.py
@@ -16,6 +16,7 @@ Follows the same ILivenessDetector protocol as other implementations
 
 import asyncio
 import logging
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Optional
 
 import cv2
@@ -32,6 +33,49 @@ if TYPE_CHECKING:
     from uniface.spoofing import MiniFASNet
 
 logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=1)
+def _get_shared_minifasnet() -> "MiniFASNet":
+    """Process-wide cached MiniFASNet ONNX session.
+
+    Copilot post-merge round 8 (PR #64): `get_liveness_detector()` is
+    intentionally NOT cached (the enhanced/hybrid detectors keep per-session
+    blink state which must not leak across requests). That meant the
+    startup warm-up loaded MiniFASNet onto a throw-away
+    `UniFaceLivenessDetector` and request handlers still constructed fresh
+    detectors paying the first-call ONNX session-init cost — the warm-up
+    was effectively dead code.
+
+    Caching the underlying MiniFASNet at module level (not the detector
+    instance) preserves blink-state isolation while ensuring the heavy
+    ONNX session is initialised exactly once per process. Every later
+    `UniFaceLivenessDetector` instance — including the inner detector
+    inside `HybridLivenessDetector` — picks up the same shared model.
+
+    Raises:
+        LivenessCheckError: If uniface is not installed or the model
+            fails to construct. The original `ImportError` is preserved
+            as `__cause__` so callers that need to disambiguate can walk
+            the cause chain.
+    """
+    try:
+        from uniface.spoofing import MiniFASNet
+        model = MiniFASNet()
+        logger.info("UniFace MiniFASNet model loaded (process-wide shared session)")
+        return model
+    except ImportError as e:
+        logger.error(f"uniface package not installed: {e}")
+        # Preserve the ImportError as __cause__ via `from e` so callers that
+        # need to disambiguate "missing dependency" from "model crashed"
+        # can walk `exc.__cause__`.
+        raise LivenessCheckError(
+            "uniface package is required for UniFace liveness detection. "
+            "Install it with: pip install 'uniface>=3.0.0'"
+        ) from e
+    except Exception as e:
+        logger.error(f"Failed to load MiniFASNet model: {e}", exc_info=True)
+        raise LivenessCheckError(f"Failed to initialize MiniFASNet: {e}") from e
 
 
 class UniFaceLivenessDetector(ILivenessDetector):
@@ -77,17 +121,17 @@ class UniFaceLivenessDetector(ILivenessDetector):
 
         Uses canonical double-checked locking: an unlocked fast-path read
         when the model is already loaded, then a lock-protected re-check
-        before construction so only one coroutine ever instantiates the
-        model.
+        before binding so only one coroutine ever populates ``self._model``.
 
         Returns the loaded model directly so callers don't have to deal
         with `Optional[MiniFASNet]` at the call site (Copilot post-merge
         finding on PR #59 — `.predict(...)` was failing mypy because
         `self._model` stayed typed `Optional` after the await).
 
-        This avoids importing uniface at module level, which allows
-        the application to start even if uniface is not installed
-        (graceful degradation).
+        The actual MiniFASNet construction lives in the module-level
+        `_get_shared_minifasnet()` `lru_cache`, so once any instance has
+        triggered the load every later instance picks up the same ONNX
+        session for free (Copilot post-merge round 8 / PR #64).
 
         Raises:
             LivenessCheckError: If uniface is not installed or model fails to load
@@ -102,54 +146,39 @@ class UniFaceLivenessDetector(ILivenessDetector):
             if self._model is not None:
                 return self._model
 
-            try:
-                from uniface.spoofing import MiniFASNet
-                self._model = MiniFASNet()
-                logger.info("UniFace MiniFASNet model loaded successfully")
-                return self._model
-            except ImportError as e:
-                logger.error(f"uniface package not installed: {e}")
-                # Version pin must match requirements.txt — keeping these
-                # in sync was a Copilot post-merge finding on PR #59.
-                raise LivenessCheckError(
-                    "uniface package is required for UniFace liveness detection. "
-                    "Install it with: pip install 'uniface>=3.0.0'"
-                )
-            except Exception as e:
-                logger.error(f"Failed to load MiniFASNet model: {e}", exc_info=True)
-                raise LivenessCheckError(f"Failed to initialize MiniFASNet: {e}")
+            # Resolve through the process-wide cache. Errors are already
+            # wrapped in LivenessCheckError by `_get_shared_minifasnet`.
+            self._model = _get_shared_minifasnet()
+            return self._model
 
     def warm_model_sync(self) -> None:
-        """Synchronously preload the MiniFASNet model on this detector instance.
+        """Synchronously preload the MiniFASNet model.
 
-        Intended for application startup (`initialize_dependencies`) before
-        the asyncio event loop is running. By loading the model directly onto
-        `self._model`, the same long-lived detector instance returned by
-        `get_liveness_detector()` skips the lazy-load on the first
-        `check_liveness()` call.
+        Intended for application startup (`initialize_dependencies`),
+        during startup before serving requests. Even though FastAPI's
+        ``lifespan`` is itself an `async` context, this hook is purely
+        synchronous: it forces the module-level
+        ``_get_shared_minifasnet()`` cache to populate so the heavy ONNX
+        session-init cost is paid by the operator, never by an end user
+        on the first `/verify` call after a deploy.
 
-        Copilot post-merge round 5 (PR #63): the previous warm-up created a
-        throw-away MiniFASNet, which only helped if `uniface` cached global
-        state — it did NOT prepopulate the per-instance `self._model`.
+        Copilot post-merge round 8 (PR #64): the previous implementation
+        wrote to a per-instance ``self._model``. Combined with
+        ``get_liveness_detector()`` being intentionally non-cached (so
+        per-session blink state in the enhanced/hybrid detectors stays
+        isolated), the warmed instance was thrown away and request
+        handlers still paid the first-call MiniFASNet load cost. Routing
+        through the module-level cache fixes that without re-introducing
+        cross-session blink-state leakage.
 
         Raises:
             LivenessCheckError: If uniface is not installed or model fails to load.
         """
-        if self._model is not None:
-            return
-        try:
-            from uniface.spoofing import MiniFASNet
-            self._model = MiniFASNet()
-            logger.info("UniFace MiniFASNet model pre-loaded (sync warm-up)")
-        except ImportError as e:
-            logger.error(f"uniface package not installed: {e}")
-            raise LivenessCheckError(
-                "uniface package is required for UniFace liveness detection. "
-                "Install it with: pip install 'uniface>=3.0.0'"
-            )
-        except Exception as e:
-            logger.error(f"Failed to pre-load MiniFASNet model: {e}", exc_info=True)
-            raise LivenessCheckError(f"Failed to initialize MiniFASNet: {e}")
+        # Bind the cached model to this instance too so the very first
+        # `check_liveness()` skips the lock + cache lookup.
+        if self._model is None:
+            self._model = _get_shared_minifasnet()
+        logger.info("UniFace MiniFASNet model pre-loaded (sync warm-up)")
 
     async def check_liveness(self, image: np.ndarray) -> LivenessResult:
         """Check if image shows a live person using MiniFASNet.

--- a/tests/unit/infrastructure/test_uniface_liveness_detector.py
+++ b/tests/unit/infrastructure/test_uniface_liveness_detector.py
@@ -17,9 +17,24 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from app.domain.exceptions.liveness_errors import LivenessCheckError
 from app.infrastructure.ml.liveness.uniface_liveness_detector import (
     UniFaceLivenessDetector,
+    _get_shared_minifasnet,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_shared_minifasnet_cache():
+    """Clear the module-level MiniFASNet `lru_cache` between tests.
+
+    The cache is intentionally process-wide in production (Copilot
+    post-merge round 8 / PR #64), but tests stub different fake
+    `MiniFASNet` factories per case and need a fresh slate each time.
+    """
+    _get_shared_minifasnet.cache_clear()
+    yield
+    _get_shared_minifasnet.cache_clear()
 
 
 @pytest.mark.asyncio
@@ -92,3 +107,105 @@ async def test_ensure_model_loaded_returns_loaded_model_directly(monkeypatch):
     # Second call (fast path) must also return the same model.
     model2 = await detector._ensure_model_loaded()
     assert model2 is model
+
+
+# ---------------------------------------------------------------------------
+# warm_model_sync — Copilot post-merge round 8 (PR #64)
+# ---------------------------------------------------------------------------
+
+
+def test_warm_model_sync_loads_minifasnet_exactly_once(monkeypatch):
+    """warm_model_sync must instantiate MiniFASNet exactly once across both
+    multiple detector instances and repeat calls — the whole point of the
+    fix is that the warm-up persists into request-time detector instances."""
+    call_count = 0
+
+    def _fake_factory():
+        nonlocal call_count
+        call_count += 1
+        return MagicMock(name=f"MiniFASNet#{call_count}")
+
+    fake_spoofing = types.ModuleType("uniface.spoofing")
+    fake_spoofing.MiniFASNet = _fake_factory
+    monkeypatch.setitem(sys.modules, "uniface", types.ModuleType("uniface"))
+    monkeypatch.setitem(sys.modules, "uniface.spoofing", fake_spoofing)
+
+    # Detector A: warm at "startup" (analogue of initialize_dependencies).
+    warm_detector = UniFaceLivenessDetector()
+    warm_detector.warm_model_sync()
+    assert call_count == 1, "warm_model_sync should construct exactly one MiniFASNet"
+    assert warm_detector._model is not None
+
+    # Repeat call on the same instance is a no-op.
+    warm_detector.warm_model_sync()
+    assert call_count == 1, "second warm_model_sync on same instance must be a no-op"
+
+    # Detector B: a fresh instance — analogue of a request-time
+    # `get_liveness_detector()` after the warm-up. The shared lru_cache
+    # MUST hand back the same MiniFASNet, NOT instantiate another one.
+    request_detector = UniFaceLivenessDetector()
+    request_detector.warm_model_sync()
+    assert call_count == 1, (
+        "warm_model_sync on a second instance must reuse the shared MiniFASNet "
+        "(otherwise the bio-1 caching fix is broken)."
+    )
+    assert request_detector._model is warm_detector._model
+
+
+def test_warm_model_sync_surfaces_import_error_as_liveness_check_error(monkeypatch):
+    """If `uniface` is not installed, warm_model_sync must raise
+    LivenessCheckError with the original ImportError preserved as
+    `__cause__` so container.py can disambiguate missing-dependency
+    from real failures (Copilot post-merge round 8 / bio-2)."""
+    # Force `from uniface.spoofing import MiniFASNet` to raise ImportError
+    # by removing the fake modules from sys.modules and ensuring real
+    # import fails. We simulate a missing package via a sentinel module
+    # whose attribute access raises.
+    fake_spoofing = types.ModuleType("uniface.spoofing")
+
+    def _missing_attr(name):
+        raise ImportError(f"cannot import name {name!r} from 'uniface.spoofing' (test stub)")
+
+    fake_spoofing.__getattr__ = _missing_attr  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "uniface", types.ModuleType("uniface"))
+    monkeypatch.setitem(sys.modules, "uniface.spoofing", fake_spoofing)
+
+    detector = UniFaceLivenessDetector()
+    with pytest.raises(LivenessCheckError) as excinfo:
+        detector.warm_model_sync()
+
+    # The original ImportError must be reachable via __cause__ so the
+    # container.py warm-up code can log the operator-friendly message.
+    assert isinstance(excinfo.value.__cause__, ImportError)
+
+
+def test_warm_model_sync_primes_shared_cache_for_async_path(monkeypatch):
+    """After warm_model_sync(), a freshly constructed detector's
+    async `_ensure_model_loaded()` must skip MiniFASNet construction
+    and re-use the cached model — the end-to-end behaviour the warm-up
+    is meant to deliver."""
+    call_count = 0
+
+    def _fake_factory():
+        nonlocal call_count
+        call_count += 1
+        return MagicMock(name=f"MiniFASNet#{call_count}")
+
+    fake_spoofing = types.ModuleType("uniface.spoofing")
+    fake_spoofing.MiniFASNet = _fake_factory
+    monkeypatch.setitem(sys.modules, "uniface", types.ModuleType("uniface"))
+    monkeypatch.setitem(sys.modules, "uniface.spoofing", fake_spoofing)
+
+    # Warm at startup.
+    UniFaceLivenessDetector().warm_model_sync()
+    assert call_count == 1
+
+    # Simulate the request path: a fresh non-cached detector instance
+    # calls the async lazy-loader. The shared cache must short-circuit.
+    request_detector = UniFaceLivenessDetector()
+    loaded = asyncio.run(request_detector._ensure_model_loaded())
+    assert loaded is not None
+    assert call_count == 1, (
+        "request-time _ensure_model_loaded() must not pay the MiniFASNet "
+        "construction cost when warm_model_sync() ran at startup."
+    )


### PR DESCRIPTION
## Summary
4 round-8 Copilot findings on PR #64.

- **Substantive (bio-1)**: `get_liveness_detector()` is intentionally not cached (per-session blink state in enhanced/hybrid detectors must stay isolated), so the previous warm-up loaded MiniFASNet onto a throw-away instance and request handlers still paid the first-call ONNX session-init cost. Fixed by caching the underlying MiniFASNet at module level via `_get_shared_minifasnet()` `lru_cache`. Warm-up now primes the shared ONNX session for every later instance, including the inner detector inside `HybridLivenessDetector`.
- **bio-2**: dropped unreachable `except ImportError` in `initialize_dependencies()`. `warm_model_sync()` wraps `ImportError` in `LivenessCheckError` (with original preserved as `__cause__`); the outer handler now catches `LivenessCheckError` and walks `__cause__` to keep the operator-facing "uniface not installed" message accurate.
- **bio-3**: docstring corrected — warm-up runs during startup before serving requests (FastAPI lifespan is itself async but the hook is synchronous).
- **bio-4**: unit tests for `warm_model_sync()` — load-once across multiple instances, no-op-second-call, ImportError surfaces with `__cause__` set, warmed cache primes the request-time async path.
- Bonus: `HybridLivenessDetector` now exposes its own `warm_model_sync()` forwarding to the inner UniFace detector. Previously hybrid mode silently fell through the `getattr(..., None)` fallthrough and skipped warm-up entirely.

## Test plan
- [ ] CI: `pytest tests/unit/infrastructure/test_uniface_liveness_detector.py` green.
- [ ] After deploy: first `/check_liveness` request after start does NOT log model-loading; load happened at warm-up.
- [ ] With `LIVENESS_BACKEND=hybrid`: startup log shows "UniFace MiniFASNet pre-loaded" (not "skipping explicit MiniFASNet pre-load").

🤖 Generated with [Claude Code](https://claude.com/claude-code)