### PR TITLE
fix(security): live-camera-analysis fail-closed when liveness detector unavailable (P0)

### DIFF
--- a/app/application/use_cases/live_camera_analysis.py
+++ b/app/application/use_cases/live_camera_analysis.py
@@ -185,11 +185,29 @@ class LiveCameraAnalysisUseCase:
                     liveness = await self._analyze_liveness(face_region)
                     response.liveness = liveness
                 else:
+                    # P0 fail-closed (INVESTIGATION_MASTER_2026-05-07): when DI
+                    # fails to inject a liveness detector (env-var typo, missing
+                    # model file, init exception), the previous default of
+                    # is_live=True silently approved every frame on /live-analysis/*.
+                    # We now return is_live=False with a machine-parseable reason.
+                    # The boot-time health check in app.main.lifespan additionally
+                    # aborts startup when the detector cannot be instantiated, so
+                    # this branch should only ever fire if a route-level dependency
+                    # explicitly bypasses the container — easier to diagnose than
+                    # a silent fail-open.
+                    logger.error(
+                        "Liveness detector unavailable; failing closed for mode=%s. "
+                        "Check container.get_liveness_detector() wiring and "
+                        "LIVENESS_BACKEND/LIVENESS_MODE env vars.",
+                        mode,
+                    )
                     response.liveness = LivenessResult(
-                        is_live=True,  # Default to true if no detector
-                        confidence=0.5,
-                        method="none",
-                        checks={"passive": True},
+                        is_live=False,
+                        confidence=0.0,
+                        method="unavailable",
+                        checks={"detector_available": False},
+                        scores={},
+                        metadata={"reason": "liveness_detector_unavailable"},
                     )
 
             # Step 5: Enrollment readiness check

--- a/app/main.py
+++ b/app/main.py
@@ -90,6 +90,37 @@ async def lifespan(app: FastAPI):
     initialize_dependencies()
     logger.info("Dependencies initialized")
 
+    # P0 startup health-check (INVESTIGATION_MASTER_2026-05-07):
+    # Fail boot if the liveness detector cannot be instantiated.
+    # The previous behavior (silent None injection -> use case fail-OPEN
+    # in live_camera_analysis.py) approved every frame on /live-analysis/*
+    # with is_live=True. Aborting at boot converts a runtime silent
+    # fail-open into a deterministic, easy-to-diagnose crash. The use case
+    # itself now also fail-CLOSES if the detector is missing at runtime.
+    from app.core.container import get_liveness_detector
+
+    try:
+        _liveness_health = get_liveness_detector()
+        if _liveness_health is None:
+            raise RuntimeError(
+                "get_liveness_detector() returned None — refusing to boot "
+                "because /live-analysis/* would silently fail-open."
+            )
+        logger.info(
+            "Startup health-check: liveness detector OK (%s)",
+            type(_liveness_health).__name__,
+        )
+    except Exception as exc:
+        logger.critical(
+            "Startup health-check FAILED: liveness detector cannot be "
+            "instantiated (%s). Aborting boot to prevent silent fail-open "
+            "on /live-analysis/* — check LIVENESS_MODE / LIVENESS_BACKEND "
+            "env vars and model files.",
+            exc,
+            exc_info=True,
+        )
+        raise
+
     yield
 
     # Shutdown

