### PR TITLE
fix(docker): install git so pip can fetch spoof-detector from git+https

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ffmpeg \
     gcc \
+    git \
     build-essential \
     tesseract-ocr \
     tesseract-ocr-tur \


### PR DESCRIPTION
## Summary
- `requirements.txt` installs `spoof-detector` from `git+https://github.com/Rollingcat-Software/spoof-detector.git@v0.2.1`
- Build image was missing the `git` CLI, so `pip install -r requirements.txt` failed
- This is why the prod rebuild after PR #88/#89 produced an image still on **spoof-detector v0.2.0** with the obsolete `src.*` namespace
- One-line apt addition (`+ git`) — no behaviour change beyond unblocking the build

## Test plan
- [x] Dockerfile `apt-get install` line includes `git`
- [ ] `docker compose -f docker-compose.prod.yml --env-file .env.prod build --no-cache biometric-api` succeeds end-to-end
- [ ] `docker exec biometric-api pip show spoof-detector` reports `0.2.1`
- [ ] `docker exec biometric-api grep -n "from spoof_detector" app/api/routes/verification.py` returns matches
- [ ] `/biometric/health` returns 200 and `ANTISPOOF_*` env vars are visible via `docker inspect`

🤖 Generated with [Claude Code](https://claude.com/claude-code)