### PR TITLE
feat(antispoof): wire device-spoof risk evaluator into /verify (Aysenur 4/5)

### DIFF
--- a/app/api/routes/verification.py
+++ b/app/api/routes/verification.py
@@ -6,6 +6,9 @@ from typing import Optional
 from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Request, UploadFile
 
 from app.api.schemas.verification import VerificationResponse
+from app.application.services.device_spoof_risk_evaluator import (
+    DeviceSpoofRiskEvaluator,
+)
 from app.application.use_cases.check_liveness import CheckLivenessUseCase
 from app.application.use_cases.verify_face import VerifyFaceUseCase
 from app.core.container import (
@@ -27,6 +30,37 @@ settings = get_settings()
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Verification"])
+
+# Lazy-init singleton — DeviceSpoofRiskEvaluator constructs cv2 detectors at
+# import time, so we delay instantiation until the flag is first observed true.
+_device_spoof_risk_evaluator: Optional[DeviceSpoofRiskEvaluator] = None
+
+
+def _get_device_spoof_risk_evaluator() -> DeviceSpoofRiskEvaluator:
+    global _device_spoof_risk_evaluator
+    if _device_spoof_risk_evaluator is None:
+        _device_spoof_risk_evaluator = DeviceSpoofRiskEvaluator()
+    return _device_spoof_risk_evaluator
+
+
+def _evaluate_device_spoof_risk_safe(image_path: str) -> Optional[dict]:
+    """Run the device-spoof risk evaluator on an on-disk image.
+
+    Failures here MUST NOT break verification — the call is wrapped in a
+    broad except and any exception returns None so the response can still
+    return its primary verdict.
+    """
+    try:
+        import cv2  # local to avoid hard import at module load
+        frame_bgr = cv2.imread(image_path)
+        if frame_bgr is None or frame_bgr.size == 0:
+            return None
+        evaluator = _get_device_spoof_risk_evaluator()
+        assessment = evaluator.evaluate(frame_bgr=frame_bgr)
+        return assessment.to_dict()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("device_spoof_risk evaluation failed: %s", exc)
+        return None
 
 
 @router.post("/verify", response_model=VerificationResponse, status_code=200)
@@ -139,12 +173,21 @@ async def verify_face(
 
         message = "Face verified successfully" if result.verified else "Face does not match"
 
+        # PR 4/5 Aysenur cherry-pick: optionally attach device-spoof risk
+        # signal. Default OFF (ANTISPOOF_DEVICE_RISK_ENABLED=false) so prod
+        # behaviour is unchanged until an operator opts in. Failures are
+        # swallowed inside the helper — they never block verification.
+        device_spoof_risk: Optional[dict] = None
+        if settings.ANTISPOOF_DEVICE_RISK_ENABLED:
+            device_spoof_risk = _evaluate_device_spoof_risk_safe(image_path)
+
         response = VerificationResponse(
             verified=result.verified,
             confidence=result.confidence,
             distance=result.distance,
             threshold=result.threshold,
             message=message,
+            device_spoof_risk=device_spoof_risk,
         )
 
         # D1 log-only: persist client pre-filter embedding for offline analysis.

--- a/app/api/schemas/verification.py
+++ b/app/api/schemas/verification.py
@@ -1,5 +1,7 @@
 """Verification API schemas."""
 
+from typing import Optional
+
 from pydantic import BaseModel, Field
 
 
@@ -17,6 +19,14 @@ class VerificationResponse(BaseModel):
     distance: float = Field(..., ge=0.0, description="Similarity distance")
     threshold: float = Field(..., description="Threshold used for verification")
     message: str = Field(..., description="Human-readable message")
+    device_spoof_risk: Optional[dict] = Field(
+        default=None,
+        description=(
+            "Optional device-replay risk assessment from "
+            "DeviceSpoofRiskEvaluator. Populated only when "
+            "ANTISPOOF_DEVICE_RISK_ENABLED=true. Additive, non-blocking."
+        ),
+    )
 
     model_config = {
         "json_schema_extra": {

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -638,6 +638,14 @@ class Settings(BaseSettings):
             "OFF until the gesture backend ships."
         ),
     )
+    ANTISPOOF_DEVICE_RISK_ENABLED: bool = Field(
+        default=False,
+        description=(
+            "Feature flag for attaching DeviceSpoofRiskEvaluator output "
+            "to /verify responses. Additive, non-blocking; default OFF "
+            "so prod behaviour is unchanged until an operator opts in."
+        ),
+    )
     GESTURE_HAND_LANDMARKER_MODEL_PATH: str = Field(
         default=str(_REPO_ROOT / "models" / "hand_landmarker.task"),
         description=(

--- a/tests/integration/test_verify_device_spoof_risk.py
+++ b/tests/integration/test_verify_device_spoof_risk.py
@@ -1,0 +1,179 @@
+"""Integration tests for ANTISPOOF_DEVICE_RISK_ENABLED on /verify (PR 4/5)."""
+
+from __future__ import annotations
+
+import io
+import sys
+from unittest.mock import AsyncMock, Mock, patch
+
+import cv2
+import numpy as np
+import pytest
+
+# Mock DeepFace before any imports that depend on it
+sys.modules.setdefault("deepface", Mock())
+sys.modules.setdefault("deepface.DeepFace", Mock())
+
+from fastapi.testclient import TestClient
+
+from app.api.routes import verification as verify_route
+from app.core.container import (
+    get_check_liveness_use_case,
+    get_client_embedding_observation_repository,
+    get_file_storage,
+    get_verify_face_use_case,
+)
+from app.domain.entities.liveness_result import LivenessResult
+from app.domain.entities.verification_result import VerificationResult
+from app.main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app.dependency_overrides.clear()
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def test_image_file():
+    img = np.full((100, 100, 3), 80, dtype=np.uint8)
+    ok, buf = cv2.imencode(".jpg", img)
+    assert ok
+    return ("test.jpg", io.BytesIO(buf.tobytes()), "image/jpeg")
+
+
+@pytest.fixture
+def mocks(tmp_path):
+    """Bundled mocks: verify use-case, liveness, file storage, observation repo.
+
+    File storage's ``save_temp`` returns a path that actually exists on
+    disk (a small JPEG) so the route's ``validate_image_file`` magic-byte
+    check passes without us having to stub it.
+    """
+    img = np.full((100, 100, 3), 80, dtype=np.uint8)
+    ok, buf = cv2.imencode(".jpg", img)
+    assert ok
+    image_path = tmp_path / "saved.jpg"
+    image_path.write_bytes(buf.tobytes())
+
+    verify_uc = Mock()
+    verify_uc.execute = AsyncMock(
+        return_value=VerificationResult(
+            verified=True, confidence=0.87, distance=0.13, threshold=0.6,
+        )
+    )
+
+    liveness_uc = Mock()
+    liveness_uc.execute = AsyncMock(
+        return_value=LivenessResult(
+            is_live=True, score=92.0, challenge="none",
+            challenge_completed=True, confidence=0.91,
+        )
+    )
+
+    storage = Mock()
+    storage.save_temp = AsyncMock(return_value=str(image_path))
+    storage.cleanup = AsyncMock()
+
+    observation_repo = Mock()
+    observation_repo.record = AsyncMock()
+
+    return verify_uc, liveness_uc, storage, observation_repo
+
+
+def _wire_overrides(verify_uc, liveness_uc, storage, observation_repo) -> None:
+    app.dependency_overrides[get_verify_face_use_case] = lambda: verify_uc
+    app.dependency_overrides[get_check_liveness_use_case] = lambda: liveness_uc
+    app.dependency_overrides[get_file_storage] = lambda: storage
+    app.dependency_overrides[get_client_embedding_observation_repository] = (
+        lambda: observation_repo
+    )
+
+
+def test_verify_omits_device_spoof_risk_when_flag_off(
+    client: TestClient, mocks, test_image_file
+) -> None:
+    """When ANTISPOOF_DEVICE_RISK_ENABLED=False (default), the field is null."""
+    verify_uc, liveness_uc, storage, observation_repo = mocks
+    _wire_overrides(verify_uc, liveness_uc, storage, observation_repo)
+
+    with patch.object(
+        verify_route.settings, "ANTISPOOF_DEVICE_RISK_ENABLED", False
+    ):
+        resp = client.post(
+            "/api/v1/verify",
+            data={"user_id": "test_user_123"},
+            files={"file": test_image_file},
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is True
+    assert body["device_spoof_risk"] is None
+
+
+def test_verify_attaches_device_spoof_risk_when_flag_on(
+    client: TestClient, mocks, test_image_file
+) -> None:
+    """When ANTISPOOF_DEVICE_RISK_ENABLED=True, the field is a dict."""
+    verify_uc, liveness_uc, storage, observation_repo = mocks
+    _wire_overrides(verify_uc, liveness_uc, storage, observation_repo)
+
+    fake_assessment = {
+        "moire_risk": 0.12,
+        "reflection_risk": 0.05,
+        "flicker_risk": 0.0,
+        "flash_response_score": 0.0,
+        "flash_response_strength": 0.0,
+        "flash_response_consistency": 0.0,
+        "flash_replay_risk": 0.0,
+        "hole_cutout_risk": 0.0,
+        "focal_blur_anomaly_risk": 0.0,
+        "cutout_spoof_support": 0.0,
+        "screen_frame_risk": 0.0,
+        "device_replay_risk": 0.04,
+    }
+
+    with patch.object(
+        verify_route.settings, "ANTISPOOF_DEVICE_RISK_ENABLED", True
+    ), patch.object(
+        verify_route, "_evaluate_device_spoof_risk_safe",
+        return_value=fake_assessment,
+    ):
+        resp = client.post(
+            "/api/v1/verify",
+            data={"user_id": "test_user_123"},
+            files={"file": test_image_file},
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is True
+    assert body["device_spoof_risk"] == fake_assessment
+
+
+def test_verify_does_not_break_when_evaluator_raises(
+    client: TestClient, mocks, test_image_file
+) -> None:
+    """If the evaluator throws, verification still succeeds with null risk."""
+    verify_uc, liveness_uc, storage, observation_repo = mocks
+    _wire_overrides(verify_uc, liveness_uc, storage, observation_repo)
+
+    with patch.object(
+        verify_route.settings, "ANTISPOOF_DEVICE_RISK_ENABLED", True
+    ), patch.object(
+        verify_route, "_get_device_spoof_risk_evaluator",
+        side_effect=RuntimeError("synthetic detector failure"),
+    ):
+        resp = client.post(
+            "/api/v1/verify",
+            data={"user_id": "test_user_123"},
+            files={"file": test_image_file},
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is True
+    # The helper swallows the exception and returns None.
+    assert body["device_spoof_risk"] is None


### PR DESCRIPTION
Cherry-pick 4/5 from Aysenur's working_spoof_detection — `device-risk wire to /verify`.

## What does this give you?
Once an operator sets `ANTISPOOF_DEVICE_RISK_ENABLED=true`, every `/verify` response gains a new `device_spoof_risk` JSON object alongside the existing fields:

```json
{
  "verified": true,
  "confidence": 0.87,
  ...,
  "device_spoof_risk": {
    "moire_risk": 0.12,
    "reflection_risk": 0.05,
    "flicker_risk": 0.0,
    "flash_response_score": 0.0,
    "flash_replay_risk": 0.0,
    "hole_cutout_risk": 0.0,
    "screen_frame_risk": 0.0,
    "device_replay_risk": 0.04,
    ...
  }
}
```

This is **purely informational** — the field never blocks verification under any condition (intentional, per spec). The web/mobile UI can surface it as a soft warning or pipe it into per-tenant analytics. Hardening (using it as a hard veto) is a separate decision for PR 5 / a future PR.

When the flag is off (default), the field is `null` and the evaluator never runs — zero overhead.

## Source
- Branch: `origin/working_spoof_detection`
- Tip: `cbdbe0b`
- Underlying service: `app/application/services/device_spoof_risk_evaluator.py` — already in `main` since 2026-04 but never wired to `/verify` before today (per investigation doc).

## What's added
- `app/api/routes/verification.py` — flag-gated call to evaluator; safe `_evaluate_device_spoof_risk_safe` wrapper that swallows any evaluator exception and returns `None`
- `app/api/schemas/verification.py` — new optional `device_spoof_risk: dict | None` field
- `app/core/config.py` — `ANTISPOOF_DEVICE_RISK_ENABLED: bool = False`
- `tests/integration/test_verify_device_spoof_risk.py` — 3 new integration tests

## What's deferred (intentional)
- **No hard veto.** The signal is attached but never blocks. The right place to fuse it into a verdict is the `HybridFusionEvaluator` in PR 5, gated behind a separate `LIVENESS_FUSION_ENABLED` flag.
- The evaluator is constructed lazily (on first request with flag on) so cold-start cost is paid by the operator who opts in, not by everybody.

## Test strategy
`pytest tests/integration/test_verify_device_spoof_risk.py` → **3 passed, 0 failed**.

Cases: flag off → field is null; flag on → field is populated dict; flag on + evaluator throws → request still 200 with field null.

## No security regressions
- `requirements.txt` **not touched**
- No existing tests deleted
- No binaries
- No new external deps; uses `cv2` + `numpy` already pinned

## PR chain
PR **4 of 5**. Independent of PRs 1, 2, 3 — can land in any order. **PR 5 will read this output via the `HybridFusionEvaluator`** introduced in PR 3.

cc @Aysenur15 — your branch wires the evaluator through `LiveCameraAnalysisUseCase`; this PR uses the simpler `/verify` path Ahmet asked for. The same evaluator is reused unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)