--- a/tests/unit/application/use_cases/test_live_camera_analysis.py
+++ b/tests/unit/application/use_cases/test_live_camera_analysis.py
@@ -1,0 +1,157 @@
+"""Unit tests for LiveCameraAnalysisUseCase.
+
+P0 regression (INVESTIGATION_MASTER_2026-05-07, T0-4):
+``LiveCameraAnalysisUseCase.analyze_frame`` previously returned
+``is_live=True`` whenever ``self._liveness_detector`` was ``None`` (DI failure
+at boot time, env-var typo, missing model file). That silently approved every
+frame on ``/live-analysis/*``. This test pins the fail-CLOSED contract:
+when no detector is wired, the use case must return ``is_live=False`` with
+``metadata.reason == 'liveness_detector_unavailable'``.
+"""
+
+from unittest.mock import AsyncMock, Mock
+
+import numpy as np
+import pytest
+
+from app.api.schemas.live_analysis import AnalysisMode
+from app.application.use_cases.live_camera_analysis import LiveCameraAnalysisUseCase
+
+
+def _make_detection(bbox=(50, 50, 100, 100), confidence=0.95):
+    """Build a duck-typed detection mock matching the attrs the use case reads.
+
+    ``live_camera_analysis.py`` accesses ``detection.x/y/width/height`` and
+    calls ``detection.get_face_region(image)`` — so the mock just exposes
+    those attributes plus a callable ``get_face_region`` returning a slice
+    of the input frame.
+    """
+    x, y, w, h = bbox
+    detection = Mock()
+    detection.x = x
+    detection.y = y
+    detection.width = w
+    detection.height = h
+    detection.confidence = confidence
+    detection.landmarks = None
+    detection.get_face_region = lambda image: image[y : y + h, x : x + w]
+    return detection
+
+
+@pytest.mark.asyncio
+async def test_liveness_detector_none_returns_is_live_false_with_reason():
+    """P0 fail-closed: missing liveness detector MUST NOT auto-approve frames.
+
+    Constructs the use case with ``liveness_detector=None``, runs the LIVENESS
+    analysis mode, and asserts:
+    - ``response.liveness.is_live`` is False (was True pre-fix)
+    - ``response.liveness.method`` is "unavailable"
+    - ``response.liveness.metadata['reason']`` is "liveness_detector_unavailable"
+    - ``response.liveness.confidence`` is 0.0 (no signal, so no confidence)
+    """
+    detector = Mock()
+    detector.detect = AsyncMock(return_value=_make_detection())
+
+    quality_assessor = Mock()
+    quality = Mock()
+    quality.score = 80.0
+    quality.is_acceptable = True
+    quality.get_issues = lambda: []
+    quality.blur_score = 0.0
+    quality.brightness_score = 0.0
+    quality.sharpness_score = 0.0
+    quality_assessor.assess = AsyncMock(return_value=quality)
+
+    use_case = LiveCameraAnalysisUseCase(
+        detector=detector,
+        quality_assessor=quality_assessor,
+        liveness_detector=None,  # the bug: DI failure
+    )
+
+    image = np.zeros((300, 300, 3), dtype=np.uint8)
+    response = await use_case.analyze_frame(image, mode=AnalysisMode.LIVENESS)
+
+    assert response.error is None or "Analysis error" not in response.error, (
+        f"Unexpected analysis error: {response.error!r}"
+    )
+    assert response.liveness is not None, "liveness result must be populated"
+    assert response.liveness.is_live is False, (
+        "fail-closed contract violated: detector=None was approved as live"
+    )
+    assert response.liveness.method == "unavailable"
+    assert response.liveness.confidence == 0.0
+    assert (
+        response.liveness.metadata.get("reason") == "liveness_detector_unavailable"
+    ), (
+        "missing-detector reason must be machine-parseable for ops/alerting; "
+        f"got metadata={response.liveness.metadata!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_liveness_detector_none_fail_closed_in_full_analysis_mode():
+    """FULL_ANALYSIS mode also runs liveness; same fail-closed contract applies."""
+    detector = Mock()
+    detector.detect = AsyncMock(return_value=_make_detection())
+
+    quality_assessor = Mock()
+    quality = Mock()
+    quality.score = 80.0
+    quality.is_acceptable = True
+    quality.get_issues = lambda: []
+    quality.blur_score = 0.0
+    quality.brightness_score = 0.0
+    quality.sharpness_score = 0.0
+    quality_assessor.assess = AsyncMock(return_value=quality)
+
+    use_case = LiveCameraAnalysisUseCase(
+        detector=detector,
+        quality_assessor=quality_assessor,
+        liveness_detector=None,
+    )
+
+    image = np.zeros((300, 300, 3), dtype=np.uint8)
+    response = await use_case.analyze_frame(image, mode=AnalysisMode.FULL_ANALYSIS)
+
+    assert response.liveness is not None
+    assert response.liveness.is_live is False
+    assert (
+        response.liveness.metadata.get("reason") == "liveness_detector_unavailable"
+    )
+
+
+@pytest.mark.asyncio
+async def test_enrollment_ready_mode_blocks_when_detector_missing():
+    """Defense-in-depth: ENROLLMENT_READY must NOT mark a frame ready when
+    liveness cannot be evaluated. The enrollment-readiness recommendation
+    string carries the user-facing failure reason.
+    """
+    detector = Mock()
+    detector.detect = AsyncMock(return_value=_make_detection())
+
+    quality_assessor = Mock()
+    quality = Mock()
+    quality.score = 95.0  # high quality so only liveness can block
+    quality.is_acceptable = True
+    quality.get_issues = lambda: []
+    quality.blur_score = 0.0
+    quality.brightness_score = 0.0
+    quality.sharpness_score = 0.0
+    quality_assessor.assess = AsyncMock(return_value=quality)
+
+    use_case = LiveCameraAnalysisUseCase(
+        detector=detector,
+        quality_assessor=quality_assessor,
+        liveness_detector=None,
+    )
+
+    image = np.zeros((300, 300, 3), dtype=np.uint8)
+    response = await use_case.analyze_frame(
+        image, mode=AnalysisMode.ENROLLMENT_READY
+    )
+
+    assert response.enrollment_ready is not None
+    assert response.enrollment_ready.ready is False, (
+        "enrollment must be blocked when the liveness detector is missing"
+    )
+    assert response.enrollment_ready.liveness_met is False


### PR DESCRIPTION
## Summary

Per INVESTIGATION_MASTER_2026-05-07 (P0-#4) and INVESTIGATION_MOCKS_2026-05-07: `LiveCameraAnalysisUseCase.analyze_frame` returned `is_live=True` whenever `self._liveness_detector` was `None`. If DI failed to inject the detector at boot (env-var typo, missing model file, init exception), **every frame on `/live-analysis/*` was silently approved**.

This PR converts that runtime silent fail-OPEN into a fail-CLOSED runtime contract **plus** a boot-time health-check that crashes the container before it serves traffic.

## Changes

### Runtime fail-closed (`app/application/use_cases/live_camera_analysis.py`)
When `self._liveness_detector is None`, the use case now returns:
- `is_live=False` (was `True`)
- `confidence=0.0` (was `0.5`)
- `method="unavailable"` (was `"none"`)
- `metadata.reason="liveness_detector_unavailable"` (new — machine-parseable for ops/alerting)
- An ERROR log entry telling the operator to check container DI wiring.

### Boot health-check (`app/main.py`)
`lifespan()` now calls `get_liveness_detector()` immediately after `initialize_dependencies()`. If instantiation raises or returns `None`, boot is aborted with a CRITICAL log entry. Easier to diagnose than a silent runtime fail-open — the container will fail to come up, surfacing the misconfiguration in `docker logs` and the existing `/ping` healthcheck.

### Test (`tests/unit/application/use_cases/test_live_camera_analysis.py`)
Three new tests pinning the fail-closed contract across LIVENESS, FULL_ANALYSIS, and ENROLLMENT_READY modes. **TDD-style proof**: tests #1 and #2 FAIL on `origin/main` (showing the bug), all three PASS on this branch:

```
$ pytest tests/unit/application/use_cases/test_live_camera_analysis.py -v
# vs origin/main: 2 failed, 1 passed
# vs this branch: 3 passed in 2.93s
```

## Deploy

**Bio container rebuild required** (changes to use case logic + boot-time check):

```
docker compose build biometric-api
docker compose up -d biometric-api
```

> [!IMPORTANT]
> If the rebuilt container fails to come up, **that is the new health-check working**. Diagnose `LIVENESS_MODE` / `LIVENESS_BACKEND` env vars and the model file mount in the `biometric_uniface` volume. **Do NOT roll back this fix** — the previous behavior was an unauthenticated bypass of liveness on `/live-analysis/*`.

Per task constraints, this PR does **NOT** trigger a prod rebuild. Flagged here so the operator can schedule it.

## Test plan

- [ ] `pytest tests/unit/application/use_cases/test_live_camera_analysis.py -v` (3 passed)
- [ ] Container boots cleanly with current prod env (`LIVENESS_MODE=passive`, `LIVENESS_BACKEND=uniface`)
- [ ] On purpose: set `LIVENESS_BACKEND=__bogus__` in a staging stack and confirm boot aborts with CRITICAL log
- [ ] Smoke `/api/v1/live-analysis/*` (LIVENESS mode) returns `is_live=true` for live faces and `is_live=false` for spoof samples (no behavioral change for the happy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)