### PR TITLE
feat(nfc): expose mrz_parser via /api/v1/nfc/mrz

### DIFF
--- a/app/api/routes/nfc.py
+++ b/app/api/routes/nfc.py
@@ -1,0 +1,252 @@
+"""NFC document MRZ parsing route.
+
+Exposes the existing ``mrz_parser`` machinery as a first-class endpoint so the
+identity-core-api ``NfcController`` can verify Machine-Readable Zones from
+chip-read passports / ID cards (DG1) and surface structured fields back to
+clients without falling back to the verification-pipeline data-extract route
+(which is geared towards manual-KYC document scans).
+
+This route is intentionally narrow:
+- Pure string parsing — no OCR, no ML, no DB writes
+- Input contract matches the task spec (T2-A, INVESTIGATION 2026-05-07 P1):
+  ``{"mrz_text": "...", "dg1_bytes_b64": null}`` (exactly one required)
+- Output contract matches the task spec — flat structured fields plus
+  ``checksum_valid`` boolean and a ``checksum_failures`` list of field names
+  that failed their ICAO 9303 check-digit verification
+
+The legacy ``/verification/data-extract`` endpoint is left untouched.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import logging
+import re
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from app.domain.services.mrz_parser import (
+    MRZData,
+    detect_and_parse_mrz,
+    format_date,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/nfc",
+    tags=["NFC Document"],
+)
+
+
+# ----------------------------------------------------------------------------
+# Request / response models
+# ----------------------------------------------------------------------------
+
+
+class MrzParseRequest(BaseModel):
+    """Input for ``POST /nfc/mrz``.
+
+    Exactly one of ``mrz_text`` or ``dg1_bytes_b64`` must be supplied:
+
+    - ``mrz_text`` — raw MRZ string (2 lines x 44 chars for TD3 passports,
+      3 lines x 30 chars for TD1 ID cards) separated by ``\\n``.
+    - ``dg1_bytes_b64`` — base64-encoded ICAO Data Group 1 bytes. DG1 wraps
+      the MRZ in a TLV envelope (5F1F tag); this route strips the wrapper
+      and parses the remaining ASCII MRZ string.
+    """
+
+    mrz_text: Optional[str] = Field(
+        default=None,
+        description="Raw MRZ string (2-3 lines separated by newline).",
+    )
+    dg1_bytes_b64: Optional[str] = Field(
+        default=None,
+        description="Base64-encoded ICAO DG1 bytes (TLV-wrapped MRZ).",
+    )
+
+
+class MrzParseResponse(BaseModel):
+    """Output for ``POST /nfc/mrz``.
+
+    Field naming mirrors the T2-A spec exactly so the Java caller can map
+    to a record without a translation layer.
+    """
+
+    document_type: Optional[str] = None
+    issuing_country: Optional[str] = None
+    surname: Optional[str] = None
+    given_names: Optional[str] = None
+    document_number: Optional[str] = None
+    nationality: Optional[str] = None
+    date_of_birth: Optional[str] = None
+    sex: Optional[str] = None
+    date_of_expiry: Optional[str] = None
+    personal_number: Optional[str] = None
+    checksum_valid: bool = False
+    checksum_failures: list[str] = Field(default_factory=list)
+    mrz_format: Optional[str] = None  # "TD1" or "TD3" — handy for diagnostics
+
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+
+
+# Maps mrz_parser error strings to the canonical field-name tokens that the
+# Java caller persists in audit metadata. Keep this list short and stable —
+# the upstream parser only ever emits these five error messages.
+_CHECKSUM_FAILURE_FIELDS: dict[str, str] = {
+    "Document number check digit invalid": "document_number",
+    "Date of birth check digit invalid": "date_of_birth",
+    "Expiry date check digit invalid": "date_of_expiry",
+    "Optional data check digit invalid": "personal_number",
+    "Overall composite check digit invalid": "composite",
+}
+
+
+def _decode_dg1_to_mrz_text(dg1_b64: str) -> str:
+    """Extract the ASCII MRZ string from a base64-encoded DG1 blob.
+
+    DG1 is TLV-encoded: the outermost tag is 0x61 (Application 1), wrapping a
+    0x5F1F tag whose value is the raw MRZ ASCII bytes. Different reader
+    libraries produce slightly different envelopes (some prepend extra
+    headers, some omit the outer 0x61 wrapper), so we use a permissive
+    strategy: decode base64, then locate the first run of contiguous
+    MRZ-legal characters (A-Z, 0-9, '<') at least 60 chars long and treat
+    that as the MRZ payload, splitting it into 30- or 44-char lines.
+    """
+    try:
+        raw = base64.b64decode(dg1_b64, validate=False)
+    except (binascii.Error, ValueError) as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"dg1_bytes_b64 is not valid base64: {exc}",
+        ) from exc
+
+    # MRZ characters are restricted to A-Z, 0-9, '<'. Find the longest
+    # contiguous run in the decoded byte string. We tolerate stray spaces
+    # but not other binary noise.
+    try:
+        ascii_text = raw.decode("ascii", errors="ignore")
+    except UnicodeDecodeError as exc:  # pragma: no cover — errors="ignore"
+        raise HTTPException(
+            status_code=400,
+            detail=f"DG1 bytes contain unparseable data: {exc}",
+        ) from exc
+
+    runs = re.findall(r"[A-Z0-9<]{20,}", ascii_text)
+    if not runs:
+        raise HTTPException(
+            status_code=400,
+            detail="No MRZ payload found in DG1 bytes (no A-Z0-9< run >= 20 chars).",
+        )
+
+    # Pick the longest run. TD3 = 88 chars total, TD1 = 90 chars total.
+    payload = max(runs, key=len)
+
+    if len(payload) >= 88 and len(payload) % 44 == 0:
+        # TD3 — 2 lines x 44 chars
+        return "\n".join(payload[i:i + 44] for i in range(0, len(payload), 44))
+    if len(payload) >= 90 and len(payload) % 30 == 0:
+        # TD1 — 3 lines x 30 chars
+        return "\n".join(payload[i:i + 30] for i in range(0, len(payload), 30))
+
+    # Fallback: hand the raw run to detect_and_parse_mrz and let it figure
+    # out the format. detect_and_parse_mrz auto-splits on newlines so we
+    # break on most-likely boundaries.
+    if len(payload) >= 88:
+        return "\n".join(payload[i:i + 44] for i in range(0, len(payload), 44))
+    return "\n".join(payload[i:i + 30] for i in range(0, len(payload), 30))
+
+
+def _failures_from_errors(errors: list[str]) -> list[str]:
+    """Map parser error strings to canonical field tokens.
+
+    Unknown error strings fall through as-is so callers still see a hint
+    rather than a silent drop.
+    """
+    return [_CHECKSUM_FAILURE_FIELDS.get(err, err) for err in errors]
+
+
+def _to_response(mrz: MRZData) -> MrzParseResponse:
+    return MrzParseResponse(
+        document_type=mrz.document_type or None,
+        issuing_country=mrz.country_code or None,
+        surname=mrz.surname or None,
+        given_names=mrz.given_names or None,
+        document_number=mrz.document_number or None,
+        nationality=mrz.nationality or None,
+        date_of_birth=format_date(mrz.date_of_birth) if mrz.date_of_birth else None,
+        sex=mrz.sex or None,
+        date_of_expiry=format_date(mrz.expiry_date) if mrz.expiry_date else None,
+        # Personal number lives in optional_data_1 for TD3 (chars 28-42 of
+        # line 2). TD1 ID cards put the national identifier there too,
+        # though the layout differs.
+        personal_number=mrz.optional_data_1 or None,
+        checksum_valid=mrz.check_digits_valid,
+        checksum_failures=_failures_from_errors(mrz.errors),
+        mrz_format=mrz.format,
+    )
+
+
+# ----------------------------------------------------------------------------
+# Route
+# ----------------------------------------------------------------------------
+
+
+@router.post(
+    "/mrz",
+    response_model=MrzParseResponse,
+    summary="Parse an NFC document MRZ",
+    description=(
+        "Parses a Machine-Readable Zone (TD1 ID card or TD3 passport) and "
+        "returns structured identity fields plus ICAO 9303 check-digit "
+        "validation results. Pure string parsing — no OCR, no DB writes. "
+        "Caller must supply exactly one of `mrz_text` or `dg1_bytes_b64`."
+    ),
+)
+async def parse_mrz(payload: MrzParseRequest) -> MrzParseResponse:
+    """Parse MRZ supplied either as raw text or as DG1 bytes."""
+
+    if not payload.mrz_text and not payload.dg1_bytes_b64:
+        raise HTTPException(
+            status_code=400,
+            detail="Provide either mrz_text or dg1_bytes_b64.",
+        )
+    if payload.mrz_text and payload.dg1_bytes_b64:
+        raise HTTPException(
+            status_code=400,
+            detail="Provide exactly one of mrz_text or dg1_bytes_b64, not both.",
+        )
+
+    if payload.dg1_bytes_b64:
+        mrz_text = _decode_dg1_to_mrz_text(payload.dg1_bytes_b64)
+        logger.info("NFC /mrz: parsed DG1 envelope, recovered %d-char MRZ payload",
+                    len(mrz_text.replace("\n", "")))
+    else:
+        mrz_text = payload.mrz_text  # type: ignore[assignment]
+
+    parsed = detect_and_parse_mrz(mrz_text)
+    if parsed is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Could not parse MRZ. Expected 2 lines x 44 chars (TD3 passport)"
+                " or 3 lines x 30 chars (TD1 ID card)."
+            ),
+        )
+
+    response = _to_response(parsed)
+    logger.info(
+        "NFC /mrz: format=%s doc_type=%s country=%s checksum_valid=%s failures=%s",
+        response.mrz_format,
+        response.document_type,
+        response.issuing_country,
+        response.checksum_valid,
+        response.checksum_failures,
+    )
+    return response

--- a/app/main.py
+++ b/app/main.py
@@ -40,6 +40,7 @@ from app.api.routes import live_analysis
 from app.api.routes import voice
 from app.api.routes import puzzle
 from app.api.routes import flash_challenge
+from app.api.routes import nfc
 from app.core.config import settings
 from app.core.container import initialize_dependencies, shutdown_dependencies
 from app.core.gpu import configure_gpu
@@ -313,6 +314,12 @@ app.include_router(card_type_router.router, prefix=API_PREFIX)
 
 # Verification Pipeline routes (Phase 8B/8C: Document Processing + Face-to-Document Matching)
 app.include_router(verification_pipeline.router, prefix=API_PREFIX)
+
+# NFC document MRZ parsing route (T2-A, INVESTIGATION 2026-05-07 P1).
+# Wraps mrz_parser in a dedicated /nfc/mrz endpoint consumed by
+# identity-core-api NfcController so chip-read passports/ID cards can be
+# verified without going through the manual-KYC verification pipeline.
+app.include_router(nfc.router, prefix=API_PREFIX)
 
 # New feature routes
 app.include_router(quality.router, prefix=API_PREFIX)

--- a/tests/unit/test_nfc_mrz_route.py
+++ b/tests/unit/test_nfc_mrz_route.py
@@ -1,0 +1,205 @@
+"""Unit tests for the /api/v1/nfc/mrz route.
+
+Uses the canonical ICAO 9303 example MRZs (UTOPIAN passport + ID card) to
+prove the round-trip from JSON request to structured response and verifies
+the corrupted-checksum failure path. The route is mounted on a minimal
+FastAPI app to avoid the global ``app.main`` import path, which pulls in
+ML/model wiring not relevant to pure-string MRZ parsing.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.routes.nfc import router as nfc_router
+
+
+# Canonical ICAO 9303 TD3 (passport) — both check digits valid, used as
+# the example in the spec itself.
+TD3_LINE1 = "P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<"
+TD3_LINE2 = "L898902C36UTO7408122F1204159ZE184226B<<<<<10"
+TD3_VALID_MRZ = f"{TD3_LINE1}\n{TD3_LINE2}"
+
+# Canonical ICAO 9303 TD1 (ID card) — both check digits valid.
+TD1_LINE1 = "I<UTOD231458907<<<<<<<<<<<<<<<"
+TD1_LINE2 = "7408122F1204159UTO<<<<<<<<<<<6"
+TD1_LINE3 = "ERIKSSON<<ANNA<MARIA<<<<<<<<<<"
+TD1_VALID_MRZ = f"{TD1_LINE1}\n{TD1_LINE2}\n{TD1_LINE3}"
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """Build a minimal FastAPI app that includes only the NFC router."""
+    app = FastAPI()
+    app.include_router(nfc_router, prefix="/api/v1")
+    return TestClient(app)
+
+
+# ----------------------------------------------------------------------------
+# Happy path
+# ----------------------------------------------------------------------------
+
+
+def test_parse_valid_td3_passport(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/nfc/mrz",
+        json={"mrz_text": TD3_VALID_MRZ},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    assert body["mrz_format"] == "TD3"
+    assert body["document_type"] == "P"
+    assert body["issuing_country"] == "UTO"
+    assert body["surname"] == "ERIKSSON"
+    assert body["given_names"] == "ANNA MARIA"
+    assert body["document_number"] == "L898902C3"
+    assert body["nationality"] == "UTO"
+    # parser converts YYMMDD -> YYYY-MM-DD; YY < 30 means 20YY
+    assert body["date_of_birth"] == "1974-08-12"
+    assert body["sex"] == "F"
+    assert body["date_of_expiry"] == "2012-04-15"
+    assert body["checksum_valid"] is True
+    assert body["checksum_failures"] == []
+
+
+def test_parse_valid_td1_id_card(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/nfc/mrz",
+        json={"mrz_text": TD1_VALID_MRZ},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    assert body["mrz_format"] == "TD1"
+    assert body["document_type"] == "I"
+    assert body["issuing_country"] == "UTO"
+    assert body["surname"] == "ERIKSSON"
+    assert body["given_names"] == "ANNA MARIA"
+    assert body["document_number"] == "D23145890"
+    assert body["date_of_birth"] == "1974-08-12"
+    assert body["sex"] == "F"
+    assert body["checksum_valid"] is True
+    assert body["checksum_failures"] == []
+
+
+# ----------------------------------------------------------------------------
+# Checksum failures
+# ----------------------------------------------------------------------------
+
+
+def test_corrupted_document_number_checksum_returns_200_with_failures(
+    client: TestClient,
+) -> None:
+    """A single-bit flip in the document number breaks both its own check
+    digit and the overall composite check digit. The route returns 200 with
+    checksum_valid=False so the API caller can surface a domain-level 400 —
+    the parse itself succeeded, only verification failed.
+    """
+    # Flip "C3" -> "C4" in the document-number block; original check digit
+    # was 6 and stays 6 in line 2 col 9, so the doc# check digit fails.
+    corrupted_line2 = "L898902C46UTO7408122F1204159ZE184226B<<<<<10"
+    corrupted = f"{TD3_LINE1}\n{corrupted_line2}"
+
+    response = client.post("/api/v1/nfc/mrz", json={"mrz_text": corrupted})
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    assert body["checksum_valid"] is False
+    # We expect at least the document_number to be flagged; the composite
+    # check digit may also fail because it incorporates the doc number.
+    assert "document_number" in body["checksum_failures"]
+
+
+def test_completely_corrupted_dob_field(client: TestClient) -> None:
+    """Replacing the DOB digits with a different valid-looking value drops
+    the DOB check digit, surfacing date_of_birth in failures."""
+    # Replace "7408122" (dob + check) with "8001011"; new dob is 800101 and
+    # its real check digit isn't 1, so this fails.
+    corrupted_line2 = "L898902C36UTO8001011F1204159ZE184226B<<<<<10"
+    corrupted = f"{TD3_LINE1}\n{corrupted_line2}"
+
+    response = client.post("/api/v1/nfc/mrz", json={"mrz_text": corrupted})
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    assert body["checksum_valid"] is False
+    assert "date_of_birth" in body["checksum_failures"]
+
+
+# ----------------------------------------------------------------------------
+# Error contract
+# ----------------------------------------------------------------------------
+
+
+def test_missing_both_inputs_returns_400(client: TestClient) -> None:
+    response = client.post("/api/v1/nfc/mrz", json={})
+    assert response.status_code == 400
+    assert "mrz_text" in response.json()["detail"]
+
+
+def test_both_inputs_supplied_returns_400(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/nfc/mrz",
+        json={"mrz_text": TD3_VALID_MRZ, "dg1_bytes_b64": "AAAA"},
+    )
+    assert response.status_code == 400
+    assert "exactly one" in response.json()["detail"].lower()
+
+
+def test_garbage_mrz_text_returns_400(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/nfc/mrz",
+        json={"mrz_text": "this is not an MRZ at all"},
+    )
+    assert response.status_code == 400
+
+
+def test_invalid_base64_dg1_returns_400(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/nfc/mrz",
+        # base64 has a strict alphabet; '*' is invalid, and the bytes that
+        # come out won't match a parseable MRZ shape either way.
+        json={"mrz_text": None, "dg1_bytes_b64": "***not-base64***"},
+    )
+    # Either base64 validation kicks in or the MRZ-payload search fails;
+    # both flow through 400 as designed.
+    assert response.status_code == 400
+
+
+# ----------------------------------------------------------------------------
+# DG1 envelope handling
+# ----------------------------------------------------------------------------
+
+
+def test_dg1_envelope_with_td3_payload(client: TestClient) -> None:
+    """A minimal DG1 wrapper around the canonical TD3 MRZ should round-trip
+    to the same parsed fields as raw MRZ text. We use the standard ICAO
+    envelope: outer tag 0x61, length, inner tag 0x5F1F, length, ASCII MRZ.
+    """
+    raw_mrz = (TD3_LINE1 + TD3_LINE2).encode("ascii")
+    # 0x5F1F + length-58 + payload (88 bytes); wrapped in 0x61 + length.
+    inner = bytes([0x5F, 0x1F, 0x5C]) + raw_mrz  # 0x5C == 92 placeholder len
+    outer = bytes([0x61, len(inner)]) + inner
+    dg1_b64 = base64.b64encode(outer).decode("ascii")
+
+    response = client.post(
+        "/api/v1/nfc/mrz",
+        json={"dg1_bytes_b64": dg1_b64},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["mrz_format"] == "TD3"
+    assert body["surname"] == "ERIKSSON"
+    assert body["checksum_valid"] is True
+
+
+def test_dg1_envelope_without_mrz_payload_returns_400(client: TestClient) -> None:
+    """Random bytes with no contiguous A-Z0-9< run >= 20 chars."""
+    dg1_b64 = base64.b64encode(b"\x00\x01\x02\x03\x04random binary noise").decode("ascii")
+    response = client.post("/api/v1/nfc/mrz", json={"dg1_bytes_b64": dg1_b64})
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary

- New `POST /api/v1/nfc/mrz` route (in `app/api/routes/nfc.py`) wraps the existing `mrz_parser` for the identity-core-api NFC auth path. Accepts either raw `mrz_text` (TD1 / TD3) or base64-encoded DG1 bytes, and returns structured identity fields plus an ICAO 9303 `checksum_valid` bit + per-field `checksum_failures` list.
- Distinct from the existing `/verification/data-extract` (manual-KYC, OCR-driven) — this route is pure string parsing, no DB writes, no ML.
- 10 unit tests cover TD1 + TD3 happy paths, corrupted-checksum failures (doc-number flip + DOB flip), DG1 envelope decode round-trip, missing/ambiguous inputs and invalid base64 DG1.

Pairs with the api-side PR that adds `NfcController#verifyMrz` (T2-A, INVESTIGATION_MASTER_2026-05-07.md P1 backlog).

## Test plan

- [x] `pytest tests/unit/test_nfc_mrz_route.py -v` — 10/10 passing locally
- [x] `python -c 'from app.api.routes import nfc; print(nfc.router.routes)'` — module imports cleanly, route registered at `/nfc/mrz`
- [ ] Reviewer: confirm `app/main.py` `include_router(nfc.router, prefix=API_PREFIX)` slots into the existing chain without touching the pipeline ordering
- [ ] Smoke test against running api PR: `curl -X POST -H 'X-API-Key: …' -d '{"mrz_text":"…"}' http://bio:8001/api/v1/nfc/mrz` returns `checksum_valid=true` for the ICAO 9303 ANNA MARIA fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)