### PR TITLE
fix(deploy): wire FIVUCSAS_EMBEDDING_KEY through to runtime container

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -76,6 +76,12 @@ services:
       JWT_ENABLED: "true"
       JWT_SECRET: ${JWT_SECRET}
 
+      # Fernet embedding encryption (P1.3 — 2026-05-02). Container fails fast
+      # if missing because the embedding repository unconditionally builds an
+      # EmbeddingCipher in its __init__.
+      FIVUCSAS_EMBEDDING_KEY: ${FIVUCSAS_EMBEDDING_KEY}
+      FIVUCSAS_EMBEDDING_KEY_VERSION: ${FIVUCSAS_EMBEDDING_KEY_VERSION}
+
       # Rate Limiting
       RATE_LIMIT_ENABLED: true
       RATE_LIMIT_STORAGE: memory


### PR DESCRIPTION
## Summary
- PR #73 (2026-05-07) made `EmbeddingCipher.from_env()` unconditional in `PgVectorEmbeddingRepository.__init__`, so the bio container now fails fast on boot if the Fernet key is not in the runtime environment.
- The compose file was substituting other secrets (POSTGRES, REDIS, JWT, API_KEY) but had no entry for `FIVUCSAS_EMBEDDING_KEY`, so `.env.prod`'s value was only visible during compose-time variable substitution, not inside the container.
- Surfaced after a fresh `--no-cache` rebuild on 2026-05-08 — the previously running image was carrying the env from a pre-rebuild state that was not committed to git.

## Test plan
- [x] Rebuild + recreate bio container on Hetzner — boots healthy
- [x] `docker exec biometric-api env | grep FIVUCSAS_EMBEDDING_KEY` confirms the key is visible inside the container
- [x] Both `identity-core-api` and `biometric-api` healthchecks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)