### PR TITLE
docs(readme): add FIVUCSAS acronym expansion to H1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Biometric Processor
+# FIVUCSAS — Face and Identity Verification Using Cloud-based SaaS
+
+## Biometric Processor
 
 ![Python](https://img.shields.io/badge/Python-3.12-yellow.svg)
 ![FastAPI](https://img.shields.io/badge/FastAPI-0.115-green.svg)


### PR DESCRIPTION
## Summary

Adds the brand-anchor H1 `FIVUCSAS — Face and Identity Verification Using Cloud-based SaaS` to the top of this submodule's README. The original module-specific title moves down to an H2 subtitle.

## Why

Google currently autocorrects searches for "FIVUCSAS" to "fivics" (an unrelated archery brand). The fix is off-page: getting the canonical acronym expansion to appear as a literal H1 anchor in every public README under the org so the name gains brand-signal weight.

Coordinated GitHub repo `--description` and topic edits landed in parallel via `gh repo edit`.

## Test plan
- [ ] GitHub renders the new H1 on the repo landing page
- [ ] README preview in repo cards shows the expansion