### PR TITLE
fix(tests): repair CI red on main (#91) — 22 stale unit tests + 3 asyncio singleton leaks

### DIFF
--- a/tests/integration/test_verify_antispoof_wiring.py
+++ b/tests/integration/test_verify_antispoof_wiring.py
@@ -40,41 +40,47 @@ from app.domain.entities.verification_result import VerificationResult
 from app.main import app
 
 
+@pytest.fixture(scope="module")
+def _module_client():
+    """Module-scoped TestClient. The previous function-scoped variant caused
+    every-other-test `RuntimeError: Event loop is closed` because each test's
+    fresh TestClient created a new anyio portal but the underlying FastAPI
+    `app` retained references (lru-cached deps, BaseHTTPMiddleware task
+    groups, anyio thread state) to the previous test's loop. Module scope
+    keeps a single TestClient — and thus a single portal/loop — alive for
+    the file's 6 tests."""
+    with TestClient(app) as c:
+        yield c
+
+
 @pytest.fixture
-def client() -> TestClient:
-    """Yield a TestClient with verify_route singletons + DI cache reset.
+def client(_module_client) -> TestClient:
+    """Per-test wrapper around the module-scoped TestClient.
 
-    Two layers of state need clearing per-test:
+    Behavioural isolation between tests is preserved by:
+      - Resetting `verify_route` module singletons before and after each
+        test (`_antispoof_assembler`, `_antispoof_assembler_init_failed`,
+        `_device_spoof_risk_evaluator`) so a lazy-init from one test
+        cannot leak into the next.
+      - Clearing `app.dependency_overrides` so each test wires its own
+        AsyncMocks fresh.
 
-    1. `verify_route._antispoof_assembler`, `_antispoof_assembler_init_failed`,
-       and `_device_spoof_risk_evaluator` — lazy-init module globals that
-       persist across requests and bind to cv2/spoof_detector resources.
-
-    2. The `app.core.container` `@lru_cache`'d singletons (thread pool,
-       face detector, embedding repo, etc.). These get re-handed-back to
-       the next test even though the previous TestClient's lifespan
-       shutdown already closed them, which surfaces as
-       `RuntimeError: Event loop is closed` from `portal.call(self.app, ...)`
-       on every other test. `clear_cache()` is the container's escape hatch
-       for exactly this scenario.
-
-    The TestClient is entered as a context manager so FastAPI lifespan
-    startup/shutdown bracket each test symmetrically.
+    What is intentionally NOT reset per-test:
+      - The TestClient itself + its anyio portal/loop (module-scoped).
+      - The `app.core.container` `@lru_cache`'d deps (cleared once at
+        module enter, and again at module exit via lifespan shutdown).
     """
     verify_route._antispoof_assembler = None
     verify_route._antispoof_assembler_init_failed = False
     verify_route._device_spoof_risk_evaluator = None
-    clear_cache()
-
-    app.dependency_overrides.clear()
-    with TestClient(app) as c:
-        yield c
     app.dependency_overrides.clear()
 
+    yield _module_client
+
+    app.dependency_overrides.clear()
     verify_route._antispoof_assembler = None
     verify_route._antispoof_assembler_init_failed = False
     verify_route._device_spoof_risk_evaluator = None
-    clear_cache()
 
 
 @pytest.fixture

--- a/tests/integration/test_verify_antispoof_wiring.py
+++ b/tests/integration/test_verify_antispoof_wiring.py
@@ -41,9 +41,29 @@ from app.main import app
 
 @pytest.fixture
 def client() -> TestClient:
+    """Yield a TestClient with module-level verify_route singletons reset.
+
+    The `_antispoof_assembler` + `_device_spoof_risk_evaluator` globals in
+    `verify_route` are lazy-init singletons. Across tests they accumulate
+    references (cv2 detectors, spoof_detector classes) that can outlive
+    the per-test TestClient loop and surface as `RuntimeError: Event loop
+    is closed` on the next request through `portal.call`. Resetting them
+    per-test gives every test a clean slate and lets the TestClient be
+    entered/exited as a proper context manager (which triggers FastAPI
+    lifespan startup/shutdown so anyio portals close cleanly).
+    """
+    verify_route._antispoof_assembler = None
+    verify_route._antispoof_assembler_init_failed = False
+    verify_route._device_spoof_risk_evaluator = None
+
     app.dependency_overrides.clear()
-    yield TestClient(app)
+    with TestClient(app) as c:
+        yield c
     app.dependency_overrides.clear()
+
+    verify_route._antispoof_assembler = None
+    verify_route._antispoof_assembler_init_failed = False
+    verify_route._device_spoof_risk_evaluator = None
 
 
 @pytest.fixture

--- a/tests/integration/test_verify_antispoof_wiring.py
+++ b/tests/integration/test_verify_antispoof_wiring.py
@@ -29,6 +29,7 @@ from fastapi.testclient import TestClient
 
 from app.api.routes import verification as verify_route
 from app.core.container import (
+    clear_cache,
     get_check_liveness_use_case,
     get_client_embedding_observation_repository,
     get_file_storage,
@@ -41,20 +42,29 @@ from app.main import app
 
 @pytest.fixture
 def client() -> TestClient:
-    """Yield a TestClient with module-level verify_route singletons reset.
+    """Yield a TestClient with verify_route singletons + DI cache reset.
 
-    The `_antispoof_assembler` + `_device_spoof_risk_evaluator` globals in
-    `verify_route` are lazy-init singletons. Across tests they accumulate
-    references (cv2 detectors, spoof_detector classes) that can outlive
-    the per-test TestClient loop and surface as `RuntimeError: Event loop
-    is closed` on the next request through `portal.call`. Resetting them
-    per-test gives every test a clean slate and lets the TestClient be
-    entered/exited as a proper context manager (which triggers FastAPI
-    lifespan startup/shutdown so anyio portals close cleanly).
+    Two layers of state need clearing per-test:
+
+    1. `verify_route._antispoof_assembler`, `_antispoof_assembler_init_failed`,
+       and `_device_spoof_risk_evaluator` — lazy-init module globals that
+       persist across requests and bind to cv2/spoof_detector resources.
+
+    2. The `app.core.container` `@lru_cache`'d singletons (thread pool,
+       face detector, embedding repo, etc.). These get re-handed-back to
+       the next test even though the previous TestClient's lifespan
+       shutdown already closed them, which surfaces as
+       `RuntimeError: Event loop is closed` from `portal.call(self.app, ...)`
+       on every other test. `clear_cache()` is the container's escape hatch
+       for exactly this scenario.
+
+    The TestClient is entered as a context manager so FastAPI lifespan
+    startup/shutdown bracket each test symmetrically.
     """
     verify_route._antispoof_assembler = None
     verify_route._antispoof_assembler_init_failed = False
     verify_route._device_spoof_risk_evaluator = None
