### PR TITLE
fix(face-search): use cropped face_region for embedding extraction (USER-BUG-4)

### DIFF
--- a/app/application/use_cases/search_face.py
+++ b/app/application/use_cases/search_face.py
@@ -137,8 +137,21 @@ class SearchFaceUseCase:
         if hasattr(detection, "face_count") and detection.face_count > 1:
             raise MultipleFacesError(count=detection.face_count)
 
-        # Extract embedding
-        embedding = await self._extractor.extract(image)
+        # USER-BUG-4 (2026-05-04): /search must use the cropped face region as
+        # the embedding extractor input, NOT the full frame. Enrollment and
+        # /verify both call ``detection.get_face_region(image)`` and pass the
+        # crop to ``extractor.extract``; the DeepFace extractor runs with
+        # ``enforce_detection=False`` because the upstream pipeline is
+        # responsible for the crop. Passing the full frame here produced a
+        # different embedding than the one stored at enrollment, so cosine
+        # distance against the centroid never crossed the verification
+        # threshold and /search always returned "no matches found" even when
+        # /verify on the same image succeeded.
+        face_region = detection.get_face_region(image)
+
+        # Extract embedding (from the cropped face region — parity with
+        # enroll_face.py and verify_face.py)
+        embedding = await self._extractor.extract(face_region)
 
         # Get threshold from calculator if not provided
         if threshold is None:

