### PR TITLE
feat(antispoof): flash-challenge public route (Aysenur 2/5)

### DIFF
--- a/app/api/routes/flash_challenge.py
+++ b/app/api/routes/flash_challenge.py
@@ -1,0 +1,109 @@
+"""Flash / colour-light liveness challenge route.
+
+Public, stateless wrapper around `LightChallengeService` that lets a client
+(web/mobile) request a challenge colour, then submit a frame captured during
+the on-screen flash for verification. The handler is intentionally
+thin — the underlying service is already production-grade and consumed by
+`active_liveness_manager` and `device_spoof_risk_evaluator`.
+
+Endpoints:
+    POST /flash-challenge/start    — issue a fresh challenge
+    POST /flash-challenge/respond  — verify a captured frame against challenge
+
+This route is **not** enabled by default; the FLASH_CHALLENGE_ROUTE_ENABLED
+flag in settings gates registration so prod stays unchanged until an operator
+opts in.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from typing import List, Optional
+
+import cv2
+import numpy as np
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from app.application.services.light_challenge_service import LightChallengeService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Liveness"], prefix="/liveness")
+
+# Single shared service; stateless aside from RNG / config.
+_service = LightChallengeService()
+
+
+class FlashChallengeStartResponse(BaseModel):
+    color: str = Field(..., description="Colour the client must flash on the screen")
+    available_colors: List[str]
+    issued_at: float
+    expires_at: float
+    duration_ms: int
+    expected_response_window_ms: int
+    minimum_delay_ms: int
+    baseline_required: bool
+    ready_for_flash: bool
+
+
+class FlashChallengeRespondRequest(BaseModel):
+    expected_color: str = Field(..., description="Colour returned by /start")
+    flash_timestamp: float = Field(..., description="Unix epoch when the flash was rendered")
+    frame_timestamp: Optional[float] = Field(
+        None,
+        description="Unix epoch when the frame was captured; defaults to server time if omitted",
+    )
+    frame_base64: str = Field(..., description="Base64-encoded JPEG/PNG frame captured during flash")
+    baseline_bgr: Optional[List[float]] = Field(
+        None,
+        description="Optional pre-flash baseline BGR mean (length 3); strengthens detection",
+    )
+
+
+class FlashChallengeRespondResponse(BaseModel):
+    passed: bool
+    reason: Optional[str] = None
+    color_shift: Optional[float] = None
+    delay_seconds: Optional[float] = None
+    face_mean_bgr: Optional[List[float]] = None
+
+
+@router.post("/flash-challenge/start", response_model=FlashChallengeStartResponse)
+async def start_flash_challenge() -> FlashChallengeStartResponse:
+    """Issue a fresh flash-colour challenge."""
+    challenge = _service.generate_challenge()
+    return FlashChallengeStartResponse(**challenge)
+
+
+@router.post("/flash-challenge/respond", response_model=FlashChallengeRespondResponse)
+async def respond_flash_challenge(payload: FlashChallengeRespondRequest) -> FlashChallengeRespondResponse:
+    """Verify a captured frame against a previously issued challenge."""
+    if payload.expected_color not in _service._colors:  # noqa: SLF001
+        raise HTTPException(status_code=400, detail="unsupported_color")
+
+    try:
+        frame_bytes = base64.b64decode(payload.frame_base64, validate=True)
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=400, detail="invalid_base64") from exc
+
+    if not frame_bytes:
+        raise HTTPException(status_code=400, detail="empty_frame")
+
+    nparr = np.frombuffer(frame_bytes, np.uint8)
+    frame = cv2.imdecode(nparr, cv2.IMREAD_COLOR)
+    if frame is None or frame.size == 0:
+        raise HTTPException(status_code=400, detail="undecodable_frame")
+
+    if payload.baseline_bgr is not None and len(payload.baseline_bgr) != 3:
+        raise HTTPException(status_code=400, detail="baseline_bgr_must_be_length_3")
+
+    result = _service.verify_response(
+        frame=frame,
+        expected_color=payload.expected_color,
+        flash_timestamp=payload.flash_timestamp,
+        frame_timestamp=payload.frame_timestamp,
+        baseline_bgr=payload.baseline_bgr,
+    )
+    return FlashChallengeRespondResponse(**result)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -638,6 +638,13 @@ class Settings(BaseSettings):
             "OFF until the gesture backend ships."
         ),
     )
+    FLASH_CHALLENGE_ROUTE_ENABLED: bool = Field(
+        default=False,
+        description=(
+            "Feature flag for the public /liveness/flash-challenge route. "
+            "OFF by default; enable per-tenant during integration."
+        ),
+    )
     GESTURE_HAND_LANDMARKER_MODEL_PATH: str = Field(
         default=str(_REPO_ROOT / "models" / "hand_landmarker.task"),
         description=(

--- a/app/main.py
+++ b/app/main.py
@@ -39,6 +39,7 @@ from app.api.routes import admin
 from app.api.routes import live_analysis
 from app.api.routes import voice
 from app.api.routes import puzzle
+from app.api.routes import flash_challenge
 from app.core.config import settings
 from app.core.container import initialize_dependencies, shutdown_dependencies
 from app.core.gpu import configure_gpu
@@ -350,6 +351,13 @@ app.include_router(admin.router, prefix=API_PREFIX)
 # was never a real biometric. Platform fingerprint authentication is delivered
 # via WebAuthn (FIDO2) in identity-core-api, which is unrelated to this service.
 app.include_router(voice.router, prefix=API_PREFIX)
+
+# Flash / colour-light liveness challenge route (PR 2/5 of Aysenur cherry-pick).
+# Gated behind FLASH_CHALLENGE_ROUTE_ENABLED so prod stays unchanged until an
+# operator opts in. Underlying LightChallengeService is already battle-tested
+# and consumed by active_liveness_manager + device_spoof_risk_evaluator.
+if settings.FLASH_CHALLENGE_ROUTE_ENABLED:
+    app.include_router(flash_challenge.router, prefix=API_PREFIX)
 
 # ============================================================================
 # Frontend Static File Service

--- a/tests/integration/test_flash_challenge_route.py
+++ b/tests/integration/test_flash_challenge_route.py
@@ -1,0 +1,153 @@
+"""Integration tests for the /liveness/flash-challenge route (PR 2/5)."""
+
+from __future__ import annotations
+
+import base64
+import sys
+from unittest.mock import Mock, patch
+
+import cv2
+import numpy as np
+import pytest
+
+# Mock DeepFace before any imports that depend on it
+sys.modules.setdefault("deepface", Mock())
+sys.modules.setdefault("deepface.DeepFace", Mock())
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.routes.flash_challenge import router as flash_router
+
+
+@pytest.fixture
+def client_with_flag_on() -> TestClient:
+    """Build a minimal FastAPI app that includes only the flash-challenge router.
+
+    We don't import app.main because the global app object's router list
+    depends on whether FLASH_CHALLENGE_ROUTE_ENABLED was true at import time;
+    the route is gated behind that flag in main.py.
+    """
+    app = FastAPI()
+    app.include_router(flash_router, prefix="/api/v1")
+    return TestClient(app)
+
+
+def _encode_solid_bgr(b: int, g: int, r: int, size: int = 32) -> str:
+    """Encode a solid-colour BGR JPEG as base64."""
+    frame = np.full((size, size, 3), (b, g, r), dtype=np.uint8)
+    ok, buf = cv2.imencode(".jpg", frame)
+    assert ok
+    return base64.b64encode(buf.tobytes()).decode("ascii")
+
+
+def test_start_returns_a_challenge(client_with_flag_on: TestClient) -> None:
+    response = client_with_flag_on.post("/api/v1/liveness/flash-challenge/start")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["color"] in {"red", "green", "blue", "white", "yellow"}
+    assert body["duration_ms"] == 150
+    assert body["expected_response_window_ms"] == 500
+    assert body["expires_at"] > body["issued_at"]
+    assert body["baseline_required"] is True
+
+
+def test_respond_happy_path_red(client_with_flag_on: TestClient) -> None:
+    """A reddish frame within the response window passes for expected_color=red."""
+    # JPEG encoding can drift colour slightly; use a strongly red frame.
+    frame_b64 = _encode_solid_bgr(b=40, g=40, r=200)
+    payload = {
+        "expected_color": "red",
+        "flash_timestamp": 1000.0,
+        "frame_timestamp": 1000.20,
+        "frame_base64": frame_b64,
+        "baseline_bgr": [40.0, 40.0, 40.0],
+    }
+    response = client_with_flag_on.post(
+        "/api/v1/liveness/flash-challenge/respond", json=payload
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["passed"] is True
+    assert body["color_shift"] is not None and body["color_shift"] > 0
+
+
+def test_respond_rejects_timing_mismatch(client_with_flag_on: TestClient) -> None:
+    """Frame captured before the minimum delay fails."""
+    frame_b64 = _encode_solid_bgr(b=40, g=40, r=200)
+    payload = {
+        "expected_color": "red",
+        "flash_timestamp": 1000.0,
+        "frame_timestamp": 1000.001,  # 1 ms — below 50 ms minimum
+        "frame_base64": frame_b64,
+        "baseline_bgr": [40.0, 40.0, 40.0],
+    }
+    response = client_with_flag_on.post(
+        "/api/v1/liveness/flash-challenge/respond", json=payload
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["passed"] is False
+    assert body["reason"] == "timing_mismatch"
+
+
+def test_respond_rejects_invalid_base64(client_with_flag_on: TestClient) -> None:
+    payload = {
+        "expected_color": "red",
+        "flash_timestamp": 1000.0,
+        "frame_timestamp": 1000.20,
+        "frame_base64": "not!!base64!!",
+        "baseline_bgr": [40.0, 40.0, 40.0],
+    }
+    response = client_with_flag_on.post(
+        "/api/v1/liveness/flash-challenge/respond", json=payload
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "invalid_base64"
+
+
+def test_respond_rejects_undecodable_frame(client_with_flag_on: TestClient) -> None:
+    payload = {
+        "expected_color": "red",
+        "flash_timestamp": 1000.0,
+        "frame_timestamp": 1000.20,
+        # valid base64 but not an image
+        "frame_base64": base64.b64encode(b"hello world").decode("ascii"),
+        "baseline_bgr": [40.0, 40.0, 40.0],
+    }
+    response = client_with_flag_on.post(
+        "/api/v1/liveness/flash-challenge/respond", json=payload
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "undecodable_frame"
+
+
+def test_respond_rejects_unsupported_color(client_with_flag_on: TestClient) -> None:
+    frame_b64 = _encode_solid_bgr(b=40, g=40, r=200)
+    payload = {
+        "expected_color": "magenta",
+        "flash_timestamp": 1000.0,
+        "frame_timestamp": 1000.20,
+        "frame_base64": frame_b64,
+    }
+    response = client_with_flag_on.post(
+        "/api/v1/liveness/flash-challenge/respond", json=payload
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "unsupported_color"
+
+
+def test_respond_rejects_bad_baseline_length(client_with_flag_on: TestClient) -> None:
+    frame_b64 = _encode_solid_bgr(b=40, g=40, r=200)
+    payload = {
+        "expected_color": "red",
+        "flash_timestamp": 1000.0,
+        "frame_timestamp": 1000.20,
+        "frame_base64": frame_b64,
+        "baseline_bgr": [40.0, 40.0],
+    }
+    response = client_with_flag_on.post(
+        "/api/v1/liveness/flash-challenge/respond", json=payload
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "baseline_bgr_must_be_length_3"


### PR DESCRIPTION
Cherry-pick 2/5 from Aysenur's working_spoof_detection — `flash-challenge route`.

## What does this give you?
A public HTTP surface for colour-flash active liveness. The web/mobile widget can now hit `POST /api/v1/liveness/flash-challenge/start` to receive a colour ("turn the screen red for 150 ms"), then `POST /respond` with a base64 frame captured during the flash. Server returns `passed: true/false` plus diagnostics (`color_shift`, `delay_seconds`). Underlying `LightChallengeService` was already in `main` (135 LoC) and consumed by `active_liveness_manager` + `device_spoof_risk_evaluator` — this PR only adds the HTTP veneer.

**Default OFF**: route only registers when `FLASH_CHALLENGE_ROUTE_ENABLED=true`. Prod is unchanged until an operator flips the flag.

## Source
- Branch: `origin/working_spoof_detection`
- Tip: `cbdbe0b`
- Files: `app/application/services/light_challenge_service.py` (already in main), `tests/unit/application/test_light_challenge_service.py` (cherry-picked here)

## What's added
- `app/api/routes/flash_challenge.py` (thin route, ~115 LoC) — **new in this PR**, not in upstream branch (Aysenur didn't author a route)
- `app/core/config.py` — `FLASH_CHALLENGE_ROUTE_ENABLED` flag, default false
- `app/main.py` — gated `include_router`
- `tests/unit/application/test_light_challenge_service.py` — cherry-picked from Aysenur's branch (6 tests)
- `tests/integration/test_flash_challenge_route.py` — **new** route-level tests (7 tests)

## What's deferred (intentional)
- No persistence of issued challenges (server is stateless; client passes the colour back) — keeps the route trivially horizontally scalable. If we later need anti-replay we'd add a one-shot signed-token wrapper, but that's a separate PR.
- No automatic activation — operator must set the env var.

## Test strategy
`pytest tests/integration/test_flash_challenge_route.py tests/unit/application/test_light_challenge_service.py` → **13 passed, 0 failed**. Tests cover happy path (red), timing-mismatch rejection, invalid base64, undecodable frame, unsupported colour, malformed baseline.

## No security regressions
- `requirements.txt` **not touched**
- No existing tests deleted
- No binaries
- New deps: none (`cv2`, `numpy`, `fastapi`, `pydantic` already present)

## PR chain
PR **2 of 5**. Independent of PR 1; safe to merge in either order. Suggested order: 1 → 2 → 3 → 4 → 5.

cc @Aysenur15 — the route is new code I authored on top of your service. Please flag if the contract differs from how the web widget already speaks to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)