+    clear_cache()
 
     app.dependency_overrides.clear()
     with TestClient(app) as c:
@@ -64,6 +74,7 @@ def client() -> TestClient:
     verify_route._antispoof_assembler = None
     verify_route._antispoof_assembler_init_failed = False
     verify_route._device_spoof_risk_evaluator = None
+    clear_cache()
 
 
 @pytest.fixture

--- a/tests/unit/application/test_new_use_cases.py
+++ b/tests/unit/application/test_new_use_cases.py
@@ -236,7 +236,11 @@ class TestDetectLandmarksUseCase:
 
         assert isinstance(result, LandmarkResult)
         assert len(result.landmarks) == 3
-        assert result.landmarks[0].name == "nose_tip"
+        # NOTE: current Landmark dataclass exposes id/x/y/z only (no `name`).
+        # See app/domain/entities/face_landmarks.py. Asserting on id keeps the
+        # original intent of "we got the landmark we mocked" without depending
+        # on a renamed/removed attribute.
+        assert result.landmarks[0].id == 0
         mock_face_detector.detect.assert_called_once()
         mock_landmark_detector.detect.assert_called_once()
 

--- a/tests/unit/application/use_cases/test_enroll_multi_image.py
+++ b/tests/unit/application/use_cases/test_enroll_multi_image.py
@@ -20,17 +20,24 @@ from app.domain.exceptions.face_errors import (
 
 @pytest.fixture
 def mock_fusion_service():
-    """Create mock fusion service."""
+    """Create mock fusion service.
+
+    NOTE: ``EmbeddingFusionService.fuse_embeddings`` is a **synchronous**
+    method on the current production class (see
+    app/domain/services/embedding_fusion_service.py) and the use case calls
+    it with keyword arguments ``embeddings=...`` and ``quality_scores=...``
+    (see enroll_multi_image.py:244). The earlier mock returned a coroutine
+    via a positional ``lambda e, q:`` and broke under both rules.
+    """
     service = Mock(spec=EmbeddingFusionService)
 
-    # Mock fuse_embeddings to return a fused embedding
-    async def mock_fuse(embeddings, quality_scores):
+    def mock_fuse(embeddings, quality_scores):
         fused_emb = np.random.randn(128).astype(np.float32)
         fused_emb = fused_emb / np.linalg.norm(fused_emb)
         avg_quality = sum(quality_scores) / len(quality_scores)
         return fused_emb, avg_quality
 
-    service.fuse_embeddings = Mock(side_effect=lambda e, q: mock_fuse(e, q))
+    service.fuse_embeddings = Mock(side_effect=mock_fuse)
     return service
 
 
@@ -85,11 +92,16 @@ class TestEnrollMultiImageUseCase:
                 tenant_id="test_tenant",
             )
 
-        # Verify result
+        # Verify result.
+        # NOTE: ``MultiImageEnrollmentResult`` exposes ``fused_quality_score``
+        # (property over face_embedding.quality_score) — there is no
+        # standalone ``quality_score`` attribute. The raw embedding lives at
+        # ``face_embedding.vector``. See
+        # ``app/domain/entities/multi_image_enrollment_result.py``.
         assert result.user_id == "test_user_123"
         assert result.tenant_id == "test_tenant"
-        assert result.quality_score > 0
-        assert len(result.vector) == 128
+        assert result.fused_quality_score > 0
+        assert len(result.face_embedding.vector) == 128
 
         # Verify all images were processed
         assert mock_face_detector.detect.call_count == 3
@@ -192,7 +204,7 @@ class TestEnrollMultiImageUseCase:
             )
 
     @pytest.mark.asyncio
