### PR TITLE
fix(tests): repair pre-existing test rot in 4 unit files (follow-up to #91)

### DIFF
--- a/tests/unit/application/test_new_use_cases.py
+++ b/tests/unit/application/test_new_use_cases.py
@@ -236,7 +236,11 @@ class TestDetectLandmarksUseCase:
 
         assert isinstance(result, LandmarkResult)
         assert len(result.landmarks) == 3
-        assert result.landmarks[0].name == "nose_tip"
+        # NOTE: current Landmark dataclass exposes id/x/y/z only (no `name`).
+        # See app/domain/entities/face_landmarks.py. Asserting on id keeps the
+        # original intent of "we got the landmark we mocked" without depending
+        # on a renamed/removed attribute.
+        assert result.landmarks[0].id == 0
         mock_face_detector.detect.assert_called_once()
         mock_landmark_detector.detect.assert_called_once()
 

--- a/tests/unit/application/use_cases/test_enroll_multi_image.py
+++ b/tests/unit/application/use_cases/test_enroll_multi_image.py
@@ -20,17 +20,24 @@ from app.domain.exceptions.face_errors import (
 
 @pytest.fixture
 def mock_fusion_service():
-    """Create mock fusion service."""
+    """Create mock fusion service.
+
+    NOTE: ``EmbeddingFusionService.fuse_embeddings`` is a **synchronous**
+    method on the current production class (see
+    app/domain/services/embedding_fusion_service.py) and the use case calls
+    it with keyword arguments ``embeddings=...`` and ``quality_scores=...``
+    (see enroll_multi_image.py:244). The earlier mock returned a coroutine
+    via a positional ``lambda e, q:`` and broke under both rules.
+    """
     service = Mock(spec=EmbeddingFusionService)
 
-    # Mock fuse_embeddings to return a fused embedding
-    async def mock_fuse(embeddings, quality_scores):
+    def mock_fuse(embeddings, quality_scores):
         fused_emb = np.random.randn(128).astype(np.float32)
         fused_emb = fused_emb / np.linalg.norm(fused_emb)
         avg_quality = sum(quality_scores) / len(quality_scores)
         return fused_emb, avg_quality
 
-    service.fuse_embeddings = Mock(side_effect=lambda e, q: mock_fuse(e, q))
+    service.fuse_embeddings = Mock(side_effect=mock_fuse)
     return service
 
 
@@ -85,11 +92,16 @@ class TestEnrollMultiImageUseCase:
                 tenant_id="test_tenant",
             )
 
-        # Verify result
+        # Verify result.
+        # NOTE: ``MultiImageEnrollmentResult`` exposes ``fused_quality_score``
+        # (property over face_embedding.quality_score) — there is no
+        # standalone ``quality_score`` attribute. The raw embedding lives at
+        # ``face_embedding.vector``. See
+        # ``app/domain/entities/multi_image_enrollment_result.py``.
         assert result.user_id == "test_user_123"
         assert result.tenant_id == "test_tenant"
-        assert result.quality_score > 0
-        assert len(result.vector) == 128
+        assert result.fused_quality_score > 0
+        assert len(result.face_embedding.vector) == 128
 
         # Verify all images were processed
         assert mock_face_detector.detect.call_count == 3
@@ -192,7 +204,7 @@ class TestEnrollMultiImageUseCase:
             )
 
     @pytest.mark.asyncio
