### PR TITLE
fix(bio): add alembic to runtime image + repair backfill script async-iter

### DIFF
--- a/app/infrastructure/persistence/scripts/backfill_embedding_ciphertext.py
+++ b/app/infrastructure/persistence/scripts/backfill_embedding_ciphertext.py
@@ -24,7 +24,7 @@ import asyncio
 import logging
 import os
 import sys
-from typing import Iterable, Tuple
+from typing import Tuple
 
 import asyncpg
 import numpy as np
@@ -55,6 +55,19 @@ async def _setup_connection(conn: asyncpg.Connection) -> None:
     await register_vector(conn)
 
 
+def _coerce_embedding(raw) -> np.ndarray:
+    """Normalize a pgvector column value into a float32 numpy array.
+
+    pgvector returns the column as a Python string (e.g. ``'[0,0.024,0.149,...]'``)
+    when the connection isn't registered with ``pgvector.asyncpg.register_vector``,
+    and as a list/sequence when it is. Handle both — the registration call has
+    historically been fragile across asyncpg/pgvector versions.
+    """
+    if isinstance(raw, str):
+        raw = [float(x) for x in raw.strip("[]").split(",") if x]
+    return np.array(raw, dtype=np.float32)
+
+
 async def _backfill_table(
     conn: asyncpg.Connection, table: str, cipher: EmbeddingCipher, key_version: int
 ) -> Tuple[int, int]:
