### PR TITLE
fix: liveness verdict policy + 413 FILE_TOO_LARGE i18n

### DIFF
--- a/app/api/middleware/security.py
+++ b/app/api/middleware/security.py
@@ -304,11 +304,14 @@ class RequestSizeLimitMiddleware(BaseHTTPMiddleware):
                     logger.warning(
                         f"Request too large: {length} bytes (max: {self._max_content_length})"
                     )
+                    # i18n contract: stable error_code + machine-readable
+                    # limit; clients localize the message. Aligned with
+                    # main.py request_size_guard.
                     return JSONResponse(
                         status_code=413,
                         content={
-                            "error_code": "PAYLOAD_TOO_LARGE",
-                            "message": f"Request body exceeds maximum size of {self._max_content_length} bytes",
+                            "error_code": "FILE_TOO_LARGE",
+                            "max_size_bytes": self._max_content_length,
                         },
                     )
             except ValueError:

--- a/app/application/use_cases/check_liveness.py
+++ b/app/application/use_cases/check_liveness.py
@@ -20,6 +20,11 @@ from app.domain.interfaces.liveness_detector import ILivenessDetector
 logger = logging.getLogger(__name__)
 calibration_logger = logging.getLogger("liveness_calibration")
 settings = get_settings()
+# Backwards-compat constant retained for OPTIMISTIC policy (prior default behavior):
+# in optimistic mode, DeepFace's spoof verdict is only honored when UniFace's
+# liveness confidence is below this threshold; above it, UniFace "wins" and we
+# log a warning when the two backends disagree. The CONSERVATIVE policy
+# (current default) ignores this threshold and lets either backend veto.
 DEEPFACE_VETO_CONFIDENCE_THRESHOLD = 0.85
 FACE_CROP_BLUR_THRESHOLD = 50.0
 
@@ -154,10 +159,50 @@ class CheckLivenessUseCase:
             and antispoof_score >= settings.ANTI_SPOOFING_THRESHOLD
         )
 
-        if deepface_spoof_detected and liveness_result.confidence < DEEPFACE_VETO_CONFIDENCE_THRESHOLD:
+        # Verdict policy (P1 — INVESTIGATION_FAILOPEN_2026-05-07.md, fix
+        # `LIVENESS_VERDICT_POLICY`): when DeepFace and the primary liveness
+        # backend (e.g. UniFace) disagree, the policy decides how the
+        # contradiction resolves.
+        #
+        # - "conservative" (default): EITHER backend voting spoof at/above its
+        #   configured confidence wins. This is the secure default per
+        #   INVESTIGATION_FAILOPEN_2026-05-07.md — no silent fail-open.
+        # - "optimistic": preserves the historical behavior — DeepFace's spoof
+        #   verdict is only honored when the primary backend's confidence is
+        #   below DEEPFACE_VETO_CONFIDENCE_THRESHOLD. A warning is always logged
+        #   on contradiction so operators can see the disagreement even when
+        #   the primary backend "wins".
+        verdict_policy = settings.LIVENESS_VERDICT_POLICY
+        contradiction = (
+            deepface_spoof_detected and liveness_result.is_live
+        )
+
+        if verdict_policy == "conservative":
+            apply_veto = deepface_spoof_detected
+        else:  # "optimistic"
+            apply_veto = (
+                deepface_spoof_detected
+                and liveness_result.confidence < DEEPFACE_VETO_CONFIDENCE_THRESHOLD
+            )
+            if contradiction and not apply_veto:
+                logger.warning(
+                    "liveness_verdict_contradiction (optimistic policy: primary backend wins): "
+                    "antispoof_score=%.3f, antispoof_label=%s, "
+                    "primary_is_live=%s, primary_confidence=%.3f, "
+                    "veto_threshold=%.3f, deepface_spoof_ignored=True",
+                    antispoof_score if antispoof_score is not None else 0.0,
+                    antispoof_label,
+                    liveness_result.is_live,
+                    liveness_result.confidence,
+                    DEEPFACE_VETO_CONFIDENCE_THRESHOLD,
+                )
+
+        if apply_veto:
             logger.warning(
-                "DeepFace anti-spoof veto applied: antispoof_score=%.3f, liveness_confidence=%.3f",
-                antispoof_score,
+                "DeepFace anti-spoof veto applied (policy=%s): "
+                "antispoof_score=%.3f, liveness_confidence=%.3f",
+                verdict_policy,
+                antispoof_score if antispoof_score is not None else 0.0,
                 liveness_result.confidence,
             )
             updated_details = {
@@ -167,6 +212,8 @@ class CheckLivenessUseCase:
                 "antispoof_score": antispoof_score,
                 "antispoof_label": antispoof_label,
                 "deepface_veto_applied": True,
+                "verdict_policy": verdict_policy,
+                "verdict_contradiction": contradiction,
             }
             liveness_result = replace(
                 liveness_result,
@@ -183,6 +230,8 @@ class CheckLivenessUseCase:
                     "antispoof_score": antispoof_score,
                     "antispoof_label": antispoof_label,
                     "deepface_veto_applied": False,
+                    "verdict_policy": verdict_policy,
+                    "verdict_contradiction": contradiction,
                 },
             )
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -135,6 +135,23 @@ class Settings(BaseSettings):
         description="Minimum antispoof score to accept a face as real"
     )
 
