### PR TITLE
fix(antispoof): wire ANTISPOOF_* flags in compose + bump spoof-detector to v0.2.1

### DIFF
--- a/app/api/routes/verification.py
+++ b/app/api/routes/verification.py
@@ -93,9 +93,9 @@ def _get_antispoof_assembler() -> Optional[Any]:
     if _antispoof_assembler_init_failed:
         return None
     try:
-        from src.fusion import HybridFusionEvaluator
-        from src.gates import FaceUsabilityGate
-        from src.pipeline import AntispoofPipelineAssembler
+        from spoof_detector.fusion import HybridFusionEvaluator
+        from spoof_detector.gates import FaceUsabilityGate
+        from spoof_detector.pipeline import AntispoofPipelineAssembler
     except ImportError as exc:  # pragma: no cover - exercised only when dep missing
         logger.warning(
             "spoof_detector package not importable; AntispoofPipelineAssembler "

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -82,6 +82,15 @@ services:
       FIVUCSAS_EMBEDDING_KEY: ${FIVUCSAS_EMBEDDING_KEY}
       FIVUCSAS_EMBEDDING_KEY_VERSION: ${FIVUCSAS_EMBEDDING_KEY_VERSION}
 
+      # Anti-spoof feature flags (PR #88, 2026-05-09). All default OFF
+      # so prod behaviour is unchanged until an operator opts in via
+      # .env.prod. The runtime imports these gates from the
+      # spoof_detector pip package (≥ v0.2.1).
+      ANTISPOOF_DEVICE_RISK_ENABLED: ${ANTISPOOF_DEVICE_RISK_ENABLED:-false}
+      ANTISPOOF_USABILITY_GATE_ENABLED: ${ANTISPOOF_USABILITY_GATE_ENABLED:-false}
+      ANTISPOOF_FUSION_ENABLED: ${ANTISPOOF_FUSION_ENABLED:-false}
+      ANTISPOOF_CUTOUT_ENABLED: ${ANTISPOOF_CUTOUT_ENABLED:-false}
+
       # Rate Limiting
       RATE_LIMIT_ENABLED: true
       RATE_LIMIT_STORAGE: memory

--- a/requirements.txt
+++ b/requirements.txt
@@ -84,10 +84,11 @@ prometheus_client>=0.21.1
 uniface>=3.0.0
 # Standalone spoof-detector engine (gates + fusion + pipeline assembler).
 # Lives at https://github.com/Rollingcat-Software/spoof-detector — the
-# algorithms ported there (v0.2.0) replace the in-tree cherry-pick that
-# was reverted in PR #87 (2026-05-09). We pin to the v0.2.0 tag; bump
-# only after the upstream tag exists in CI.
-spoof-detector @ git+https://github.com/Rollingcat-Software/spoof-detector.git@v0.2.0
+# algorithms ported there (v0.2.x) replace the in-tree cherry-pick that
+# was reverted in PR #87 (2026-05-09).
+# v0.2.1 adds the public `spoof_detector.*` namespace shim so we can
+# `from spoof_detector.gates import ...` (v0.2.0 only exposed `src.*`).
+spoof-detector @ git+https://github.com/Rollingcat-Software/spoof-detector.git@v0.2.1
 # CPU-only ONNX Runtime — required for direct ONNX model loading (voice ONNX migration,
 # future client-side model parity checks). Ultralytics bundles its own but this ensures
 # onnxruntime is an explicit, versioned dependency of this service.

--- a/tests/integration/test_verify_antispoof_wiring.py
+++ b/tests/integration/test_verify_antispoof_wiring.py
@@ -283,10 +283,10 @@ def test_antispoof_pipeline_safe_returns_none_when_dep_missing(
     ), patch.dict(
         sys.modules,
         {
-            "src": Mock(),
-            "src.fusion": Mock(spec=[]),  # empty mock — `from src.fusion import HybridFusionEvaluator` will AttributeError
-            "src.gates": Mock(spec=[]),
-            "src.pipeline": Mock(spec=[]),
+            "spoof_detector": Mock(),
+            "spoof_detector.fusion": Mock(spec=[]),  # empty mock — `from spoof_detector.fusion import HybridFusionEvaluator` will AttributeError
+            "spoof_detector.gates": Mock(spec=[]),
+            "spoof_detector.pipeline": Mock(spec=[]),
         },
         clear=False,
     ), patch.object(verify_route, "_antispoof_assembler", None), patch.object(


### PR DESCRIPTION
## Summary
- Compose was missing the 4 `${ANTISPOOF_*:-false}` interpolations introduced by PR #88. Operator can now flip them via .env.prod (matches existing JWT_SECRET / FIVUCSAS_EMBEDDING_KEY pattern). All default false.
- Spoof-detector v0.2.0 installed as `src.*` namespace (too generic, will clash). v0.2.1 ships a `spoof_detector.*` shim. Update the import site in `verification.py` and pin v0.2.1.
- Update mock in `test_verify_antispoof_wiring.py` to match new namespace.

## Test plan
- [ ] Rebuild bio container, recreate
- [ ] `docker exec biometric-api python -c "from spoof_detector.gates import FaceUsabilityGate; print('ok')"` returns ok
- [ ] `docker exec biometric-api env | grep ANTISPOOF` lists all 4 flags
- [ ] Operator can set `ANTISPOOF_USABILITY_GATE_ENABLED=true` in `.env.prod`, recreate, observe field in `/verify` response

🤖 Generated with [Claude Code](https://claude.com/claude-code)