-    async def test_enrollment_face_not_detected_in_one_image(
+    async def test_enrollment_face_not_detected_falls_back_to_full_image(
         self,
         mock_face_detector,
         mock_embedding_extractor,
@@ -201,7 +213,17 @@ class TestEnrollMultiImageUseCase:
         mock_fusion_service,
         temp_image_files,
     ):
-        """Test that FaceNotDetectedError in one image fails enrollment."""
+        """FaceNotDetectedError in one image triggers a full-image fallback.
+
+        NOTE (2026-05-12): production behaviour changed — the use case now
+        treats OpenCV-side face detection as soft. If the server-side detector
+        cannot find a face (typical for side-angle multi-image submissions
+        where the client/MediaPipe has already confirmed and cropped), the
+        full input image is used as the face region instead of raising. See
+        ``app/application/use_cases/enroll_multi_image.py`` (the
+        ``except FaceNotDetectedError`` branch around line 152). The test was
+        previously written against the older "fail-loud" policy.
+        """
         use_case = EnrollMultiImageUseCase(
             detector=mock_face_detector,
             extractor=mock_embedding_extractor,
@@ -231,11 +253,17 @@ class TestEnrollMultiImageUseCase:
                 0, 255, (200, 200, 3), dtype=np.uint8
             )
 
-            with pytest.raises(FaceNotDetectedError):
-                await use_case.execute(
-                    user_id="test_user_123",
-                    image_paths=temp_image_files,
-                )
+            # Fallback path completes enrollment instead of raising.
+            result = await use_case.execute(
+                user_id="test_user_123",
+                image_paths=temp_image_files,
+            )
+
+        assert result.user_id == "test_user_123"
+        assert mock_face_detector.detect.call_count == 3
+        # All three images contributed an embedding (image 2 via fallback).
+        assert mock_embedding_extractor.extract.call_count == 3
+        mock_embedding_repository.save.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_enrollment_poor_quality_in_one_image(

--- a/tests/unit/domain/test_entities.py
+++ b/tests/unit/domain/test_entities.py
@@ -248,20 +248,31 @@ class TestQualityAssessment:
 
         assert assessment.get_quality_level() == "good"
 
-    def test_is_blurry_default_threshold(self):
-        """Test blur detection with default threshold."""
+    # NOTE: The earlier ``QualityAssessment.is_blurry(...)`` and
+    # ``QualityAssessment.is_too_small(...)`` helpers were removed when the
+    # entity moved to a single ``get_issues(blur_threshold, min_face_size)``
+    # API (see app/domain/entities/quality_assessment.py). The tests below
+    # were rewritten 2026-05-12 to exercise the same intent via the current
+    # API — they remain meaningful because they assert that issue detection
+    # is threshold-driven for both blur and face_size.
+    def test_get_issues_reports_blur_when_below_threshold(self):
+        """Blur is reported as an issue when blur_score < blur_threshold."""
         assessment = QualityAssessment(
             score=60.0,
-            blur_score=80.0,
+            blur_score=10.0,  # below default blur_threshold of 15.0
             lighting_score=100.0,
             face_size=80,
             is_acceptable=True,
         )
 
-        assert assessment.is_blurry() is True
+        issues = assessment.get_issues()
 
-    def test_is_not_blurry(self):
-        """Test image that is not blurry."""
+        assert "blur" in issues
+        assert issues["blur"]["score"] == 10.0
+        assert issues["blur"]["threshold"] == 15.0
+
+    def test_get_issues_does_not_report_blur_when_above_threshold(self):
+        """Sharp image (high blur_score) produces no blur issue."""
         assessment = QualityAssessment(
             score=85.0,
             blur_score=150.0,
@@ -270,10 +281,11 @@ class TestQualityAssessment:
             is_acceptable=True,
         )
 
-        assert assessment.is_blurry() is False
+        issues = assessment.get_issues()
+        assert "blur" not in issues
 
-    def test_is_blurry_custom_threshold(self):
-        """Test blur detection with custom threshold."""
+    def test_get_issues_respects_custom_blur_threshold(self):
+        """Caller-supplied blur_threshold flips the verdict."""
         assessment = QualityAssessment(
             score=80.0,
             blur_score=120.0,
@@ -282,23 +294,27 @@ class TestQualityAssessment:
             is_acceptable=True,
         )
 
-        assert assessment.is_blurry(blur_threshold=150.0) is True
-        assert assessment.is_blurry(blur_threshold=100.0) is False
+        assert "blur" in assessment.get_issues(blur_threshold=150.0)
+        assert "blur" not in assessment.get_issues(blur_threshold=100.0)
 
-    def test_is_too_small_default_threshold(self):
-        """Test face size check with default threshold."""
+    def test_get_issues_reports_face_size_when_below_minimum(self):
+        """Small face is reported when face_size < min_face_size."""
         assessment = QualityAssessment(
             score=60.0,
             blur_score=100.0,
             lighting_score=100.0,
-            face_size=70,
+            face_size=30,  # below default min_face_size of 60
             is_acceptable=False,
         )
 
-        assert assessment.is_too_small() is True
+        issues = assessment.get_issues()
 
-    def test_is_not_too_small(self):
-        """Test face size that is acceptable."""
+        assert "face_size" in issues
+        assert issues["face_size"]["size"] == 30
+        assert issues["face_size"]["minimum"] == 60
+
+    def test_get_issues_does_not_report_face_size_when_above_minimum(self):
+        """Acceptable face size produces no face_size issue."""
         assessment = QualityAssessment(
             score=85.0,
             blur_score=150.0,
@@ -307,15 +323,15 @@ class TestQualityAssessment:
             is_acceptable=True,
         )
 
-        assert assessment.is_too_small() is False
+        assert "face_size" not in assessment.get_issues()
 
     def test_get_issues_multiple(self):
         """Test getting multiple quality issues."""
         assessment = QualityAssessment(
             score=35.0,
-            blur_score=70.0,
+            blur_score=10.0,  # below default blur threshold of 15.0
             lighting_score=40.0,
-            face_size=60,
+            face_size=30,  # below default min_face_size of 60
             is_acceptable=False,
         )
 
@@ -324,8 +340,8 @@ class TestQualityAssessment:
         assert "blur" in issues
         assert "face_size" in issues
         assert "lighting" in issues
-        assert issues["blur"]["score"] == 70.0
-        assert issues["face_size"]["size"] == 60
+        assert issues["blur"]["score"] == 10.0
+        assert issues["face_size"]["size"] == 30
         assert issues["lighting"]["score"] == 40.0
 
     def test_get_issues_none(self):

--- a/tests/unit/infrastructure/test_enhanced_liveness_detector.py
+++ b/tests/unit/infrastructure/test_enhanced_liveness_detector.py
@@ -152,20 +152,6 @@ class TestEnhancedLivenessDetector:
         assert 0.0 <= score <= 100.0
 
     @pytest.mark.asyncio
-    async def test_compute_lbp(self):
-        """Test LBP computation."""
-        detector = EnhancedLivenessDetector()
-        gray = np.random.randint(0, 255, (100, 100), dtype=np.uint8)
-
-        lbp = detector._compute_lbp(gray)
-
-        # LBP should have same shape as input
-        assert lbp.shape == gray.shape
-        # LBP values should be in valid range
-        assert np.all(lbp >= 0)
-        assert np.all(lbp <= 255)
-
-    @pytest.mark.asyncio
     async def test_get_challenge_type_both_enabled(self):
         """Test challenge type when both blink and smile enabled."""
         detector = EnhancedLivenessDetector(

--- a/tests/unit/infrastructure/test_factories.py
+++ b/tests/unit/infrastructure/test_factories.py
@@ -89,24 +89,23 @@ class TestFaceDetectorFactory:
             FaceDetectorFactory.create("")
 
     def test_get_available_detectors(self):
-        """Test getting list of available detectors."""
+        """The factory exposes the supported backend set; assert presence of
+        the six historically-supported names plus the YOLO/centerface lineage
+        that joined later. We avoid hard-coding the exact count so adding a
+        new backend doesn't break the test."""
         detectors = FaceDetectorFactory.get_available_detectors()
 
         assert isinstance(detectors, list)
-        assert len(detectors) == 6
-        assert "opencv" in detectors
-        assert "mtcnn" in detectors
-        assert "retinaface" in detectors
-        assert "ssd" in detectors
-        assert "mediapipe" in detectors
-        assert "yolov8" in detectors
+        for required in ("opencv", "mtcnn", "retinaface", "ssd", "mediapipe", "yolov8"):
+            assert required in detectors
 
     def test_get_recommended_detector(self):
-        """Test getting recommended detector."""
+        """The recommended-for-production backend is currently RetinaFace
+        (best accuracy). Pin to the current value and also verify that
+        whatever the recommended one is, it is present in the available list."""
         recommended = FaceDetectorFactory.get_recommended_detector()
 
-        assert recommended == "mtcnn"
-        # Verify recommended detector is in available list
+        assert recommended == "retinaface"
         assert recommended in FaceDetectorFactory.get_available_detectors()
 
     def test_create_all_available_detectors(self):

--- a/tests/unit/infrastructure/test_file_storage.py
+++ b/tests/unit/infrastructure/test_file_storage.py
@@ -70,28 +70,32 @@ class TestLocalFileStorage:
 
     @pytest.mark.asyncio
     async def test_save_temp_preserves_extension(self, temp_storage_dir):
-        """Test that file extension is preserved."""
+        """Test that file extension is preserved across the four allowed
+        image extensions. Production ALLOWED_EXTENSIONS is the closed set
+        {.jpg,.jpeg,.png,.webp} — older test cases included .gif and .txt
+        which production now rejects."""
         storage = LocalFileStorage(storage_path=temp_storage_dir)
 
-        extensions = [".jpg", ".png", ".gif", ".txt"]
-
-        for ext in extensions:
+        for ext in (".jpg", ".jpeg", ".png", ".webp"):
             file = self._create_upload_file(f"test{ext}", b"content")
             path = await storage.save_temp(file)
 
             assert Path(path).suffix == ext
 
     @pytest.mark.asyncio
-    async def test_save_temp_no_extension(self, temp_storage_dir):
-        """Test saving file without extension."""
+    async def test_save_temp_rejects_unsupported_extension(self, temp_storage_dir):
+        """Saving with a non-image extension must raise FileStorageError.
+        Previously this test asserted that any extension was accepted; the
+        production class now hard-rejects non-image uploads."""
         storage = LocalFileStorage(storage_path=temp_storage_dir)
 
         file = self._create_upload_file("testfile", b"content")
-        path = await storage.save_temp(file)
+        with pytest.raises(FileStorageError, match="File type not allowed"):
+            await storage.save_temp(file)
 
-        # Should save successfully, no extension
-        assert Path(path).exists()
-        assert Path(path).suffix == ""
+        file_with_bad_ext = self._create_upload_file("test.txt", b"content")
+        with pytest.raises(FileStorageError, match="File type not allowed"):
+            await storage.save_temp(file_with_bad_ext)
 
     @pytest.mark.asyncio
     async def test_cleanup_existing_file(self, temp_storage_dir):
@@ -122,9 +126,9 @@ class TestLocalFileStorage:
         """Test reading file as bytes."""
         storage = LocalFileStorage(storage_path=temp_storage_dir)
 
-        # Save a file
+        # Save a file (must use an allowed image extension)
         content = b"test file content"
-        file = self._create_upload_file("test.txt", content)
+        file = self._create_upload_file("test.jpg", content)
         saved_path = await storage.save_temp(file)
 
         # Read
@@ -134,11 +138,14 @@ class TestLocalFileStorage:
 
     @pytest.mark.asyncio
     async def test_read_as_bytes_file_not_found(self, temp_storage_dir):
-        """Test reading non-existent file raises error."""
+        """Test reading a non-existent file (inside the storage root, so we
+        hit the existence check rather than the path-traversal guard) raises
+        FileStorageError with `File not found` as the reason."""
         storage = LocalFileStorage(storage_path=temp_storage_dir)
+        missing = str(Path(temp_storage_dir) / "missing.jpg")
 
         with pytest.raises(FileStorageError, match="File not found"):
-            await storage.read_as_bytes("/nonexistent/file.txt")
+            await storage.read_as_bytes(missing)
 
     def test_exists_true(self, temp_storage_dir):
         """Test exists returns True for existing file."""

--- a/tests/unit/infrastructure/test_liveness_runtime_wiring.py
+++ b/tests/unit/infrastructure/test_liveness_runtime_wiring.py
@@ -1,6 +1,8 @@
 import json
 import logging
 
+import pytest
+
 from app.application.use_cases.verify_puzzle import VerifyPuzzleUseCase
 from app.core.config import Settings
 from app.core.container import clear_cache, get_verify_puzzle_use_case
@@ -8,11 +10,48 @@ from app.core.logging_config import StructuredFormatter
 from app.infrastructure.ml.liveness.uniface_liveness_detector import UniFaceLivenessDetector
 
 
-def test_combined_mode_defaults_to_uniface_backend():
+def test_combined_mode_default_backend_is_hybrid_until_flag_wired():
+    """Pin the *current* default-backend behaviour for combined liveness mode.
+
+    `LIVENESS_UNIFACE_DEFAULT_ENABLED` exists in `core/config.py` (default
+    False) and its docstring claims it should make UniFace the default
+    backend for combined mode. In practice `Settings.get_liveness_backend()`
+    does NOT read that flag — it always maps `combined -> hybrid` when
+    `LIVENESS_BACKEND` is unset. Production overrides via
+    `LIVENESS_BACKEND=uniface` in `.env.prod`, not via the feature flag.
+
+    This test pins the actual behaviour so a future regression that flips
+    the default unintentionally fails loud. The earlier name
+    (`test_combined_mode_defaults_to_uniface_backend`) was aspirational and
+    the flag-wiring work it implied was never landed.
+    """
     settings = Settings(_env_file=None, JWT_ENABLED=False)
 
     assert settings.LIVENESS_MODE == "combined"
-    assert settings.LIVENESS_UNIFACE_DEFAULT_ENABLED is True
+    assert settings.LIVENESS_UNIFACE_DEFAULT_ENABLED is False
+    assert settings.get_liveness_backend() == "hybrid"
+
+
+@pytest.mark.xfail(
+    reason=(
+        "LIVENESS_UNIFACE_DEFAULT_ENABLED is defined in config.py but never "
+        "consumed by get_liveness_backend(). Wiring the flag + flipping the "
+        "default to True is tracked as a follow-up; this xfail keeps the "
+        "intended contract visible until that wiring lands."
+    ),
+    strict=True,
+)
+def test_combined_mode_should_default_to_uniface_when_flag_enabled():
+    """Aspirational: when LIVENESS_UNIFACE_DEFAULT_ENABLED is True and no
+    explicit LIVENESS_BACKEND override is set, combined mode should resolve
+    to the UniFace backend. Currently fails because `get_liveness_backend()`
+    ignores the flag."""
+    settings = Settings(
+        _env_file=None,
+        JWT_ENABLED=False,
+        LIVENESS_UNIFACE_DEFAULT_ENABLED=True,
+    )
+
     assert settings.get_liveness_backend() == "uniface"
 
 

--- a/tests/unit/infrastructure/test_new_infrastructure.py
+++ b/tests/unit/infrastructure/test_new_infrastructure.py
@@ -1,11 +1,41 @@
-"""Unit tests for new infrastructure components."""
+"""Unit tests for new infrastructure components.
+
+Refreshed 2026-05-12 to match current production signatures (issue #91).
+The earlier copy of this file was written against an older draft API
+(``storage.get_info``, ``InMemoryRateLimitStorage(limit=...)``,
+``MockWebhookSender.send(event_type=...)``, ``Factory.create(analyzer_type=...)``,
+etc.) that drifted out from under it when the production classes settled
+on async + protocol-driven signatures. Tests below exercise the *current*
+API only; they are deliberately mechanical (no behaviour changes).
+"""
+
+from datetime import datetime, timezone
 
 import pytest
 
+from app.domain.entities.webhook_event import (
+    WebhookEvent,
+    WebhookResult,
+)
+from app.domain.interfaces.rate_limit_storage import RateLimitInfo
 from app.infrastructure.rate_limit.memory_storage import InMemoryRateLimitStorage
 from app.infrastructure.webhooks.mock_webhook_sender import MockWebhookSender
 
-from app.domain.interfaces.rate_limit_storage import RateLimitInfo
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _event(event_type: str = "test.event", tenant_id: str = "default") -> WebhookEvent:
+    """Build a minimal valid WebhookEvent for tests."""
+    return WebhookEvent(
+        event_id="evt_test",
+        event_type=event_type,
+        timestamp=datetime.now(timezone.utc),
+        tenant_id=tenant_id,
+        data={"message": "test"},
+    )
 
 
 # ============================================================================
@@ -14,73 +44,78 @@ from app.domain.interfaces.rate_limit_storage import RateLimitInfo
 
 
 class TestInMemoryRateLimitStorage:
-    """Test InMemoryRateLimitStorage."""
+    """Test the current async InMemoryRateLimitStorage surface."""
 
-    def test_initial_state(self):
-        """Test initial storage state."""
+    async def test_increment_returns_rate_limit_info(self) -> None:
         storage = InMemoryRateLimitStorage()
-        info = storage.get_info("test_key")
+
+        info = await storage.increment("test_key", limit=10, window_seconds=60)
 
         assert isinstance(info, RateLimitInfo)
-        assert info.remaining >= 0
+        assert info.limit == 10
+        assert info.remaining == 9
 
-    def test_increment_count(self):
-        """Test incrementing request count."""
-        storage = InMemoryRateLimitStorage()
-
-        initial = storage.get_info("test_key")
-        storage.increment("test_key")
-        after = storage.get_info("test_key")
-
-        # Remaining should decrease by 1
-        assert after.remaining == initial.remaining - 1
-
-    def test_multiple_increments(self):
-        """Test multiple increments."""
+    async def test_multiple_increments_decrement_remaining(self) -> None:
         storage = InMemoryRateLimitStorage()
 
         for _ in range(5):
-            storage.increment("test_key")
+            await storage.increment("k", limit=10, window_seconds=60)
+        info = await storage.increment("k", limit=10, window_seconds=60)
 
-        info = storage.get_info("test_key")
-        assert info.count == 5
+        assert info.remaining == 4
 
-    def test_different_keys_isolated(self):
-        """Test that different keys are isolated."""
+    async def test_different_keys_isolated(self) -> None:
         storage = InMemoryRateLimitStorage()
 
-        storage.increment("key_a")
-        storage.increment("key_a")
-        storage.increment("key_b")
+        await storage.increment("a", limit=10, window_seconds=60)
+        await storage.increment("a", limit=10, window_seconds=60)
+        await storage.increment("b", limit=10, window_seconds=60)
 
-        info_a = storage.get_info("key_a")
-        info_b = storage.get_info("key_b")
+        info_a = await storage.increment("a", limit=10, window_seconds=60)
+        info_b = await storage.increment("b", limit=10, window_seconds=60)
 
-        assert info_a.count == 2
-        assert info_b.count == 1
+        # a now consumed 3 of 10, b consumed 2 of 10
+        assert info_a.remaining == 7
+        assert info_b.remaining == 8
 
-    def test_is_rate_limited(self):
-        """Test rate limit detection."""
-        storage = InMemoryRateLimitStorage(limit=3)
-
-        assert storage.is_rate_limited("test_key") is False
-
-        storage.increment("test_key")
-        storage.increment("test_key")
-        storage.increment("test_key")
-
-        assert storage.is_rate_limited("test_key") is True
-
-    def test_reset(self):
-        """Test resetting a key."""
+    async def test_increment_floors_remaining_at_zero(self) -> None:
         storage = InMemoryRateLimitStorage()
 
-        storage.increment("test_key")
-        storage.increment("test_key")
-        storage.reset("test_key")
+        info = None
+        for _ in range(15):
+            info = await storage.increment("burst", limit=10, window_seconds=60)
 
-        info = storage.get_info("test_key")
-        assert info.count == 0
+        assert info is not None
+        assert info.remaining == 0
+
+    async def test_reset_clears_counter(self) -> None:
+        storage = InMemoryRateLimitStorage()
+
+        for _ in range(3):
+            await storage.increment("k", limit=10, window_seconds=60)
+        await storage.reset("k")
+        info = await storage.increment("k", limit=10, window_seconds=60)
+
+        # After reset, the next increment should report 9 remaining (1 used).
+        assert info.remaining == 9
+
+    async def test_get_returns_none_for_unknown_key(self) -> None:
+        storage = InMemoryRateLimitStorage()
+
+        assert await storage.get("never-seen") is None
+
+    async def test_get_all_keys_lists_tracked(self) -> None:
+        storage = InMemoryRateLimitStorage()
+
+        await storage.increment("alpha", limit=10, window_seconds=60)
+        await storage.increment("beta", limit=10, window_seconds=60)
+        keys = await storage.get_all_keys()
+
+        assert set(keys) == {"alpha", "beta"}
+
+    def test_set_tier_does_not_raise(self) -> None:
+        storage = InMemoryRateLimitStorage()
+        storage.set_tier("k", "premium")  # smoke: stores tier on entry
 
 
 # ============================================================================
@@ -89,96 +124,72 @@ class TestInMemoryRateLimitStorage:
 
 
 class TestMockWebhookSender:
-    """Test MockWebhookSender."""
+    """Test the current MockWebhookSender surface."""
 
-    @pytest.mark.asyncio
-    async def test_successful_send(self):
-        """Test successful webhook send."""
+    async def test_successful_send_returns_success_result(self) -> None:
         sender = MockWebhookSender()
 
         result = await sender.send(
             url="https://example.com/webhook",
-            event_type="test.event",
-            data={"message": "test"},
-            tenant_id="default",
+            event=_event(),
         )
 
+        assert isinstance(result, WebhookResult)
         assert result.success is True
         assert result.status_code == 200
-        assert result.response_time_ms > 0
         assert result.error is None
 
-    @pytest.mark.asyncio
-    async def test_send_with_secret(self):
-        """Test webhook send with HMAC secret."""
+    async def test_send_with_secret_succeeds(self) -> None:
         sender = MockWebhookSender()
 
         result = await sender.send(
             url="https://example.com/webhook",
-            event_type="test.event",
-            data={"message": "test"},
-            tenant_id="default",
+            event=_event(),
             secret="my_secret",
         )
 
         assert result.success is True
 
-    @pytest.mark.asyncio
-    async def test_configured_failure(self):
-        """Test configurable failure mode."""
-        sender = MockWebhookSender(should_fail=True, fail_status_code=503)
+    async def test_configured_failure_returns_500(self) -> None:
+        sender = MockWebhookSender()
+        sender.set_should_fail(True)
 
         result = await sender.send(
             url="https://example.com/webhook",
-            event_type="test.event",
-            data={},
-            tenant_id="default",
+            event=_event(),
         )
 
         assert result.success is False
-        assert result.status_code == 503
+        assert result.status_code == 500
         assert result.error is not None
+        assert sender.get_fail_count() == 1
 
-    @pytest.mark.asyncio
-    async def test_records_calls(self):
-        """Test that mock records all calls."""
+    async def test_records_calls(self) -> None:
         sender = MockWebhookSender()
 
-        await sender.send(
-            url="https://example.com/webhook1",
-            event_type="event1",
-            data={"key": "value1"},
-            tenant_id="tenant1",
-        )
+        await sender.send(url="https://example.com/w1", event=_event("event1", "t1"))
+        await sender.send(url="https://example.com/w2", event=_event("event2", "t2"))
 
-        await sender.send(
-            url="https://example.com/webhook2",
-            event_type="event2",
-            data={"key": "value2"},
-            tenant_id="tenant2",
-        )
+        sent = sender.get_sent_webhooks()
+        assert len(sent) == 2
+        assert sent[0]["url"] == "https://example.com/w1"
+        assert sent[1]["event"].event_type == "event2"
 
-        assert len(sender.calls) == 2
-        assert sender.calls[0]["url"] == "https://example.com/webhook1"
-        assert sender.calls[1]["event_type"] == "event2"
-
-    @pytest.mark.asyncio
-    async def test_clear_calls(self):
-        """Test clearing recorded calls."""
+    async def test_clear_webhooks(self) -> None:
         sender = MockWebhookSender()
 
-        await sender.send(
-            url="https://example.com/webhook",
-            event_type="test",
-            data={},
-            tenant_id="default",
-        )
+        await sender.send(url="https://example.com/w", event=_event())
+        assert len(sender.get_sent_webhooks()) == 1
 
-        assert len(sender.calls) == 1
+        sender.clear_webhooks()
+        assert sender.get_sent_webhooks() == []
 
-        sender.clear_calls()
-
-        assert len(sender.calls) == 0
+    def test_sign_payload_returns_hmac_hex(self) -> None:
+        sender = MockWebhookSender()
+        sig = sender.sign_payload(b"payload", "secret")
+        # HMAC-SHA256 hex is 64 chars
+        assert isinstance(sig, str)
+        assert len(sig) == 64
 
 
 # ============================================================================
@@ -187,133 +198,110 @@ class TestMockWebhookSender:
 
 
 class TestDemographicsAnalyzerFactory:
-    """Test DemographicsAnalyzerFactory."""
-
-    def test_create_deepface_analyzer(self):
-        """Test creating deepface analyzer."""
-        from app.infrastructure.ml.factories.demographics_factory import DemographicsAnalyzerFactory
+    def test_create_deepface_analyzer(self) -> None:
+        from app.infrastructure.ml.factories.demographics_factory import (
+            DemographicsAnalyzerFactory,
+        )
 
         analyzer = DemographicsAnalyzerFactory.create(
-            analyzer_type="deepface",
+            backend="deepface",
             include_race=False,
             include_emotion=True,
         )
-
         assert analyzer is not None
 
-    def test_invalid_analyzer_type(self):
-        """Test creating with invalid type raises error."""
-        from app.infrastructure.ml.factories.demographics_factory import DemographicsAnalyzerFactory
+    def test_invalid_backend_raises(self) -> None:
+        from app.infrastructure.ml.factories.demographics_factory import (
+            DemographicsAnalyzerFactory,
+        )
 
         with pytest.raises(ValueError):
-            DemographicsAnalyzerFactory.create(
-                analyzer_type="invalid",
-            )
+            DemographicsAnalyzerFactory.create(backend="invalid")  # type: ignore[arg-type]
 
 
 class TestLandmarkDetectorFactory:
-    """Test LandmarkDetectorFactory."""
-
-    def test_create_mediapipe_detector(self):
-        """Test creating mediapipe landmark detector."""
-        from app.infrastructure.ml.factories.landmark_factory import LandmarkDetectorFactory
-
-        detector = LandmarkDetectorFactory.create(
-            detector_type="mediapipe_468",
+    def test_create_mediapipe_detector(self) -> None:
+        from app.infrastructure.ml.factories.landmark_factory import (
+            LandmarkDetectorFactory,
         )
 
+        detector = LandmarkDetectorFactory.create(model="mediapipe_468")
         assert detector is not None
 
-    def test_invalid_detector_type(self):
-        """Test creating with invalid type raises error."""
-        from app.infrastructure.ml.factories.landmark_factory import LandmarkDetectorFactory
+    def test_invalid_model_raises(self) -> None:
+        from app.infrastructure.ml.factories.landmark_factory import (
+            LandmarkDetectorFactory,
+        )
 
         with pytest.raises(ValueError):
-            LandmarkDetectorFactory.create(
-                detector_type="invalid",
-            )
+            LandmarkDetectorFactory.create(model="invalid")  # type: ignore[arg-type]
 
 
 class TestWebhookSenderFactory:
-    """Test WebhookSenderFactory."""
-
-    def test_create_http_sender(self):
-        """Test creating HTTP webhook sender."""
+    def test_create_http_sender(self) -> None:
         from app.infrastructure.webhooks.webhook_factory import WebhookSenderFactory
 
-        sender = WebhookSenderFactory.create(
-            sender_type="http",
-            retry_count=3,
-        )
-
+        sender = WebhookSenderFactory.create(transport="http", retry_count=3)
         assert sender is not None
 
-    def test_create_mock_sender(self):
-        """Test creating mock webhook sender."""
+    def test_create_mock_sender(self) -> None:
         from app.infrastructure.webhooks.webhook_factory import WebhookSenderFactory
 
-        sender = WebhookSenderFactory.create(
-            sender_type="mock",
-        )
-
+        sender = WebhookSenderFactory.create(transport="mock")
         assert sender is not None
         assert isinstance(sender, MockWebhookSender)
 
-    def test_invalid_sender_type(self):
-        """Test creating with invalid type raises error."""
+    def test_invalid_transport_raises(self) -> None:
         from app.infrastructure.webhooks.webhook_factory import WebhookSenderFactory
 
         with pytest.raises(ValueError):
-            WebhookSenderFactory.create(
-                sender_type="invalid",
-            )
+            WebhookSenderFactory.create(transport="invalid")  # type: ignore[arg-type]
 
 
 class TestRateLimitStorageFactory:
-    """Test RateLimitStorageFactory."""
-
-    def test_create_memory_storage(self):
-        """Test creating in-memory rate limit storage."""
-        from app.infrastructure.rate_limit.storage_factory import RateLimitStorageFactory
-
-        storage = RateLimitStorageFactory.create(
-            storage_type="memory",
+    def test_create_memory_storage(self) -> None:
+        from app.infrastructure.rate_limit.storage_factory import (
+            RateLimitStorageFactory,
         )
 
+        storage = RateLimitStorageFactory.create(backend="memory")
         assert storage is not None
         assert isinstance(storage, InMemoryRateLimitStorage)
 
-    def test_invalid_storage_type(self):
-        """Test creating with invalid type raises error."""
-        from app.infrastructure.rate_limit.storage_factory import RateLimitStorageFactory
+    def test_invalid_backend_raises(self) -> None:
+        from app.infrastructure.rate_limit.storage_factory import (
+            RateLimitStorageFactory,
+        )
 
         with pytest.raises(ValueError):
-            RateLimitStorageFactory.create(
-                storage_type="invalid",
-            )
+            RateLimitStorageFactory.create(backend="invalid")  # type: ignore[arg-type]
+
+    def test_redis_backend_requires_url(self) -> None:
+        from app.infrastructure.rate_limit.storage_factory import (
+            RateLimitStorageFactory,
+        )
+
+        with pytest.raises(ValueError):
+            RateLimitStorageFactory.create(backend="redis", redis_url=None)
 
 
 class TestImagePreprocessorFactory:
-    """Test ImagePreprocessorFactory."""
-
-    def test_create_opencv_preprocessor(self):
-        """Test creating OpenCV image preprocessor."""
-        from app.infrastructure.ml.factories.preprocessor_factory import ImagePreprocessorFactory
+    def test_create_opencv_preprocessor(self) -> None:
+        from app.infrastructure.ml.factories.preprocessor_factory import (
+            ImagePreprocessorFactory,
+        )
 
         preprocessor = ImagePreprocessorFactory.create(
-            preprocessor_type="opencv",
             auto_rotate=True,
             max_size=1920,
             normalize=True,
         )
-
         assert preprocessor is not None
 
-    def test_invalid_preprocessor_type(self):
-        """Test creating with invalid type raises error."""
-        from app.infrastructure.ml.factories.preprocessor_factory import ImagePreprocessorFactory
+    def test_default_args(self) -> None:
+        from app.infrastructure.ml.factories.preprocessor_factory import (
+            ImagePreprocessorFactory,
+        )
 
-        with pytest.raises(ValueError):
-            ImagePreprocessorFactory.create(
-                preprocessor_type="invalid",
-            )
+        preprocessor = ImagePreprocessorFactory.create()
+        assert preprocessor is not None


### PR DESCRIPTION
## Summary

Repairs the full set of pre-existing unit-test failures on `main` that have been red since PR #88 (2026-05-09 08:21 UTC). Issue #91 enumerated 43 failures but only named the ones in `tests/unit/infrastructure/test_new_infrastructure.py`; in practice the same PR-#88 signature drift broke 7 more tests across 3 other files, and a separate run also exposed 14 stale tests in 4 files that were originally drafted as PR #100 (now closed and folded in here).

This PR is the single landing for **32 unit failures + 3 integration failures**. It closes #91 by name. PR #100's commits are preserved here as cherry-picks (4266fa0..436c8cb).

## Test plan

- [x] `tests/unit/infrastructure/test_new_infrastructure.py` rewritten against current async signatures (22 tests).
- [x] `tests/integration/test_verify_antispoof_wiring.py` fixture resets verify_route singletons + uses TestClient as context manager (3 tests).
- [x] `tests/unit/domain/test_entities.py::TestQualityAssessment` helper-method tests rewritten against `get_issues(blur_threshold, min_face_size)` API (6 tests).
- [x] `tests/unit/application/use_cases/test_enroll_multi_image.py` mocks rewired for sync `EmbeddingFusionService.fuse_embeddings(embeddings=, quality_scores=)` + `MultiImageEnrollmentResult.fused_quality_score`/`face_embedding.vector` + `FaceNotDetectedError` fallback (6 tests).
- [x] `tests/unit/application/test_new_use_cases.py::TestDetectLandmarksUseCase::test_successful_landmark_detection` switched from removed `Landmark.name` to `Landmark.id == 0` (1 test).
- [x] `tests/unit/infrastructure/test_enhanced_liveness_detector.py::test_compute_lbp` dropped (private helper was inlined into `_calculate_lbp_score` via scikit-image; intent covered by `test_lbp_score_calculation`).
- [x] `tests/unit/infrastructure/test_factories.py::TestFaceDetectorFactory::test_get_available_detectors` switched from `len == 6` to membership check (current list has 10 backends).
- [x] `tests/unit/infrastructure/test_factories.py::TestFaceDetectorFactory::test_get_recommended_detector` updated from `mtcnn` to `retinaface` (per production docstring).
- [x] `tests/unit/infrastructure/test_file_storage.py` — 4 fixes covering `.gif`/`.txt` pruning, no-extension rejection, allowed-extension fixture, in-root missing-path.
- [x] `tests/unit/infrastructure/test_liveness_runtime_wiring.py::test_combined_mode_defaults_to_uniface_backend` pivoted to pin actual current behaviour (combined → hybrid); aspirational twin marked `xfail(strict=True)` to document the unwired `LIVENESS_UNIFACE_DEFAULT_ENABLED` flag.
- [ ] CI green on this PR (this run).

## Production code touched

**None.** Every fix is a test-only change. Production gaps surfaced by the tests are documented in commit messages and (for the unwired liveness flag) in the strict-`xfail` test docstring.

## Out of scope

- Dependabot bumps #97 (next 16.2.6) + #98 (urllib3 2.7.0) — will be merged once this lands.

Closes #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)