+    # Liveness verdict policy — how to resolve contradictions between
+    # DeepFace anti-spoof ("spoof" label) and the primary liveness backend
+    # (e.g. UniFace). See INVESTIGATION_FAILOPEN_2026-05-07.md.
+    # - "conservative" (default, secure): either backend voting spoof wins.
+    # - "optimistic" (legacy): DeepFace only vetoes when primary backend
+    #   confidence < DEEPFACE_VETO_CONFIDENCE_THRESHOLD; otherwise primary
+    #   backend wins. Contradictions are logged.
+    LIVENESS_VERDICT_POLICY: Literal["conservative", "optimistic"] = Field(
+        default="conservative",
+        description=(
+            "Policy for resolving DeepFace vs primary-backend liveness "
+            "verdict contradictions. 'conservative' = either-vetoes "
+            "(secure default). 'optimistic' = primary backend wins on "
+            "high confidence, log warning on contradiction."
+        ),
+    )
+
     # Thresholds
     VERIFICATION_THRESHOLD: float = Field(default=0.45, ge=0.0, le=1.0)
     LIVENESS_THRESHOLD: float = Field(default=70.0, ge=0.0, le=100.0)

--- a/app/main.py
+++ b/app/main.py
@@ -275,14 +275,15 @@ async def request_size_guard(request, call_next):
                 f"Request rejected: Content-Length {length} > MAX_UPLOAD_SIZE "
                 f"{_MAX_UPLOAD_SIZE} (path={request.url.path})"
             )
+            # i18n contract: server returns a stable machine-readable
+            # error_code plus the limit; clients localize the message.
+            # See INVESTIGATION_USER_CONSTRAINTS_2026-05-07.md "bio 413s
+            # return raw English from main.py".
             return _JR(
                 status_code=413,
                 content={
-                    "error_code": "PAYLOAD_TOO_LARGE",
-                    "message": (
-                        f"Request body exceeds maximum size of "
-                        f"{_MAX_UPLOAD_SIZE} bytes"
-                    ),
+                    "error_code": "FILE_TOO_LARGE",
+                    "max_size_bytes": _MAX_UPLOAD_SIZE,
                 },
             )
     return await call_next(request)

--- a/tests/integration/test_request_size_limit.py
+++ b/tests/integration/test_request_size_limit.py
@@ -60,11 +60,8 @@ def _build_app(max_upload_size: int, api_key: str = "test-key"):
                 return JSONResponse(
                     status_code=413,
                     content={
-                        "error_code": "PAYLOAD_TOO_LARGE",
-                        "message": (
-                            f"Request body exceeds maximum size of "
-                            f"{max_upload_size} bytes"
-                        ),
+                        "error_code": "FILE_TOO_LARGE",
+                        "max_size_bytes": max_upload_size,
                     },
                 )
         return await call_next(request)
@@ -90,8 +87,11 @@ class TestRequestSizeGuard:
 
         assert response.status_code == 413
         payload = response.json()
-        assert payload["error_code"] == "PAYLOAD_TOO_LARGE"
-        assert str(max_upload) in payload["message"]
+        # i18n contract: stable error_code + machine-readable size; no
+        # English message field. Frontend localizes.
+        assert payload["error_code"] == "FILE_TOO_LARGE"
+        assert payload["max_size_bytes"] == max_upload
+        assert "message" not in payload
 
     def test_size_guard_runs_before_api_key_auth(self):
         """413 must fire even without an API key (auth must NOT be reached)."""

--- a/tests/unit/application/test_use_cases.py
+++ b/tests/unit/application/test_use_cases.py
@@ -622,3 +622,184 @@ class TestCheckLivenessUseCase:
         # Verify liveness detector received the image
         call_args = mock_liveness_detector.check_liveness.call_args
         assert isinstance(call_args[0][0], np.ndarray)