--- a/tests/unit/application/use_cases/test_search_face.py
+++ b/tests/unit/application/use_cases/test_search_face.py
@@ -1,0 +1,178 @@
+"""Unit tests for SearchFaceUseCase.
+
+USER-BUG-4 (2026-05-04): /face/search disagreed with /face/verify on the same
+input. Root cause was that the search use case extracted an embedding from the
+full input frame, while enroll_face.py and verify_face.py both pre-crop with
+``detection.get_face_region(image)`` and pass the crop to the extractor.
+
+These tests pin the parity contract: the extractor MUST be invoked with the
+cropped face region, not the original frame.
+"""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import numpy as np
+import pytest
+
+from app.application.use_cases.search_face import SearchFaceUseCase, SearchResult
+from app.domain.entities.face_detection import FaceDetectionResult
+from app.domain.exceptions.face_errors import FaceNotDetectedError
+
+
+class TestSearchFaceUseCase:
+    """Test SearchFaceUseCase parity with verify/enroll preprocessing."""
+
+    @pytest.mark.asyncio
+    async def test_extractor_receives_cropped_face_region_not_full_image(
+        self,
+        mock_embedding_extractor,
+        mock_similarity_calculator,
+        mock_embedding_repository,
+        temp_image_file,
+        sample_embedding,
+    ):
+        """USER-BUG-4 regression: search must crop face before extracting.
+
+        Asserts that the embedding extractor is called with the bounding-box
+        slice of the input image, NOT the full frame. With
+        DeepFace ``enforce_detection=False`` set in
+        ``DeepFaceExtractor.extract_sync``, passing the full frame produces a
+        very different embedding from the one stored at enrollment time
+        (which was extracted from a cropped face), so search would never match.
+        """
+        # Build a 200x200 frame and a detection that picks out the inner
+        # 100x100 region at offset (50, 50). face_region must be image[50:150, 50:150].
+        full_image = np.random.randint(0, 255, (200, 200, 3), dtype=np.uint8)
+        bbox = (50, 50, 100, 100)  # x, y, w, h
+        expected_face_region = full_image[50:150, 50:150]
+
+        detection = FaceDetectionResult(
+            found=True,
+            bounding_box=bbox,
+            landmarks=None,
+            confidence=0.95,
+        )
+        detector = Mock()
+        detector.detect = AsyncMock(return_value=detection)
+
+        mock_embedding_repository.find_similar = AsyncMock(return_value=[])
+        mock_embedding_repository.count = AsyncMock(return_value=0)
+
+        use_case = SearchFaceUseCase(
+            detector=detector,
+            extractor=mock_embedding_extractor,
+            repository=mock_embedding_repository,
+            similarity_calculator=mock_similarity_calculator,
+        )
+
+        with patch("cv2.imread") as mock_imread:
+            mock_imread.return_value = full_image
+            await use_case.execute(
+                image_path=temp_image_file,
+                tenant_id="tenant_xyz",
+            )
+
+        # Extractor must have been called exactly once
+        mock_embedding_extractor.extract.assert_called_once()
+        passed_arg = mock_embedding_extractor.extract.call_args[0][0]
+
+        # The argument must be the cropped face region, not the full frame.
+        # Shape check guards against silent fall-through to the full image.
+        assert passed_arg.shape == expected_face_region.shape, (
+            f"Expected face_region shape {expected_face_region.shape}, "
+            f"got {passed_arg.shape}. Search likely passed full image to extractor "
+            f"(USER-BUG-4 regression)."
+        )
+        assert np.array_equal(passed_arg, expected_face_region), (
+            "Extractor received different pixels than the bounding-box crop "
+            "(USER-BUG-4 regression)."
+        )
+
+    @pytest.mark.asyncio
+    async def test_search_returns_empty_when_no_face_detected(
+        self,
+        mock_embedding_extractor,
+        mock_similarity_calculator,
+        mock_embedding_repository,
+        temp_image_file,
+    ):
+        """Search must raise FaceNotDetectedError when detector returns found=False."""
+        detection = FaceDetectionResult(
+            found=False,
+            bounding_box=None,
+            landmarks=None,
+            confidence=0.0,
+        )
+        detector = Mock()
+        detector.detect = AsyncMock(return_value=detection)
+
+        use_case = SearchFaceUseCase(
+            detector=detector,
+            extractor=mock_embedding_extractor,
+            repository=mock_embedding_repository,
+            similarity_calculator=mock_similarity_calculator,
+        )
+
+        with patch("cv2.imread") as mock_imread:
+            mock_imread.return_value = np.random.randint(0, 255, (200, 200, 3), dtype=np.uint8)
+
+            with pytest.raises(FaceNotDetectedError):
+                await use_case.execute(
+                    image_path=temp_image_file,
+                    tenant_id="tenant_xyz",
+                )
+
+        # Extractor must NOT be called when no face is detected
+        mock_embedding_extractor.extract.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_search_forwards_tenant_id_to_repository(
+        self,
+        mock_embedding_extractor,
+        mock_similarity_calculator,
+        mock_embedding_repository,
+        temp_image_file,
+        sample_embedding,
+    ):
+        """tenant_id must be forwarded to find_similar (defense-in-depth)."""
+        full_image = np.random.randint(0, 255, (200, 200, 3), dtype=np.uint8)
+        bbox = (10, 10, 80, 80)
+        detection = FaceDetectionResult(
+            found=True,
+            bounding_box=bbox,
+            landmarks=None,
+            confidence=0.95,
+        )
+        detector = Mock()
+        detector.detect = AsyncMock(return_value=detection)
+
+        mock_embedding_repository.find_similar = AsyncMock(return_value=[])
+        mock_embedding_repository.count = AsyncMock(return_value=42)
+
+        use_case = SearchFaceUseCase(
+            detector=detector,
+            extractor=mock_embedding_extractor,
+            repository=mock_embedding_repository,
+            similarity_calculator=mock_similarity_calculator,
+        )
+
+        with patch("cv2.imread") as mock_imread:
+            mock_imread.return_value = full_image
+            result = await use_case.execute(
+                image_path=temp_image_file,
+                tenant_id="tenant_abc",
+                max_results=3,
+            )
+
+        # find_similar called with tenant_id keyword
+        call = mock_embedding_repository.find_similar.call_args
+        assert call.kwargs.get("tenant_id") == "tenant_abc", (
+            f"Expected tenant_id='tenant_abc' forwarded to find_similar, "
+            f"got {call.kwargs.get('tenant_id')}"
+        )
+        # count is also tenant-scoped
+        mock_embedding_repository.count.assert_called_with(tenant_id="tenant_abc")
+
+        assert isinstance(result, SearchResult)
+        assert result.total_searched == 42
+        assert result.found is False  # empty repository result


### PR DESCRIPTION
## Summary
USER-BUG-4 (face-search != face-verify) verified at HEAD `d91760a` by code-path comparison.

**Root cause (H3 — encoding/preprocessing mismatch).** `enroll_face.py:96-121` and `verify_face.py:113-146` both pre-crop the detected face via `detection.get_face_region(image)` and pass the crop to `extractor.extract(...)`. `search_face.py:131-141` (before this PR) detected the face but then called `extractor.extract(image)` on the **full** frame.

