### PR TITLE
docs: add SECURITY.md and LICENSE (T4.12.a/b)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 FIVUCSAS Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you've found a security vulnerability in biometric-processor — the FastAPI face/voice/liveness inference service of the FIVUCSAS biometric authentication platform — please report it privately so we can fix it before disclosing publicly.
+
+**Email:** info@app.fivucsas.com (subject prefix: `[SECURITY] biometric-processor`)
+
+Please include:
+- A clear description of the issue and its impact.
+- Steps to reproduce, ideally with a minimal proof of concept.
+- Affected versions or commit SHAs if known.
+- Whether the issue is already public.
+
+We commit to:
+- Acknowledging your report within **3 business days**.
+- Providing a full assessment within **10 business days**.
+- Coordinating disclosure timing with you once a fix is ready.
+
+## Scope
+
+In scope:
+- Authentication/authorization bypass (JWT, OAuth2, refresh-token, MFA, WebAuthn).
+- Account takeover or session hijacking.
+- Biometric data integrity (tenant scoping, embedding-encryption-at-rest, replay).
+- Multi-tenant isolation breaks.
+- Server-side injection (SQL, command, log).
+- Data exposure beyond the authenticated principal's tenant.
+
+Out of scope:
+- Issues requiring physical access to a user's device.
+- Social-engineering of platform staff or end-users.
+- Best-practice hardening recommendations without a concrete attack path (please open a regular issue).
+- Self-XSS, missing security headers without exploit, clickjacking on non-state-changing pages.
+
+## Safe-Harbor
+
+Good-faith research that respects user privacy, doesn't degrade service, and follows this disclosure process is welcomed. We will not pursue legal action against researchers who follow this policy.


### PR DESCRIPTION
## Summary
- Adds SECURITY.md (vulnerability disclosure policy → info@app.fivucsas.com).
- Adds MIT LICENSE (closes README-badge / no-license mismatch).

Closes T4.12.a, T4.12.b (parent ROADMAP_OPTIMIZED_2026-05-04.md / DOC_AUDIT_2026-05-04.md).

## Test plan
- Pure docs change. No code or CI behavior altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)