+
+
+# ============================================================================
+# CheckLivenessUseCase — Verdict Policy Tests
+# ============================================================================
+#
+# Regression: INVESTIGATION_FAILOPEN_2026-05-07.md flagged that when UniFace's
+# liveness confidence was >= 0.85, DeepFace's "spoof" verdict was silently
+# ignored — a fail-open. The fix introduces LIVENESS_VERDICT_POLICY:
+#   - "conservative" (default): either backend voting spoof wins
+#   - "optimistic" (legacy): primary backend wins on high confidence,
+#                           contradiction is logged
+# ============================================================================
+
+
+class TestCheckLivenessVerdictPolicy:
+    """Verify the contradictory-vote scenario across both verdict policies.
+
+    Scenario: DeepFace says spoof with antispoof_score=0.95, primary backend
+    (UniFace) says is_live=True with confidence=0.92 (>= 0.85 veto threshold).
+    """
+
+    @staticmethod
+    def _spoof_detection():
+        from app.domain.entities.face_detection import FaceDetectionResult
+        return FaceDetectionResult(
+            found=True,
+            bounding_box=(50, 50, 100, 100),
+            landmarks=None,
+            confidence=0.95,
+            antispoof_score=0.95,
+            antispoof_label="spoof",
+        )
+
+    @staticmethod
+    def _live_high_confidence_result():
+        # UniFace says "live" with high confidence (>= 0.85)
+        return LivenessResult(
+            is_live=True,
+            score=92.0,
+            challenge="passive",
+            challenge_completed=True,
+            confidence=0.92,
+        )
+
+    @pytest.mark.asyncio
+    async def test_conservative_policy_either_vetoes_spoof(
+        self,
+        temp_image_file,
+    ):
+        """Conservative (default): DeepFace spoof + UniFace live -> spoof."""
+        from app.core.config import get_settings
+
+        settings = get_settings()
+        settings.ANTI_SPOOFING_ENABLED = True
+        settings.LIVENESS_VERDICT_POLICY = "conservative"
+
+        face_detector = Mock()
+        face_detector.detect = AsyncMock(return_value=self._spoof_detection())
+
+        liveness_detector = Mock()
+        liveness_detector.check_liveness = AsyncMock(
+            return_value=self._live_high_confidence_result()
+        )
+
+        use_case = CheckLivenessUseCase(
+            detector=face_detector,
+            liveness_detector=liveness_detector,
+        )
+
+        with patch("cv2.imread") as mock_imread:
+            mock_imread.return_value = np.random.randint(
+                0, 255, (200, 200, 3), dtype=np.uint8
+            )
+            result = await use_case.execute(image_path=temp_image_file)
+
+        # The conservative policy must override UniFace and reject as spoof.
+        assert result.is_live is False, (
+            "Conservative policy must let DeepFace veto when it says 'spoof', "
+            "even if UniFace confidence >= veto threshold."
+        )
+        assert result.details["deepface_veto_applied"] is True
+        assert result.details["verdict_policy"] == "conservative"
+        assert result.details["verdict_contradiction"] is True
+
+    @pytest.mark.asyncio
+    async def test_optimistic_policy_high_confidence_primary_wins_and_logs(
+        self,
+        temp_image_file,
+        caplog,
+    ):
+        """Optimistic: UniFace confidence >= 0.85 -> live, but warning logged."""
+        import logging
+
+        from app.core.config import get_settings
+
+        settings = get_settings()
+        settings.ANTI_SPOOFING_ENABLED = True
+        settings.LIVENESS_VERDICT_POLICY = "optimistic"
+
+        face_detector = Mock()
+        face_detector.detect = AsyncMock(return_value=self._spoof_detection())
+
+        liveness_detector = Mock()
+        liveness_detector.check_liveness = AsyncMock(
+            return_value=self._live_high_confidence_result()
+        )
+
+        use_case = CheckLivenessUseCase(
+            detector=face_detector,
+            liveness_detector=liveness_detector,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="app.application.use_cases.check_liveness"):
+            with patch("cv2.imread") as mock_imread:
+                mock_imread.return_value = np.random.randint(
+                    0, 255, (200, 200, 3), dtype=np.uint8
+                )
+                result = await use_case.execute(image_path=temp_image_file)
+
+        # Optimistic mode: primary backend (UniFace) wins on high confidence.
+        assert result.is_live is True, (
+            "Optimistic policy preserves legacy behavior: primary backend "
+            "wins when its confidence >= DEEPFACE_VETO_CONFIDENCE_THRESHOLD."
+        )
+        assert result.details["deepface_veto_applied"] is False
+        assert result.details["verdict_policy"] == "optimistic"
+        assert result.details["verdict_contradiction"] is True
+
+        # The contradiction MUST be logged as a warning even though we let
+        # the primary backend win.
+        contradiction_logs = [
+            r for r in caplog.records
+            if "liveness_verdict_contradiction" in r.getMessage()
+        ]
+        assert contradiction_logs, (
+            "Optimistic mode must log a warning when DeepFace and the "
+            "primary backend disagree, even when the primary backend wins."
+        )
+
+    @pytest.mark.asyncio
+    async def test_optimistic_policy_low_confidence_deepface_still_vetoes(
+        self,
+        temp_image_file,
+    ):
+        """Optimistic: when UniFace confidence < 0.85, DeepFace still vetoes."""
+        from app.core.config import get_settings
+
+        settings = get_settings()
+        settings.ANTI_SPOOFING_ENABLED = True
+        settings.LIVENESS_VERDICT_POLICY = "optimistic"
+
+        face_detector = Mock()
+        face_detector.detect = AsyncMock(return_value=self._spoof_detection())
+
+        # Low-confidence "live" verdict from primary backend.
+        low_conf_live = LivenessResult(
+            is_live=True,
+            score=70.0,
+            challenge="passive",
+            challenge_completed=True,
+            confidence=0.70,  # < 0.85
+        )
+        liveness_detector = Mock()
+        liveness_detector.check_liveness = AsyncMock(return_value=low_conf_live)
+
+        use_case = CheckLivenessUseCase(
+            detector=face_detector,
+            liveness_detector=liveness_detector,
+        )
+
+        with patch("cv2.imread") as mock_imread:
+            mock_imread.return_value = np.random.randint(
+                0, 255, (200, 200, 3), dtype=np.uint8
+            )
+            result = await use_case.execute(image_path=temp_image_file)
+
+        # Below the veto threshold, optimistic mode also rejects.
+        assert result.is_live is False
+        assert result.details["deepface_veto_applied"] is True
+        assert result.details["verdict_policy"] == "optimistic"