-    async def test_enrollment_face_not_detected_in_one_image(
+    async def test_enrollment_face_not_detected_falls_back_to_full_image(
         self,
         mock_face_detector,
         mock_embedding_extractor,
@@ -201,7 +213,17 @@ class TestEnrollMultiImageUseCase:
         mock_fusion_service,
         temp_image_files,
     ):
-        """Test that FaceNotDetectedError in one image fails enrollment."""
+        """FaceNotDetectedError in one image triggers a full-image fallback.
+
+        NOTE (2026-05-12): production behaviour changed — the use case now
+        treats OpenCV-side face detection as soft. If the server-side detector
+        cannot find a face (typical for side-angle multi-image submissions
+        where the client/MediaPipe has already confirmed and cropped), the
+        full input image is used as the face region instead of raising. See
+        ``app/application/use_cases/enroll_multi_image.py`` (the
+        ``except FaceNotDetectedError`` branch around line 152). The test was
+        previously written against the older "fail-loud" policy.
+        """
         use_case = EnrollMultiImageUseCase(
             detector=mock_face_detector,
             extractor=mock_embedding_extractor,
@@ -231,11 +253,17 @@ class TestEnrollMultiImageUseCase:
                 0, 255, (200, 200, 3), dtype=np.uint8
             )
 
-            with pytest.raises(FaceNotDetectedError):
-                await use_case.execute(
-                    user_id="test_user_123",
-                    image_paths=temp_image_files,
-                )
+            # Fallback path completes enrollment instead of raising.
+            result = await use_case.execute(
+                user_id="test_user_123",
+                image_paths=temp_image_files,
+            )
+
+        assert result.user_id == "test_user_123"
+        assert mock_face_detector.detect.call_count == 3
+        # All three images contributed an embedding (image 2 via fallback).
+        assert mock_embedding_extractor.extract.call_count == 3
+        mock_embedding_repository.save.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_enrollment_poor_quality_in_one_image(

--- a/tests/unit/domain/test_entities.py
+++ b/tests/unit/domain/test_entities.py
@@ -248,20 +248,31 @@ class TestQualityAssessment:
 
         assert assessment.get_quality_level() == "good"
 
-    def test_is_blurry_default_threshold(self):
-        """Test blur detection with default threshold."""
+    # NOTE: The earlier ``QualityAssessment.is_blurry(...)`` and
+    # ``QualityAssessment.is_too_small(...)`` helpers were removed when the
+    # entity moved to a single ``get_issues(blur_threshold, min_face_size)``
+    # API (see app/domain/entities/quality_assessment.py). The tests below
+    # were rewritten 2026-05-12 to exercise the same intent via the current
+    # API — they remain meaningful because they assert that issue detection
+    # is threshold-driven for both blur and face_size.
+    def test_get_issues_reports_blur_when_below_threshold(self):
+        """Blur is reported as an issue when blur_score < blur_threshold."""
         assessment = QualityAssessment(
             score=60.0,
-            blur_score=80.0,
+            blur_score=10.0,  # below default blur_threshold of 15.0
             lighting_score=100.0,
             face_size=80,
             is_acceptable=True,
         )
 
-        assert assessment.is_blurry() is True
+        issues = assessment.get_issues()
 
-    def test_is_not_blurry(self):
-        """Test image that is not blurry."""
+        assert "blur" in issues
+        assert issues["blur"]["score"] == 10.0
+        assert issues["blur"]["threshold"] == 15.0
+
+    def test_get_issues_does_not_report_blur_when_above_threshold(self):
+        """Sharp image (high blur_score) produces no blur issue."""
         assessment = QualityAssessment(
             score=85.0,
             blur_score=150.0,
@@ -270,10 +281,11 @@ class TestQualityAssessment:
             is_acceptable=True,
         )
 
-        assert assessment.is_blurry() is False
+        issues = assessment.get_issues()
+        assert "blur" not in issues
 
-    def test_is_blurry_custom_threshold(self):
-        """Test blur detection with custom threshold."""
+    def test_get_issues_respects_custom_blur_threshold(self):
+        """Caller-supplied blur_threshold flips the verdict."""
         assessment = QualityAssessment(
             score=80.0,
             blur_score=120.0,
@@ -282,23 +294,27 @@ class TestQualityAssessment:
             is_acceptable=True,
         )
 
-        assert assessment.is_blurry(blur_threshold=150.0) is True
-        assert assessment.is_blurry(blur_threshold=100.0) is False
+        assert "blur" in assessment.get_issues(blur_threshold=150.0)
+        assert "blur" not in assessment.get_issues(blur_threshold=100.0)
 
-    def test_is_too_small_default_threshold(self):
-        """Test face size check with default threshold."""
+    def test_get_issues_reports_face_size_when_below_minimum(self):
+        """Small face is reported when face_size < min_face_size."""
         assessment = QualityAssessment(
             score=60.0,
             blur_score=100.0,
             lighting_score=100.0,
-            face_size=70,
+            face_size=30,  # below default min_face_size of 60
             is_acceptable=False,
         )
 
-        assert assessment.is_too_small() is True
+        issues = assessment.get_issues()
 
-    def test_is_not_too_small(self):
-        """Test face size that is acceptable."""
+        assert "face_size" in issues
+        assert issues["face_size"]["size"] == 30
+        assert issues["face_size"]["minimum"] == 60
+
+    def test_get_issues_does_not_report_face_size_when_above_minimum(self):
+        """Acceptable face size produces no face_size issue."""
         assessment = QualityAssessment(
             score=85.0,
             blur_score=150.0,
@@ -307,15 +323,15 @@ class TestQualityAssessment:
             is_acceptable=True,
         )
 
-        assert assessment.is_too_small() is False
+        assert "face_size" not in assessment.get_issues()
 
     def test_get_issues_multiple(self):
         """Test getting multiple quality issues."""
         assessment = QualityAssessment(
             score=35.0,
-            blur_score=70.0,
+            blur_score=10.0,  # below default blur threshold of 15.0
             lighting_score=40.0,
-            face_size=60,
+            face_size=30,  # below default min_face_size of 60
             is_acceptable=False,
         )
 
@@ -324,8 +340,8 @@ class TestQualityAssessment:
         assert "blur" in issues
         assert "face_size" in issues
         assert "lighting" in issues
-        assert issues["blur"]["score"] == 70.0
-        assert issues["face_size"]["size"] == 60
+        assert issues["blur"]["score"] == 10.0
+        assert issues["face_size"]["size"] == 30
         assert issues["lighting"]["score"] == 40.0
 
     def test_get_issues_none(self):

--- a/tests/unit/infrastructure/test_enhanced_liveness_detector.py
+++ b/tests/unit/infrastructure/test_enhanced_liveness_detector.py
@@ -152,20 +152,6 @@ class TestEnhancedLivenessDetector:
         assert 0.0 <= score <= 100.0
 
     @pytest.mark.asyncio
-    async def test_compute_lbp(self):
-        """Test LBP computation."""
-        detector = EnhancedLivenessDetector()
-        gray = np.random.randint(0, 255, (100, 100), dtype=np.uint8)
-
-        lbp = detector._compute_lbp(gray)
-
-        # LBP should have same shape as input
-        assert lbp.shape == gray.shape
-        # LBP values should be in valid range
-        assert np.all(lbp >= 0)
-        assert np.all(lbp <= 255)
-
-    @pytest.mark.asyncio
     async def test_get_challenge_type_both_enabled(self):
         """Test challenge type when both blink and smile enabled."""
         detector = EnhancedLivenessDetector(


### PR DESCRIPTION
## Summary

Follow-up to issue #91 and PR #99. The earlier triage in #91 enumerated only the failures in `tests/unit/infrastructure/test_new_infrastructure.py` (22 tests, fixed in #99). A re-run of the full unit suite against `main` surfaced **14 more failures** in four unrelated test files — same root cause: the tests were written against older production API signatures and never refreshed when those signatures drifted.

This PR is **test-only**. No production code under `app/` was touched.

## Files fixed

### 1. `tests/unit/domain/test_entities.py` — 6 failures
`QualityAssessment.is_blurry(blur_threshold)` and `is_too_small(min_size)` helper methods were removed when the entity moved to a single threshold-driven `get_issues(blur_threshold, min_face_size)` API (see `app/domain/entities/quality_assessment.py`). Rewrote `test_is_blurry_*`, `test_is_too_small_*`, `test_is_not_blurry`, `test_is_not_too_small`, and `test_get_issues_multiple` against `get_issues()` while preserving the original intent (threshold-driven verdicts that flip with caller-supplied thresholds). Stale values from the old defaults (100.0 / 80) were corrected to the current defaults (15.0 / 60).

### 2. `tests/unit/application/use_cases/test_enroll_multi_image.py` — 6 failures
Three independent drifts:
- `EmbeddingFusionService.fuse_embeddings` is **synchronous** and is invoked via keyword arguments (`embeddings=..., quality_scores=...`). The mock fixture wrapped it in an async coroutine and used a positional `lambda e, q:` that rejected the kwargs. Switched to a plain sync function.
- `MultiImageEnrollmentResult` exposes `fused_quality_score` (no `quality_score`) and the raw embedding lives at `face_embedding.vector` (no top-level `vector`). Assertions in `test_successful_multi_image_enrollment` updated.
- When server-side face detection raises `FaceNotDetectedError` for one image, the use case now **falls back** to using the full image as the face region (typical for side-angle multi-image submissions where the client/MediaPipe already cropped) — see the `except FaceNotDetectedError` branch around `enroll_multi_image.py:152`. Rewrote `test_enrollment_face_not_detected_in_one_image` → `test_enrollment_face_not_detected_falls_back_to_full_image` to assert the new behaviour.

### 3. `tests/unit/application/test_new_use_cases.py` — 1 failure
`test_successful_landmark_detection` asserted `result.landmarks[0].name == "nose_tip"`, but the current `Landmark` dataclass (`app/domain/entities/face_landmarks.py`) exposes only `id, x, y, z` — no `name`. Switched to asserting on `id`.

### 4. `tests/unit/infrastructure/test_enhanced_liveness_detector.py` — 1 failure
`test_compute_lbp` exercised a private `_compute_lbp(gray)` helper that no longer exists. The class was deliberately refactored to delegate LBP computation directly to scikit-image's optimized `local_binary_pattern` inside `_calculate_lbp_score` (5-10x speed-up, see class docstring). The test's intent is already covered by `test_lbp_score_calculation`, so the obsolete test was removed cleanly.

## Why this is a follow-up to #91, not part of #99

Issue #91 enumerated only `test_new_infrastructure.py` failures. PR #99 (`fix/ci-stale-tests-and-asyncio-fixture`) fixed those plus a separate event-loop issue in `tests/integration/test_verify_antispoof_wiring.py`. The 14 failures repaired here are in four files PR #99 does not touch. Same root cause though — test files written against older API signatures that drifted out from under them. Treating as a clean follow-up keeps the diff reviewable.

## Verification

```
$ pytest tests/unit/domain/test_entities.py tests/unit/application/test_new_use_cases.py tests/unit/application/use_cases/test_enroll_multi_image.py tests/unit/infrastructure/test_enhanced_liveness_detector.py
====================== 137 passed, 113 warnings in 1.67s =======================
```

Full unit suite delta against `origin/main` (ignoring the three pre-existing module-level collection errors and the 29 failures in `test_new_infrastructure.py` already addressed by PR #99): **+14 passing**.

## Test plan

- [ ] CI green on `fix/pre-existing-test-rot`
- [ ] No production code under `app/` touched (verify with `git diff main -- app/` returning empty)
- [ ] Coexists cleanly with PR #99 — no overlapping files

Branched from `main` (NOT from `fix/ci-stale-tests-and-asyncio-fixture`).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>