@@ -62,44 +75,47 @@ async def _backfill_table(
     scanned = 0
     updated = 0
 
-    # Stream rows with a server-side cursor to keep memory bounded for large
-    # datasets. asyncpg cursors require a transaction.
-    async with conn.transaction():
-        cursor: Iterable = await conn.cursor(
-            f"""
-            SELECT id, embedding
-            FROM {table}
-            WHERE embedding_ciphertext IS NULL
-              AND embedding IS NOT NULL
-            ORDER BY id
-            """
-        )
+    # NOTE: previous implementation used ``async for row in await conn.cursor(...)``
+    # which raises ``TypeError: 'async for' requires an object with __aiter__``
+    # against the asyncpg version pinned in this repo (Cursor lacks __aiter__).
+    # ``conn.fetch`` materializes the result set in memory; current biometric_db
+    # rowcounts are O(hundreds), so this is fine. If volume grows >100k, switch
+    # to explicit cursor iteration via ``cursor.fetch(N)`` in a loop.
+    rows = await conn.fetch(
+        f"""
+        SELECT id, embedding
+        FROM {table}
+        WHERE embedding_ciphertext IS NULL
+          AND embedding IS NOT NULL
+        ORDER BY id
+        """
+    )
 
-        async for row in cursor:
-            scanned += 1
-            row_id = row["id"]
-            try:
-                vec = np.array(row["embedding"], dtype=np.float32)
-                if vec.size == 0:
-                    logger.warning("%s id=%s has empty embedding; skipping", table, row_id)
-                    continue
-                ciphertext = cipher.encrypt_vector(vec)
-                await conn.execute(
-                    f"""
-                    UPDATE {table}
-                    SET embedding_ciphertext = $1,
-                        key_version = $2
-                    WHERE id = $3
-                      AND embedding_ciphertext IS NULL
-                    """,
-                    ciphertext, key_version, row_id,
-                )
-                updated += 1
-            except Exception as e:  # noqa: BLE001 — keep going past one bad row
-                logger.error("%s id=%s failed: %s", table, row_id, e)
+    for row in rows:
+        scanned += 1
+        row_id = row["id"]
+        try:
+            vec = _coerce_embedding(row["embedding"])
+            if vec.size == 0:
+                logger.warning("%s id=%s has empty embedding; skipping", table, row_id)
+                continue
+            ciphertext = cipher.encrypt_vector(vec)
+            await conn.execute(
+                f"""
+                UPDATE {table}
+                SET embedding_ciphertext = $1,
+                    key_version = $2
+                WHERE id = $3
+                  AND embedding_ciphertext IS NULL
+                """,
+                ciphertext, key_version, row_id,
+            )
+            updated += 1
+        except Exception as e:  # noqa: BLE001 — keep going past one bad row
+            logger.error("%s id=%s failed: %s", table, row_id, e)
 
-            if scanned % PROGRESS_EVERY == 0:
-                logger.info("%s: scanned=%d updated=%d", table, scanned, updated)
+        if scanned % PROGRESS_EVERY == 0:
+            logger.info("%s: scanned=%d updated=%d", table, scanned, updated)
 
     logger.info("%s: DONE scanned=%d updated=%d", table, scanned, updated)
     return scanned, updated

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,6 +59,16 @@ psycopg2-binary>=2.9.10
 cloud-sql-python-connector[asyncpg]>=1.0.0
 
 # ===========================================
+# Migrations - Alembic (used by alembic/env.py at runtime)
+# Required so `alembic upgrade head` works inside the runtime container.
+# Without this, operators have to apply migrations via raw SQL, which is
+# how V0005 was applied during the 2026-05-02 prod deploy.
+# SQLAlchemy 2.0+ compatible (lock file pins SQLAlchemy==2.0.25).
+# ===========================================
+alembic>=1.13.0
+SQLAlchemy[asyncio]>=2.0.25
+
+# ===========================================
 # Caching - Redis
 # ===========================================
 redis>=5.3.0


### PR DESCRIPTION
## Summary

Two related defects discovered live during the **2026-05-02 prod deploy** of the embedding-encryption (P1.3) feature.

### Defect 1 — alembic missing from runtime image

The bio Dockerfile + `requirements.txt` don't install alembic. Live errors:

```
$ docker compose -f docker-compose.prod.yml --env-file .env.prod \
    exec biometric-api alembic upgrade head
OCI runtime exec failed: exec failed: unable to start container process:
exec: "alembic": executable file not found in $PATH: unknown

$ docker compose -f docker-compose.prod.yml --env-file .env.prod \
    exec biometric-api python -m alembic upgrade head
/usr/local/bin/python: No module named alembic.__main__; 'alembic' is a package
and cannot be directly executed
```

V0005 had to be applied via raw SQL during the 05-02 deploy to unblock the embedding-encryption rollout. Future migrations would hit the same wall.

**Fix:** pin `alembic>=1.13.0` (SQLAlchemy 2.0+ compatible) and `SQLAlchemy[asyncio]>=2.0.25` (alembic/env.py imports from `sqlalchemy.ext.asyncio` and the lock file already pins SQLAlchemy==2.0.25 — but the runtime image was relying on transitive resolution that never picked it up).

**Verified:**
```
$ docker run --rm python:3.12-slim sh -c "pip install 'alembic>=1.13.0' 'SQLAlchemy[asyncio]>=2.0.25' && which alembic && alembic --version"
/usr/local/bin/alembic
alembic 1.18.4
```

### Defect 2 — backfill script async-iter bug + pgvector string parsing

`app/infrastructure/persistence/scripts/backfill_embedding_ciphertext.py` line 78 raised:

```
TypeError: 'async for' requires an object with __aiter__ method, got Cursor
```

against the asyncpg version pinned in this repo. asyncpg's `Cursor` exposes `.fetch(N)` / `.fetchrow()` but no `__aiter__`.

Additionally, when the embedding column came back from `conn.fetch`, it was a Python string (e.g. `'[0,0.024,0.149,...]'`) — `register_vector` registration is historically fragile across asyncpg/pgvector versions — so `np.array(row["embedding"])` produced a 0-d object array, not a vector.

**Fix:**
- Replace `async with conn.transaction(): cursor = await conn.cursor(...); async for row in cursor` with `rows = await conn.fetch(...)` + sync `for row in rows` loop. Current `biometric_db` is O(hundreds of rows), so materializing in memory is fine. Comment in code flags the threshold at which to switch to explicit `cursor.fetch(N)` chunked iteration.
- Add `_coerce_embedding(raw)` helper that handles both `str` and sequence inputs from pgvector before `np.array(..., dtype=np.float32)`.
- Drop the now-unused `Iterable` typing import.

Reference: working one-shot at `/tmp/backfill_oneshot.py` (host file) successfully encrypted 25 `face_embeddings` rows in prod on 2026-05-02 using the exact `conn.fetch` + string-parse pattern this PR ports back into the canonical script.

### Diff scope

```
app/.../scripts/backfill_embedding_ciphertext.py | 94 +++++++++++++--------
requirements.txt                                  | 10 +++
2 files changed, 65 insertions(+), 39 deletions(-)
```

No other files touched. Tight, two-defect PR.

## Test plan

- [x] `ruff check app/infrastructure/persistence/scripts/backfill_embedding_ciphertext.py` — All checks passed
- [x] `ruff check app/` — 31 errors, all pre-existing on `origin/main`, no new warnings introduced
- [x] `pytest tests/unit/test_config_validator.py tests/unit/test_demographics_gating.py` — 17 passed, 1 skipped
- [x] `docker run python:3.12-slim` smoke — `alembic --version` resolves to `1.18.4` post-install
- [ ] **Operator (post-merge):** rebuild `biometric-api` image with `--no-cache` so requirements.txt is re-resolved
- [ ] **Operator (post-merge):** re-run `docker compose exec biometric-api python -m app.infrastructure.persistence.scripts.backfill_embedding_ciphertext` — expect `scanned=N updated=0` (idempotent: WHERE clause filters out rows that already have a ciphertext)
- [ ] **Operator (post-merge):** confirm `docker compose exec biometric-api alembic --version` no longer fails

## Notes

- Full unit test suite requires the container env (cv2, pytesseract, mediapipe). Out-of-scope for this PR. CI on this branch will run them.
- Don't merge — main thread merges after CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)