### PR DESCRIPTION
## Summary

Two narrowly-scoped fixes from `INVESTIGATION_MASTER_2026-05-07.md` (Team B / single-fix dispatch).

### 1. Liveness verdict-contradiction fail-open
`check_liveness.py` previously let the primary liveness backend (UniFace) silently win when its confidence was >= 0.85, even if DeepFace anti-spoof said `spoof` — a documented fail-open (`INVESTIGATION_FAILOPEN_2026-05-07.md`).

- New env var `LIVENESS_VERDICT_POLICY` (`conservative` | `optimistic`).
- Default is `conservative` = either backend voting `spoof` above its configured confidence wins.
- `optimistic` preserves legacy behavior; **contradictions are always logged at WARNING** so operators can see the disagreement even when the primary backend wins.
- The verdict policy and contradiction flag are surfaced in `liveness_result.details` for calibration logs.

### 2. Bio 413 i18n
`main.py` `request_size_guard` and `api/middleware/security.py` `RequestSizeLimitMiddleware` returned a verbose English `message`. Turkish-locale users saw English. Switched to a stable machine-readable contract:

```json
{ "error_code": "FILE_TOO_LARGE", "max_size_bytes": 10485760 }
```

No Turkish strings server-side (per project rule). Frontend localizes from the error_code.

## Policy decisions

- **Default policy = `conservative`** — secure-by-default. Operators who want the legacy permissive behavior must opt in via `LIVENESS_VERDICT_POLICY=optimistic`.
- **413 error_code = `FILE_TOO_LARGE`** (per dispatch spec). Existing `PAYLOAD_TOO_LARGE` shape was renamed in lockstep across both `main.py` and `RequestSizeLimitMiddleware` to keep the wire contract consistent. The integration test was updated to assert the new shape (and the absence of `message`).
- Aligned the parallel `RequestSizeLimitMiddleware` (currently unused but reachable via `security.py`) with the same shape — otherwise the two 413 paths would drift.

## Test plan

- [x] `pytest tests/unit/application/test_use_cases.py::TestCheckLivenessVerdictPolicy` — 3 new tests pass (conservative-vetoes, optimistic-honors-primary-and-logs, optimistic-still-vetoes-on-low-confidence)
- [x] `pytest tests/unit/application/test_use_cases.py::TestCheckLivenessUseCase` — 6 existing tests still pass
- [x] `pytest tests/integration/test_request_size_limit.py` — 12 tests pass (1 updated to new contract, 11 unchanged)
- [ ] Operator: set `LIVENESS_VERDICT_POLICY=conservative` (default) in prod `.env.prod` if explicit, or rely on default
- [ ] Operator: confirm frontend `formatApiError` recognizes `FILE_TOO_LARGE` and `PAYLOAD_TOO_LARGE` (transitional safety; this PR removed the legacy code from server)