### PR TITLE
docs(bio): note alembic in runtime image (PR #68 2026-05-02)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,14 @@ pip install -r requirements.txt
 python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8001
 ```
 
+## Migrations (Alembic)
+
+Alembic is included in `requirements.txt` and `Dockerfile.gpu` since PR #68
+(2026-05-02 morning) — `alembic upgrade head` runs inside the runtime
+container. The earlier manual-SQL workaround for embedding-ciphertext
+backfill (Task #81) is obsolete; `backfill_embedding_ciphertext.py` was
+also repaired in the same PR.
+
 Runs on port 8001. API docs at `/docs`. Demo UI served at root `/` (disabled in production).
 
 ## Security (Production)


### PR DESCRIPTION
## Summary

`CLAUDE.md` adds a Migrations section: alembic is now in `requirements.txt` and `Dockerfile.gpu` since PR #68 (2026-05-02 morning), so `alembic upgrade head` runs inside the runtime container. The Task #81 manual-SQL workaround for embedding-ciphertext backfill is obsolete.

No source-code changes.

## Test plan

- [x] `git diff --stat` shows only CLAUDE.md modified
- [x] cross-references PR #68 (`22bd33c`) on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)