### PR TITLE
feat(antispoof): hybrid fusion evaluator (Aysenur 3/5)

### DIFF
--- a/app/application/services/hybrid_fusion_evaluator.py
+++ b/app/application/services/hybrid_fusion_evaluator.py
@@ -1,0 +1,190 @@
+"""Hybrid fusion evaluator for liveness and spoof signals."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class FusionWeights:
+    """Weights for combining model and heuristic spoof signals."""
+
+    pretrained_model: float = 0.30
+    flash_response: float = 0.30
+    moire_pattern: float = 0.20
+    device_replay: float = 0.20
+
+    def __post_init__(self) -> None:
+        total = sum(
+            (
+                self.pretrained_model,
+                self.flash_response,
+                self.moire_pattern,
+                self.device_replay,
+            )
+        )
+        if not np.isclose(total, 1.0):
+            raise ValueError(f"Weights must sum to 1.0, got {total}")
+
+
+@dataclass(frozen=True)
+class FusionResult:
+    """Hybrid fusion decision output."""
+
+    is_spoof: bool
+    confidence: float
+    spoof_score: float
+    breakdown: dict[str, float]
+    reasoning: str
+
+
+class HybridFusionEvaluator:
+    """Fuse pretrained liveness output with replay- and physiology-based signals."""
+
+    def __init__(self, weights: Optional[FusionWeights] = None, threshold: float = 0.45) -> None:
+        self.weights = weights or FusionWeights()
+        self.threshold = float(threshold)
+
+    def evaluate(
+        self,
+        pretrained_spoof_score: float,
+        custom_signals: dict[str, Any],
+    ) -> FusionResult:
+        """Combine all signals into a final spoof decision."""
+        pretrained_score = self._clamp01(pretrained_spoof_score)
+        flicker_score = self._resolve_numeric_signal(
+            custom_signals.get("flicker_score"),
+            neutral=0.0,
+        )
+        device_replay_score = self._resolve_numeric_signal(
+            custom_signals.get("device_replay_score"),
+            neutral=0.0,
+        )
+        if flicker_score > 0.85 or (flicker_score > 0.75 and device_replay_score > 0.55):
+            reasoning = (
+                f"High flicker ({flicker_score:.2f}) + device replay ({device_replay_score:.2f})"
+                if flicker_score <= 0.85
+                else f"Very high flicker detected ({flicker_score:.2f})"
+            )
+            return FusionResult(
+                is_spoof=True,
+                confidence=0.90,
+                spoof_score=0.90,
+                breakdown={
+                    "pretrained": pretrained_score,
+                    "flicker": flicker_score,
+                    "device_replay": device_replay_score,
+                    **custom_signals,
+                },
+                reasoning=reasoning,
+            )
+
+        signal_scores = self._compute_signal_scores(custom_signals)
+        final_spoof_score = self._clamp01(
+            self.weights.pretrained_model * pretrained_score
+            + self.weights.flash_response * signal_scores["flash"]
+            + self.weights.moire_pattern * signal_scores["moire"]
+            + self.weights.device_replay * signal_scores["device"]
+        )
+        is_spoof = final_spoof_score > self.threshold
+        confidence = self._decision_confidence(final_spoof_score)
+        breakdown = {
+            "pretrained": pretrained_score,
+            **signal_scores,
+        }
+        reasoning = self._generate_reasoning(
+            is_spoof=is_spoof,
+            score=final_spoof_score,
+            breakdown=breakdown,
+        )
+        return FusionResult(
+            is_spoof=is_spoof,
+            confidence=confidence,
+            spoof_score=final_spoof_score,
+            breakdown=breakdown,
+            reasoning=reasoning,
+        )
+
+    def _compute_signal_scores(self, signals: dict[str, Any]) -> dict[str, float]:
+        flash_score = self._resolve_flash_score(signals)
+        moire_score = self._resolve_numeric_signal(
+            signals.get("moire_score", signals.get("moire_risk")),
+            neutral=0.5,
+        )
+        device_score = self._resolve_numeric_signal(
+            signals.get("device_replay_score", signals.get("device_replay_risk")),
+            neutral=0.5,
+        )
+        return {
+            "flash": flash_score,
+            "moire": moire_score,
+            "device": device_score,
+        }
+
+    def _resolve_flash_score(self, signals: dict[str, Any]) -> float:
+        flash_samples = self._coerce_float(
+            signals.get("flash_response_samples", signals.get("flash_response_sample_count"))
+        )
+        if flash_samples is not None and flash_samples < 1.0:
+            return 0.5
+
+        flash_response_score = self._coerce_float(signals.get("flash_response_score"))
+        if flash_response_score is not None:
+            return self._clamp01(1.0 - flash_response_score)
+
+        flash_response = self._coerce_float(signals.get("flash_response"))
+        if flash_response is None:
+            return 0.5
+        return self._normalize_flash_score(flash_response)
+
+    def _resolve_numeric_signal(self, value: Any, *, neutral: float) -> float:
+        numeric = self._coerce_float(value)
+        if numeric is None:
+            return neutral
+        return self._clamp01(numeric)
+
+    def _normalize_flash_score(self, flash_response: float) -> float:
+        if flash_response >= 0.15:
+            return 0.0
+        if flash_response <= 0.02:
+            return 1.0
+        return self._clamp01(1.0 - (flash_response - 0.02) / (0.15 - 0.02))
+
+    def _generate_reasoning(
+        self,
+        *,
+        is_spoof: bool,
+        score: float,
+        breakdown: dict[str, float],
+    ) -> str:
+        top_signal = max(breakdown.items(), key=lambda item: item[1])
+        if is_spoof:
+            return (
+                f"SPOOF detected (score={score:.2f}). "
+                f"Primary indicator: {top_signal[0]} ({top_signal[1]:.2f})"
+            )
+        return (
+            f"LIVE verified (score={score:.2f}). "
+            f"Strongest remaining spoof cue: {top_signal[0]} ({top_signal[1]:.2f})"
+        )
+
+    def _decision_confidence(self, spoof_score: float) -> float:
+        decision_margin = abs(spoof_score - self.threshold)
+        max_margin = max(self.threshold, 1.0 - self.threshold, 1e-6)
+        return self._clamp01(decision_margin / max_margin)
+
+    @staticmethod
+    def _coerce_float(value: Any) -> Optional[float]:
+        if value is None or isinstance(value, bool):
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _clamp01(value: float) -> float:
+        return max(0.0, min(1.0, float(value)))

--- a/tests/unit/application/test_hybrid_fusion_evaluator.py
+++ b/tests/unit/application/test_hybrid_fusion_evaluator.py
@@ -1,0 +1,254 @@
+"""Unit tests for hybrid liveness fusion (PR 3/5 of Aysenur cherry-pick).
+
+The downstream `LiveCameraAnalysisUseCase` integration test from Aysenur's
+branch is intentionally **deferred to PR 4/5** of this cherry-pick chain —
+it depends on `LiveCameraAnalysisUseCase.__init__` accepting `settings` and
+`hybrid_fusion_evaluator` kwargs, which are part of the wiring PRs.
+"""
+
+import pytest
+
+from app.application.services.hybrid_fusion_evaluator import (
+    HybridFusionEvaluator,
+    FusionWeights,
+)
+
+
+def test_hybrid_fusion_evaluator_detects_clear_spoof_case() -> None:
+    evaluator = HybridFusionEvaluator()
+
+    result = evaluator.evaluate(
+        pretrained_spoof_score=0.95,
+        custom_signals={
+            "flash_response_score": 0.0,
+            "flash_response_samples": 2,
+            "rppg_live_signal": False,
+            "rppg_available": True,
+            "moire_score": 0.9,
+            "device_replay_score": 0.8,
+        },
+    )
+
+    assert result.is_spoof is True
+    assert result.spoof_score > 0.8
+    assert "SPOOF detected" in result.reasoning
+
+
+def test_hybrid_fusion_evaluator_detects_clear_live_case() -> None:
+    evaluator = HybridFusionEvaluator()
+
+    result = evaluator.evaluate(
+        pretrained_spoof_score=0.05,
+        custom_signals={
+            "flash_response_score": 0.95,
+            "flash_response_samples": 2,
+            "rppg_live_signal": True,
+            "rppg_available": True,
+            "moire_score": 0.1,
+            "device_replay_score": 0.15,
+        },
+    )
+
+    assert result.is_spoof is False
+    assert result.spoof_score < 0.3
+    assert "LIVE verified" in result.reasoning
+
+
+def test_hybrid_fusion_evaluator_flicker_override_forces_spoof() -> None:
+    evaluator = HybridFusionEvaluator()
+
+    result = evaluator.evaluate(
+        pretrained_spoof_score=0.05,
+        custom_signals={
+            "flicker_score": 0.91,
+            "flash_response_score": 0.95,
+            "flash_response_samples": 2,
+            "moire_score": 0.05,
+            "device_replay_score": 0.10,
+        },
+    )
+
+    assert result.is_spoof is True
+    assert result.spoof_score == pytest.approx(0.90)
+    assert result.confidence == pytest.approx(0.90)
+    assert result.breakdown["flicker"] == pytest.approx(0.91)
+    assert result.reasoning == "Very high flicker detected (0.91)"
+
+
+def test_hybrid_fusion_evaluator_flicker_below_override_uses_normal_fusion() -> None:
+    evaluator = HybridFusionEvaluator()
+
+    result = evaluator.evaluate(
+        pretrained_spoof_score=0.05,
+        custom_signals={
+            "flicker_score": 0.65,
+            "flash_response_score": 0.95,
+            "flash_response_samples": 2,
+            "moire_score": 0.10,
+            "device_replay_score": 0.15,
+        },
+    )
+
+    assert result.is_spoof is False
+    assert result.spoof_score < 0.30
+    assert "LIVE verified" in result.reasoning
+
+
+def test_hybrid_fusion_evaluator_weak_minifasnet_neutral_signals_remains_consistent() -> None:
+    """Edge case: weak MiniFASNet (0.65) with neutral/missing custom signals.
+
+    With the current 4-weight scheme (0.30/0.30/0.20/0.20) the fused score
+    sits very close to the default threshold (0.5). This test pins the
+    *behaviour* — that the evaluator returns a consistent verdict and a
+    bounded score in the uncertainty zone — rather than a specific decimal,
+    so it survives weight tuning.
+    """
+    evaluator = HybridFusionEvaluator()
+
+    result = evaluator.evaluate(
+        pretrained_spoof_score=0.65,
+        custom_signals={
+            "flash_response_samples": 0,
+            "flash_response_score": None,
+            "rppg_available": False,
+            "rppg_live_signal": None,
+            "moire_score": 0.30,
+            "device_replay_score": 0.25,
+        },
+    )
+
+    # Score should be in the uncertainty band, not extreme either way.
+    assert 0.30 < result.spoof_score < 0.55
+    # Whatever the verdict, the reasoning string must be coherent.
+    assert "score=" in result.reasoning
+
+
+def test_hybrid_fusion_evaluator_threshold_boundary_low_side_is_live() -> None:
+    """Mixed-but-mostly-live signals stay below threshold and report LIVE."""
+    evaluator = HybridFusionEvaluator(threshold=0.55)
+
+    result = evaluator.evaluate(
+        pretrained_spoof_score=0.40,
+        custom_signals={
+            "flash_response_score": 0.70,
+            "flash_response_samples": 2,
+            "rppg_live_signal": True,
+            "rppg_available": True,
+            "moire_score": 0.30,
+            "device_replay_score": 0.30,
+        },
+    )
+
+    assert result.is_spoof is False
+    assert result.spoof_score < 0.55
+    assert "LIVE" in result.reasoning
+
+
+def test_hybrid_fusion_evaluator_threshold_boundary_high_side_is_spoof() -> None:
+    """Multiple spoof indicators above threshold trigger SPOOF verdict."""
+    evaluator = HybridFusionEvaluator(threshold=0.55)
+
+    result = evaluator.evaluate(
+        pretrained_spoof_score=0.70,
+        custom_signals={
+            "flash_response_score": 0.20,
+            "flash_response_samples": 2,
+            "rppg_live_signal": False,
+            "rppg_available": True,
+            "moire_score": 0.70,
+            "device_replay_score": 0.65,
+        },
+    )
+
+    assert result.is_spoof is True
+    assert result.spoof_score >= 0.55
+    assert "SPOOF detected" in result.reasoning
+
+
+def test_hybrid_fusion_evaluator_spoof_with_one_strong_live_signal() -> None:
+    """Adversarial case: Spoof attack with one strong contradictory signal.
+
+    If a spoof video manages to trigger a false rPPG signal, fusion should
+    still catch it via other indicators.
+    """
+    evaluator = HybridFusionEvaluator()
+
+    result = evaluator.evaluate(
+        pretrained_spoof_score=0.90,  # Clear spoof signature
+        custom_signals={
+            "flash_response_score": 0.05,  # No flash response
+            "flash_response_samples": 2,
+            "rppg_live_signal": True,  # FALSE POSITIVE from rPPG (video artifact)
+            "rppg_available": True,
+            "moire_score": 0.88,  # Clear moire from screen
+            "device_replay_score": 0.85,  # Clear replay from screen
+        },
+    )
+
+    # Multiple strong spoof indicators should overcome single rPPG false positive
+    assert result.is_spoof is True, (
+        f"Should detect spoof despite rPPG false positive. "
+        f"Score: {result.spoof_score:.3f}"
+    )
+    assert result.spoof_score > 0.65
+
+
+def test_hybrid_fusion_evaluator_missing_all_custom_signals() -> None:
+    """Fallback case: What if all custom signals are unavailable?
+
+    Should fall back to MiniFASNet with neutral padding.
+    """
+    evaluator = HybridFusionEvaluator()
+
+    result = evaluator.evaluate(
+        pretrained_spoof_score=0.80,  # Strong spoof from MiniFASNet
+        custom_signals={
+            # Everything missing/null
+            "flash_response_score": None,
+            "flash_response_samples": None,
+            "rppg_available": False,
+            "rppg_live_signal": None,
+            "moire_score": None,
+            "device_replay_score": None,
+        },
+    )
+
+    # With all custom signals neutral (0.5), should still detect spoof from MiniFASNet
+    # Score = 0.25*0.80 + 0.75*0.5 = 0.20 + 0.375 = 0.575 > 0.55
+    assert result.is_spoof is True
+    assert result.spoof_score > 0.55
+    assert "backend_score" in result.breakdown or "pretrained" in result.breakdown
+
+
+def test_hybrid_fusion_evaluator_weights_normalize_correctly() -> None:
+    """Verify that FusionWeights properly normalize."""
+    weights = FusionWeights(
+        pretrained_model=0.30,
+        flash_response=0.30,
+        moire_pattern=0.20,
+        device_replay=0.20,
+    )
+
+    assert abs(sum([
+        weights.pretrained_model,
+        weights.flash_response,
+        weights.moire_pattern,
+        weights.device_replay,
+    ]) - 1.0) < 1e-6
+
+
+def test_hybrid_fusion_evaluator_invalid_weights_raise() -> None:
+    """Verify that invalid weights are caught."""
+    with pytest.raises(ValueError, match="Weights must sum to 1.0"):
+        FusionWeights(
+            pretrained_model=0.5,  # Sum will be > 1.0
+            flash_response=0.5,
+            moire_pattern=0.1,
+            device_replay=0.1,
+        )
+
+
+# NOTE: Aysenur's branch also asserted that LiveCameraAnalysisUseCase wires the
+# hybrid evaluator behind LIVENESS_FUSION_ENABLED. That integration test is
+# intentionally deferred to PRs 4 and 5 of this cherry-pick chain (which add
+# the wiring + the env-flag gate). See the PR description.


### PR DESCRIPTION
Cherry-pick 3/5 from Aysenur's working_spoof_detection — `hybrid fusion evaluator`.

## What does this give you?
A pure service class (`HybridFusionEvaluator`) that combines MiniFASNet's per-frame liveness probability with three heuristic spoof signals — flash response, moire pattern, device replay — using a 4-way weighted fusion (default `0.30 / 0.30 / 0.20 / 0.20`). Two hard-veto rules can override the weighted sum: `flicker > 0.85` alone, or `flicker > 0.75 AND device_replay > 0.55` together. Returns a `FusionResult` with `is_spoof`, `spoof_score`, `confidence`, per-signal `breakdown`, and a human-readable `reasoning`. **No wiring in this PR** — that's PR 4 (device-risk wiring) and PR 5 (full pipeline assembly).

## Source
- Branch: `origin/working_spoof_detection`
- Tip: `cbdbe0b`
- File: `app/application/services/hybrid_fusion_evaluator.py` (190 LoC)
- Test: `tests/unit/application/test_hybrid_fusion_evaluator.py` (cherry-picked + adapted)

## What's added
- `app/application/services/hybrid_fusion_evaluator.py` — verbatim from upstream tip
- `tests/unit/application/test_hybrid_fusion_evaluator.py` — cherry-picked, with 4 calibration tests rewritten to match the actual 4-weight scheme on the upstream tip (Aysenur's test file was authored against an earlier 5-weight draft of the source — her source tip has since been simplified to 4 weights). Behavioural assertions are preserved; brittle decimal-score asserts replaced with band-checks.

## What's deferred (intentional)
- The `test_live_camera_analysis_applies_hybrid_fusion_when_enabled` integration test from Aysenur's branch is **deferred to PR 4/5**: it requires `LiveCameraAnalysisUseCase.__init__` to accept `settings` and `hybrid_fusion_evaluator` kwargs, which is wiring code that lands in PR 4 (device-risk wiring) and PR 5 (full pipeline assembly). The deletion is annotated in the test file.
- No env flag in this PR — the service is purely importable and is gated by the consumer in PR 5.

## Test strategy
`pytest tests/unit/application/test_hybrid_fusion_evaluator.py` → **11 passed, 0 failed**.

Coverage: clear-spoof, clear-live, flicker hard-veto override, flicker below override, weak-MiniFASNet uncertainty band, threshold low-side LIVE, threshold high-side SPOOF, adversarial single-strong-live-signal, all-signals-missing fallback, weight validation (sums to 1.0), weight ValueError on bad inputs.

## No security regressions
- `requirements.txt` **not touched**
- No existing tests deleted
- No binaries

## PR chain
PR **3 of 5**. Independent of PR 1 and PR 2 (no shared code); merge order doesn't matter for these three. **Required by PR 5** which assembles this service into the `/verify` adapter behind a feature flag.

cc @Aysenur15 — I had to retune four of your calibration tests because the source tip on `working_spoof_detection` uses 4 weights but your test file still expected the 5-weight version. The behavioural assertions are preserved. If you intended the 5-weight scheme to ship instead, please flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)