`DeepFaceExtractor.extract_sync` runs DeepFace with `enforce_detection=False` (infrastructure/ml/extractors/deepface_extractor.py:210) because the upstream pipeline owns the crop. Passing the full frame produced a fundamentally different 512-d embedding than the one stored at enrollment, so cosine distance against the user centroid never crossed the verification threshold. /search therefore returned "no matches found" on the same image that /verify accepted.

**Fix.** `search_face.py` now mirrors enroll/verify: detect → `face_region = detection.get_face_region(image)` → `extractor.extract(face_region)`.

**Hypotheses tested:**
- H1 (tenant scope): refuted as the in-process bug. Both routes accept `tenant_id` and forward it to the repo. Note however that bio `/search` requires `tenant_id` (`Form(..., min_length=1)`) while `/verify` accepts `None`, AND the web-app `BiometricService.searchFace` currently discards its `tenantId` arg (`_tenantId` underscore-prefix). Result: bio receives no tenant_id and returns 422 before any embedding work happens. That web-app/api gap is **not** fixed here — see "Out of scope" below.
- H2 (threshold): refuted. Both routes use the same `get_similarity_calculator()` instance from `core/container.py`; same `VERIFICATION_THRESHOLD`.
- H3 (preprocessing): **confirmed** as above. Fixed in this PR.

## Test plan
- New unit tests in `tests/unit/application/use_cases/test_search_face.py`:
  - `test_extractor_receives_cropped_face_region_not_full_image` — uses `np.array_equal` to assert the extractor input is the bbox slice, not the full frame. This is the regression pin for USER-BUG-4.
  - `test_search_returns_empty_when_no_face_detected` — `FaceNotDetectedError` raised, extractor not called.
  - `test_search_forwards_tenant_id_to_repository` — defense-in-depth check that `find_similar(..., tenant_id=...)` is called.
- All 3 PASS (run inside the `biometric-api` prod container with pytest installed into a writable+exec working copy):
  ```
  tests/unit/application/use_cases/test_search_face.py::TestSearchFaceUseCase::test_extractor_receives_cropped_face_region_not_full_image PASSED
  tests/unit/application/use_cases/test_search_face.py::TestSearchFaceUseCase::test_search_returns_empty_when_no_face_detected PASSED
  tests/unit/application/use_cases/test_search_face.py::TestSearchFaceUseCase::test_search_forwards_tenant_id_to_repository PASSED
  ```
- Existing `TestVerifyFaceUseCase` (6 tests) still passes against the same code base.
- Manual: re-run face search via Biometric Tools -> Face Search after deploy, with the web-app/api tenant_id forwarding question resolved (see follow-up).

## Out of scope follow-ups (flagged for the lead, not fixed here)

1. **web-app discards `tenantId` in `BiometricService.searchFace`** (`web-app/src/core/services/BiometricService.ts:229`). Even with this preprocessing fix, the request currently still reaches bio without `tenant_id` and bio responds 422 before this code path runs. Either:
   - patch web-app to append `formData.append('tenant_id', tenantId)`, or
   - patch the api `BiometricController.searchFace` to fall back to `rbacService.getCurrentUser().getTenant().getId()` when the param is absent (matches what `verifyFace` would also benefit from).

2. **Production data drift for ahabgu@gmail.com**: user is in tenant `ff000001-0000-...` but all his `face_embeddings` rows are tagged `11111111-1111-...` (Marmara). With (1) fixed and tenant_id correctly derived from the JWT, `find_similar` will still find zero matches because of this. /verify works today only because `find_by_user_id` ignores `tenant_id` (separate audit item — defense-in-depth gap, but it explains the verify/search asymmetry the user observed). Operator-side data fix.

## Container rebuild

**Bio container needs rebuild on Hetzner once this PR lands** (no infra changes; just a code path edit).

```bash
cd /opt/projects/fivucsas/biometric-processor
docker compose -f docker-compose.prod.yml --env-file .env.prod build --no-cache biometric-api
docker compose -f docker-compose.prod.yml --env-file .env.prod up -d biometric-api
```

API container does NOT need a rebuild for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)