### PR TITLE
docs(readme): repair broken docs/ links (CF-3 from session 2026-05-11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ All documentation is organized in the `docs/` directory:
 - **[API Documentation](docs/2-api-documentation/)** - Complete API reference
 - **[Deployment](docs/3-deployment/)** - Deployment guides and database setup
 - **[Testing](docs/4-testing/)** - Testing guides and test reports
-- **[Performance](docs/5-performance/)** - Performance analysis and optimizations
+- **[Performance](docs/PERFORMANCE_OPTIMIZATION_GUIDE.md)** - Performance analysis and optimizations
 - **[Architecture](docs/6-architecture/)** - Design documents and architecture
-- **[Development](docs/7-development/)** - Bug fixes, changelog, contributing
+- **[Changelog](CHANGELOG.md)** - Release history and notable changes
 
 ## Features
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,9 +8,9 @@ Welcome to the biometric-processor documentation!
 🔌 **[API Documentation](2-api-documentation/)** - Complete API reference
 🚀 **[Deployment](3-deployment/)** - Deployment guides and database setup
 🧪 **[Testing](4-testing/)** - Testing guides and test reports
-⚡ **[Performance](5-performance/)** - Performance analysis and optimizations
+⚡ **[Performance](PERFORMANCE_OPTIMIZATION_GUIDE.md)** - Performance analysis and optimizations
 🏗️ **[Architecture](6-architecture/)** - Design documents and architecture
-💻 **[Development](7-development/)** - Development guides, bug fixes, changelog
+💻 **[Changelog](../CHANGELOG.md)** - Release history and notable changes
 
 ---
 
@@ -33,19 +33,14 @@ docs/
 │   ├── test-reports/       # Test results
 │   └── *.md                # Testing guides
 │
-├── 5-performance/          # Performance
-│   ├── DEMO_LOCAL_PERFORMANCE_ANALYSIS.md  # ⭐ Latest analysis
-│   └── PERFORMANCE_IMPROVEMENTS_SUMMARY.md # ⭐ What we improved
+├── PERFORMANCE_OPTIMIZATION_GUIDE.md  # ⭐ Performance guide
+├── UNIFACE_BACKEND_BENCHMARKING.md    # UniFace backend benchmarks
 │
 ├── 6-architecture/         # Architecture
 │   ├── FEATURE_DESIGN.md
 │   └── MODULE_PLAN.md
 │
-├── 7-development/          # Development
-│   ├── BUG_FIX_SUMMARY.md
-│   └── IMPLEMENTATION_*.md
-│
-└── archive/                # Old/outdated docs
+└── archive/                # Old/outdated docs (incl. legacy dev notes)
 ```
 
 ---
@@ -58,14 +53,15 @@ docs/
 3. **[Demo Usage](1-getting-started/DEMO_USAGE.md)** - How to use demo_local.py
 
 ### For Developers:
-1. **[Performance Analysis](5-performance/DEMO_LOCAL_PERFORMANCE_ANALYSIS.md)** - Latest performance analysis
+1. **[Performance Optimization Guide](PERFORMANCE_OPTIMIZATION_GUIDE.md)** - Performance guidance
 2. **[Architecture](6-architecture/)** - Design and architecture docs
-3. **[Development](7-development/)** - Bug fixes and implementation notes
+3. **[Changelog](../CHANGELOG.md)** - Release history and notable changes
 
 ---
 
 ## Quick Links
 
 - [Main README](../README.md)
-- [Demo Local (demo_local.py)](../demo_local.py)
-- [Performance Improvements Summary](5-performance/PERFORMANCE_IMPROVEMENTS_SUMMARY.md)
+- [Demo Local Fast (demo_local_fast.py)](../demo_local_fast.py)
+- [Demo Local Optimized (demo_local_optimized.py)](../demo_local_optimized.py)
+- [Performance Optimization Guide](PERFORMANCE_OPTIMIZATION_GUIDE.md)


### PR DESCRIPTION
## Summary

Followup from PR #13 (fivucsas docs submodule). The bio repo's `README.md` referenced numeric-prefixed `docs/` subdirectories that never existed in this repo's own `docs/` tree. Same drift in `docs/README.md`. This PR repairs every broken local link in those two files; no new content added.

## Broken links found and resolutions

### `README.md` (top-level)

| Broken link | Resolution | Why |
|---|---|---|
| `docs/5-performance/` | replaced with `docs/PERFORMANCE_OPTIMIZATION_GUIDE.md` | Performance docs live as flat files at `docs/` root (`PERFORMANCE_OPTIMIZATION_GUIDE.md`, `UNIFACE_BACKEND_BENCHMARKING.md`); no numeric subdir was ever created. |
| `docs/7-development/` | replaced with `CHANGELOG.md` | No development subdir exists. Bullet was "Bug fixes, changelog, contributing"; the canonical changelog is at repo root and dev-bug-fix notes are in `docs/archive/2026-04-16/`. Pointing readers at the live changelog is more useful than a 404. |

### `docs/README.md` (docs landing page)

| Broken link | Resolution |
|---|---|
| `5-performance/` (Quick Navigation) | replaced with `PERFORMANCE_OPTIMIZATION_GUIDE.md` |
| `7-development/` (Quick Navigation) | replaced with `../CHANGELOG.md` |
| `5-performance/DEMO_LOCAL_PERFORMANCE_ANALYSIS.md` (Most Important Documents) | replaced with `PERFORMANCE_OPTIMIZATION_GUIDE.md` (file still exists under `docs/archive/2026-04-16/` but the optimization guide is the canonical replacement) |
| `7-development/` (Most Important Documents) | replaced with `../CHANGELOG.md` |
| `../demo_local.py` (Quick Links) | replaced with `../demo_local_fast.py` + `../demo_local_optimized.py` (the file was split during optimization; both replacements exist at repo root) |
| `5-performance/PERFORMANCE_IMPROVEMENTS_SUMMARY.md` (Quick Links) | replaced with `PERFORMANCE_OPTIMIZATION_GUIDE.md` |

Also collapsed the "Documentation Structure" ASCII tree to reflect what is actually on disk (drop missing `5-performance/` and `7-development/` blocks, list the two performance docs at `docs/` root).

## Verification

After fix, running the broken-link scan on both files returns zero hits:

```
=== README.md ===
=== docs/README.md ===
```

`CHANGELOG.md`, `SECURITY.md`, `ARCHITECTURE.md` were also scanned and have no broken local links — no change needed.

## Test plan

- [x] `grep`-based broken-link scan on `README.md` and `docs/README.md` returns zero hits
- [x] Every replacement target verified to exist on disk
- [x] No content added, only stale references repaired