### PR TITLE
docs: refresh stale config/model/endpoint claims (freshness audit 2026-05-28)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,6 +18,8 @@
 
 ## Overview
 
+> **Anti-spoof algorithm note**: The production anti-spoof pipeline (`AntispoofPipelineAssembler`, `HybridFusionEvaluator`, `FaceUsabilityGate`, EAR blink detection) is **not implemented in this repository**. These algorithms live in the external `spoof-detector` pip package, declared as a git dependency in `requirements.txt`. This repo only imports, wires, and configures them. Do not cherry-pick algorithm code directly into `biometric-processor`; changes belong in the `spoof-detector` submodule.
+
 The Biometric Processor API follows **Hexagonal Architecture** (also known as Ports and Adapters Architecture), which ensures:
 
 - **Business logic independence**: Core domain logic is isolated from technical concerns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 ## [Unreleased]
 
+### Docs — 2026-05-28 (freshness audit)
+- Corrected stale config defaults (`VERIFICATION_THRESHOLD` 0.6 → 0.45, `LIVENESS_MODE` code default vs prod override documented)
+- Added missing env vars (`FIVUCSAS_EMBEDDING_KEY`, `ANTISPOOF_BLOCK_ENFORCE`) to README and DOCKER_SETUP
+- Marked GPU-only models/backends (`ArcFace`, `VGG-Face`, `GhostFaceNet`, `retinaface`, `yolo*`) with `ALLOW_HEAVY_ML=true` requirement
+- Fixed Quick Start demo script name (`demo_local.py` → `demo_local_fast.py`)
+- Fixed API auth header (`Authorization: Bearer` → `X-API-Key`) in API_DOCUMENTATION
+- Corrected Python version references from 3.11 to 3.12
+- Fixed route module count in CLAUDE.md (17 → 27 files / 26 route modules)
+- Removed MobileFaceNet attribution from client-embedding description in CLAUDE.md
+- Corrected CLAUDE.md route references: removed non-existent `document.py` / `video_interview.py`, removed `TODO.md` reference
+- Closed voice roadmap items (fully shipped: /voice/enroll|verify|search|delete, Resemblyzer 256-dim)
+- Added anti-spoof algorithm provenance note to ARCHITECTURE.md
+- Migrated DOCKER_SETUP.md to `docker compose` v2 syntax; added prod usage section
+- Documented undocumented endpoints in README (flash-challenge, nfc, proctoring, liveness-puzzle, verification sub-paths, admin, health probes, metrics)
+- Updated copyright year 2025 → 2026
+
+## [2026-05-12] ML review — anti-spoof enforcement + EAR + verify hardening
+
+### Security / Fixes (PR #102)
+- **Anti-spoof block enforcement**: `ANTISPOOF_BLOCK_ENFORCE` (default `true`) — assembler "block" verdicts and EAR closed-eye signals now return HTTP 403 (was advisory-only).
+- **EAR veto** (`ANTISPOOF_EAR_VETO_ENABLED`, default `false`): single-frame Eye Aspect Ratio closed-eye detection on `/verify`; fails-soft when `face_landmarker.task` asset is absent.
+- **Aged-threshold inversion fix**: `VERIFICATION_THRESHOLD_AGED` default corrected from 0.38 to 0.55 (under `distance < threshold`, a lower aged threshold made aged users stricter — the opposite of intent).
+- **SHA-256 model pin**: model file integrity checked at startup.
+- **Verify-challenge endpoint** added to liveness puzzle router.
+
+## [2026-05-11] Paper P0 + blink cache + anti-spoof wiring
+
+### Features / Fixes
+- EAR/blink cache wired from `spoof-detector` package (paper P0, PR #89/#88).
+- Anti-spoof flags (`ANTISPOOF_*`) wired through to the assembler (PR #89).
+- `spoof-detector` bumped to v0.2.1; `git` added to Dockerfile so pip can fetch the git dep (PR #90).
+- NFC MRZ route exposed at `/api/v1/nfc/mrz` (PR #95).
+- Real occlusion detection + liveness contradiction policy (PR #94).
+- CI green-up: stale test repair across 7 commits (PR #99 + follow-ups).
+
+## [2026-05-07] Embedding encryption-at-rest + P0 session
+
+### Security
+- Embedding Fernet encryption-at-rest activated: `pgvector_embedding_repository` now reads/writes ciphertext column with `EmbeddingCipher.from_env()` (PR #73). `FIVUCSAS_EMBEDDING_KEY` is a hard boot requirement from this point.
+- `FIVUCSAS_EMBEDDING_KEY` wired through to runtime container in `docker-compose.prod.yml` (PR #78).
+- Live-camera analysis fail-closed when liveness detector unavailable (PR #74).
+- Anti-replay counts corrupt frames as failures (PR #76).
+- Liveness verdict policy + 413 i18n (PR #77).
+
 ### Docs — 2026-04-26 (iOS / macOS scope dropped — no-op for this repo)
 - Parent FIVUCSAS scope updated 2026-04-26 to permanently drop iOS / iPadOS / macOS (no Apple hardware available). This repo's `README.md`, `ROADMAP.md`, and `CHANGELOG.md` had no forward-looking iOS/macOS content; macOS-as-developer-environment install instructions for Redis and PostgreSQL in `README.md` are unaffected. No code or config changes required.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ pytest tests/unit/ -v           # Unit tests only
 
 ## Key Directories
 
-- `app/api/routes/` - API route handlers (17 modules)
+- `app/api/routes/` - API route handlers (27 files including `__init__.py`; 26 route modules)
 - `app/domain/` - Domain entities and interfaces
 - `app/application/use_cases/` - Business logic use cases
 - `app/infrastructure/ml/` - ML model implementations (DeepFace, MediaPipe, YOLO)
@@ -65,7 +65,7 @@ pytest tests/unit/ -v           # Unit tests only
 - **Face-to-document matching** — DeepFace cosine similarity between selfie and document photo
 - **Liveness pipeline** — server-authoritative liveness verdict with configurable thresholds
 - **Video interview upload** — endpoint for verification pipeline video step
-- Routes: `document.py`, `verification_pipeline.py`, `video_interview.py`
+- Routes: `verification_pipeline.py` (sub-paths: /document-scan, /data-extract, /face-match, /liveness-check, /pipeline/test, /video-interview)
 
 ### Not implemented:
 - **Iris**: No endpoints at all
@@ -73,7 +73,7 @@ pytest tests/unit/ -v           # Unit tests only
 ### Client Embedding Observations (Alembic 0004, log-only per D2, 2026-04-14):
 - `client_embedding_observations` table — vector(128), no HNSW (log, not search surface)
 - Populated via `BackgroundTasks` in `enrollment.py` / `verification.py` with fire-and-forget `record()`
-- NEVER used for auth decisions — offline divergence analysis only (MobileFaceNet 128-dim vs ArcFace 512-dim)
+- NEVER used for auth decisions — offline divergence analysis only (128-dim client-side model, identity opaque to server, vs ArcFace 512-dim)
 
 ## Known Issues (March 2026)
 
@@ -84,4 +84,4 @@ pytest tests/unit/ -v           # Unit tests only
 - Called by **identity-core-api** (Java/Spring on port 8080) via BiometricProcessorClient (API key auth)
 - NOT publicly accessible — all external face operations must go through identity-core-api proxy endpoints
 
-See TODO.md for full integration audit (18+ items).
+Integration audit items are tracked in GitHub issues.

--- a/DOCKER_SETUP.md
+++ b/DOCKER_SETUP.md
@@ -29,13 +29,13 @@ nano .env
 
 ```bash
 # Start core services (PostgreSQL, Redis, API)
-docker-compose up -d
+docker compose up -d
 
 # View logs
-docker-compose logs -f api
+docker compose logs -f api
 
 # Check service health
-docker-compose ps
+docker compose ps
 ```
 
 ### 3. Verify Installation
@@ -55,7 +55,7 @@ Docker Compose supports different profiles for different use cases:
 ### Core Services (Default)
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 Includes:
@@ -66,7 +66,7 @@ Includes:
 ### Development Mode
 
 ```bash
-docker-compose --profile development up -d
+docker compose --profile development up -d
 ```
 
 Includes core services plus:
@@ -75,7 +75,7 @@ Includes core services plus:
 ### With Management Tools
 
 ```bash
-docker-compose --profile tools up -d
+docker compose --profile tools up -d
 ```
 
 Includes core services plus:
@@ -85,7 +85,7 @@ Includes core services plus:
 ### With Monitoring
 
 ```bash
-docker-compose --profile monitoring up -d
+docker compose --profile monitoring up -d
 ```
 
 Includes core services plus:
@@ -95,7 +95,7 @@ Includes core services plus:
 ### All Services
 
 ```bash
-docker-compose --profile development --profile tools --profile monitoring up -d
+docker compose --profile development --profile tools --profile monitoring up -d
 ```
 
 ## Service Endpoints
@@ -124,17 +124,17 @@ To reinitialize:
 
 ```bash
 # Stop and remove volumes
-docker-compose down -v
+docker compose down -v
 
 # Start fresh
-docker-compose up -d
+docker compose up -d
 ```
 
 ### Manual Database Access
 
 ```bash
 # Connect to PostgreSQL
-docker-compose exec postgres psql -U biometric_user -d biometric_db
+docker compose exec postgres psql -U biometric_user -d biometric_db
 
 # View tables
 \dt
@@ -165,7 +165,7 @@ SELECT COUNT(*) FROM face_embeddings;
 
 ```bash
 # Connect to Redis CLI
-docker-compose exec redis redis-cli
+docker compose exec redis redis-cli
 
 # View keys
 KEYS *
@@ -210,7 +210,32 @@ CORS_ALLOWED_ORIGINS=http://localhost:3000
 # Rate Limiting
 RATE_LIMIT_ENABLED=true
 RATE_LIMIT_PER_MINUTE=60
+
+# Required in production — Fernet key for at-rest embedding encryption.
+# Container fails fast on boot if unset (EmbeddingCipher.from_env() raises).
+FIVUCSAS_EMBEDDING_KEY=<base64-fernet-key>
+FIVUCSAS_EMBEDDING_KEY_VERSION=1
+
+# Anti-spoof enforcement (default true — block verdicts return HTTP 403)
+ANTISPOOF_BLOCK_ENFORCE=true
 ```
+
+### Production Usage
+
+Use `docker compose` (v2 syntax) with a dedicated env file and the prod compose override:
+
+```bash
+# Start production stack
+docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
+
+# View logs
+docker compose -f docker-compose.prod.yml logs -f biometric-api
+
+# Rebuild image without cache
+docker compose -f docker-compose.prod.yml --env-file .env.prod build --no-cache biometric-api
+```
+
+> The prod compose file (`docker-compose.prod.yml`) enables `read_only: true` rootfs, drops all capabilities, and overrides key env vars: `LIVENESS_MODE=passive`, `LIVENESS_BACKEND=uniface`, `VERIFICATION_THRESHOLD=0.4`. Always pass `--env-file .env.prod` — never rely on shell env for secrets.
 
 ### Scaling
 
@@ -218,10 +243,10 @@ Scale API instances:
 
 ```bash
 # Scale to 3 instances
-docker-compose up -d --scale api=3
+docker compose up -d --scale api=3
 
 # Check running instances
-docker-compose ps api
+docker compose ps api
 ```
 
 ## Development Workflow
@@ -230,40 +255,40 @@ docker-compose ps api
 
 ```bash
 # Start development environment
-docker-compose --profile development up -d
+docker compose --profile development up -d
 
 # Make code changes - API will auto-reload
 # View logs
-docker-compose logs -f api-dev
+docker compose logs -f api-dev
 ```
 
 ### Running Tests
 
 ```bash
 # Run tests inside container
-docker-compose exec api pytest
+docker compose exec api pytest
 
 # With coverage
-docker-compose exec api pytest --cov=app --cov-report=html
+docker compose exec api pytest --cov=app --cov-report=html
 
 # Run specific test
-docker-compose exec api pytest tests/unit/test_enrollment.py
+docker compose exec api pytest tests/unit/test_enrollment.py
 ```
 
 ### Debugging
 
 ```bash
 # View API logs
-docker-compose logs -f api
+docker compose logs -f api
 
 # View all logs
-docker-compose logs -f
+docker compose logs -f
 
 # Exec into container
-docker-compose exec api bash
+docker compose exec api bash
 
 # Check Python environment
-docker-compose exec api python -c "import cv2; print(cv2.__version__)"
+docker compose exec api python -c "import cv2; print(cv2.__version__)"
 ```
 
 ## Production Deployment
@@ -334,29 +359,29 @@ Available metrics:
 
 ```bash
 # Check logs
-docker-compose logs api
+docker compose logs api
 
 # Check resource usage
 docker stats
 
 # Restart services
-docker-compose restart
+docker compose restart
 
 # Rebuild if needed
-docker-compose up -d --build
+docker compose up -d --build
 ```
 
 ### Database Connection Issues
 
 ```bash
 # Check PostgreSQL is running
-docker-compose ps postgres
+docker compose ps postgres
 
 # Check PostgreSQL logs
-docker-compose logs postgres
+docker compose logs postgres
 
 # Test connection
-docker-compose exec api python -c "
+docker compose exec api python -c "
 from app.core.config import settings
 print(settings.DATABASE_URL)
 "
@@ -379,16 +404,16 @@ docker stats
 sudo chown -R $USER:$USER uploads/
 
 # Or run with sudo
-sudo docker-compose up -d
+sudo docker compose up -d
 ```
 
 ### Network Issues
 
 ```bash
 # Recreate network
-docker-compose down
+docker compose down
 docker network prune
-docker-compose up -d
+docker compose up -d
 ```
 
 ## Maintenance
@@ -397,43 +422,43 @@ docker-compose up -d
 
 ```bash
 # Backup PostgreSQL
-docker-compose exec postgres pg_dump -U biometric_user biometric_db > backup.sql
+docker compose exec postgres pg_dump -U biometric_user biometric_db > backup.sql
 
 # Restore
-docker-compose exec -T postgres psql -U biometric_user biometric_db < backup.sql
+docker compose exec -T postgres psql -U biometric_user biometric_db < backup.sql
 ```
 
 ### Clear Redis Cache
 
 ```bash
 # Flush all Redis data
-docker-compose exec redis redis-cli FLUSHALL
+docker compose exec redis redis-cli FLUSHALL
 
 # Flush specific database
-docker-compose exec redis redis-cli -n 0 FLUSHDB
+docker compose exec redis redis-cli -n 0 FLUSHDB
 ```
 
 ### Update Dependencies
 
 ```bash
 # Rebuild images with latest dependencies
-docker-compose build --no-cache
+docker compose build --no-cache
 
 # Pull latest base images
-docker-compose pull
+docker compose pull
 
 # Restart with new images
-docker-compose up -d
+docker compose up -d
 ```
 
 ### Clean Up
 
 ```bash
 # Stop and remove containers
-docker-compose down
+docker compose down
 
 # Remove volumes (data will be lost!)
-docker-compose down -v
+docker compose down -v
 
 # Remove images
 docker rmi $(docker images -q biometric-processor*)
@@ -446,7 +471,7 @@ docker system prune -a
 
 ### PostgreSQL
 
-Edit `docker-compose.yml` to adjust PostgreSQL settings:
+Edit `docker compose.yml` to adjust PostgreSQL settings:
 
 ```yaml
 services:
@@ -459,7 +484,7 @@ services:
 
 ### Redis
 
-Adjust Redis configuration in `docker-compose.yml`:
+Adjust Redis configuration in `docker compose.yml`:
 
 ```yaml
 services:

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ Biometric Processor is the AI/ML microservice for the **FIVUCSAS** biometric ide
 The fastest way to test the system is with the local demo:
 
 ```bash
-python demo_local.py
+python demo_local_fast.py
 ```
+
+> Note: `demo_local.py` does not exist. Use `demo_local_fast.py` (balanced) or `demo_local_optimized.py` (CPU-optimised) — both are in the repo root.
 
 **Performance**: 18-30 FPS (CPU), optimized and production-ready!
 
@@ -173,7 +175,7 @@ biometric-processor/
 
 ## Prerequisites
 
-- **Python 3.11** or higher
+- **Python 3.12** or higher
 - **pip** package manager
 - **4GB+ RAM** (8GB recommended)
 - **GPU** (optional, for faster inference)
@@ -182,7 +184,7 @@ biometric-processor/
 
 ### Prerequisites
 
-- **Python 3.11+**
+- **Python 3.12+**
 - **Node.js 18+**
 - **PostgreSQL 14+ with pgvector extension**
 - **Redis 7+**
@@ -948,9 +950,10 @@ The service supports multiple face recognition models via DeepFace:
 | Model | Embedding Size | Best For |
 |-------|---------------|----------|
 | Facenet (default) | 128 | Balanced accuracy/speed |
-| Facenet512 | 512 | Higher accuracy |
-| VGG-Face | 2622 | High accuracy, more memory |
-| ArcFace | 512 | State-of-the-art accuracy |
+| Facenet512 | 512 | Higher accuracy (prod default) |
+| VGG-Face | 2622 | High accuracy — **requires `ALLOW_HEAVY_ML=true` (GPU)** |
+| ArcFace | 512 | State-of-the-art accuracy — **requires `ALLOW_HEAVY_ML=true` (GPU)** |
+| GhostFaceNet | 512 | Compact high accuracy — **requires `ALLOW_HEAVY_ML=true` (GPU)** |
 | OpenFace | 128 | Lightweight |
 | DeepFace | 4096 | Legacy support |
 | DeepID | 160 | Lightweight |
@@ -958,6 +961,8 @@ The service supports multiple face recognition models via DeepFace:
 | SFace | 128 | Lightweight |
 
 Configure via `FACE_RECOGNITION_MODEL` environment variable.
+
+The detection backends `retinaface`, `yolov8`, `yolov11n`, `yolov11s`, and `yolov12n` also **require `ALLOW_HEAVY_ML=true`** and will cause a hard boot failure on CPU-only hosts when that flag is `false` (the default).
 
 ## Configuration Reference
 
@@ -968,15 +973,20 @@ Configure via `FACE_RECOGNITION_MODEL` environment variable.
 | `ENVIRONMENT` | development | Environment (development/staging/production) |
 | `API_HOST` | 0.0.0.0 | API host |
 | `API_PORT` | 8001 | API port |
-| `FACE_DETECTION_BACKEND` | opencv | Face detector (opencv/ssd/mtcnn/retinaface) |
+| `FACE_DETECTION_BACKEND` | opencv | Face detector (opencv/ssd/mtcnn; retinaface/yolo* require `ALLOW_HEAVY_ML=true`) |
 | `FACE_RECOGNITION_MODEL` | Facenet | Recognition model |
-| `VERIFICATION_THRESHOLD` | 0.6 | Verification distance threshold |
-| `LIVENESS_MODE` | combined | Liveness mode (passive/active/combined) |
+| `ALLOW_HEAVY_ML` | false | Must be `true` on a GPU host to use ArcFace/VGG-Face/GhostFaceNet/retinaface/yolo* |
+| `VERIFICATION_THRESHOLD` | 0.45 | Cosine-distance threshold (`distance < threshold` → match). **Prod override: 0.4** |
+| `LIVENESS_MODE` | combined | Liveness mode (passive/active/combined). **Prod override: passive** |
+| `LIVENESS_BACKEND` | _(derived from LIVENESS_MODE)_ | Explicit backend override. **Prod override: uniface** |
 | `LIVENESS_THRESHOLD` | 70.0 | Liveness score threshold (0-100) |
 | `QUALITY_THRESHOLD` | 70.0 | Quality score threshold (0-100) |
 | `MIN_FACE_SIZE` | 80 | Minimum face size in pixels |
 | `BLUR_THRESHOLD` | 100.0 | Blur detection threshold |
 | `LOG_LEVEL` | INFO | Logging level |
+| `FIVUCSAS_EMBEDDING_KEY` | _(none)_ | **Required in production.** Fernet key for at-rest embedding encryption; container fails fast on boot if unset. |
+| `FIVUCSAS_EMBEDDING_KEY_VERSION` | _(none)_ | Key version integer for `FIVUCSAS_EMBEDDING_KEY` rotation. |
+| `ANTISPOOF_BLOCK_ENFORCE` | true | When `true`, anti-spoof "block" verdicts and EAR closed-eye detection return HTTP 403. |
 
 ## Testing
 
@@ -1028,6 +1038,64 @@ pre-commit install
 | Fingerprint | (removed P1.4) | (removed P1.4) | (removed P1.4) | Removed | SHA-256 placeholder was not a real biometric. Use WebAuthn (FIDO2) in identity-core-api for platform fingerprint auth. |
 | Iris | N/A | N/A | N/A | Not implemented | No endpoints |
 
+## Additional API Endpoints
+
+The following endpoints are implemented but not covered in the main API reference above. All are prefixed with `/api/v1` unless noted.
+
+### Health & Observability
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/ready` | GET | Kubernetes readiness probe |
+| `/live` | GET | Kubernetes liveness probe |
+| `/health/detailed` | GET | Full system health with DB/Redis/ML status |
+| `/metrics` | GET | Prometheus metrics scrape endpoint (excluded from OpenAPI schema) |
+
+### Flash Challenge (Presentation-Attack Detection)
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/flash-challenge/start` | POST | Start a flash-challenge PAD session |
+| `/flash-challenge/respond` | POST | Submit frame response to a flash challenge |
+
+### NFC / MRZ
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/nfc/mrz` | POST | Parse MRZ from raw NFC TLV payload or image |
+
+### Proctoring
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/proctoring/sessions` | POST | Create a proctoring session |
+| `/proctoring/sessions/{id}/start` | POST | Start a session |
+| `/proctoring/sessions/{id}/pause` | POST | Pause a session |
+| `/proctoring/sessions/{id}/resume` | POST | Resume a session |
+| `/proctoring/sessions/{id}/end` | POST | End a session |
+| `/proctoring/sessions/{id}` | GET | Get session detail |
+| `/proctoring/sessions` | GET | List sessions |
+| `/proctoring/sessions/{id}/frames` | POST | Submit a frame for incident analysis |
+
+### Liveness Puzzle
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/liveness/generate-puzzle` | POST | Generate a liveness puzzle challenge |
+| `/liveness/verify` | POST | Submit puzzle answer |
+| `/liveness/verify-challenge` | POST | Combined puzzle + anti-spoof challenge |
+
+### Verification Pipeline Sub-paths
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/verification/document-scan` | POST | YOLO document detection + classification |
+| `/verification/data-extract` | POST | MRZ + Tesseract OCR field extraction |
+| `/verification/face-match` | POST | Selfie-to-document cosine matching |
+| `/verification/liveness-check` | POST | Server-authoritative liveness verdict |
+| `/verification/pipeline/test` | POST | End-to-end pipeline smoke test |
+| `/verification/video-interview` | POST | Upload video for verification pipeline |
+
+### Admin
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/admin/stats` | GET | System-wide stats (face/voice enrollment counts, etc.) |
+| `/admin/activity` | GET | Recent audit activity |
+
 ## Roadmap
 
 | Sprint | Feature | Status |
@@ -1044,7 +1112,7 @@ pre-commit install
 
 This project is part of the **FIVUCSAS** platform developed as an Engineering Project at Marmara University.
 
-Copyright © 2025 FIVUCSAS Team. All rights reserved.
+Copyright © 2026 FIVUCSAS Team. All rights reserved.
 
 Licensed under the MIT License.
 
@@ -1057,4 +1125,4 @@ Licensed under the MIT License.
 
 ---
 
-**FIVUCSAS Team © 2025**
+**FIVUCSAS Team © 2026**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,8 +5,8 @@
 ### Phase 1: Fix Integration Gaps (Priority: Critical)
 
 - [ ] Improve fingerprint stub to return structured error responses matching BiometricServiceAdapter expectations
-- [ ] Improve voice stub to return structured error responses matching BiometricServiceAdapter expectations
-- [ ] Document which biometric modalities are implemented vs stubbed for consumers
+- [x] Improve voice stub to return structured error responses matching BiometricServiceAdapter expectations — **Done**: voice is fully shipped with Resemblyzer 256-dim; /voice/enroll, /voice/verify, /voice/search, /voice/delete all implemented in `voice.py`.
+- [x] Document which biometric modalities are implemented vs stubbed for consumers — see README Biometric Modality Support Status table.
 - [ ] Verify face enrollment/verification field names match BiometricServiceAdapter
 
 ### Phase 2: Expand Biometric Support (Priority: High)
@@ -14,9 +14,7 @@
 - [ ] Evaluate fingerprint processing options:
   - Option A: WebAuthn/FIDO2 platform authenticators (recommended for web)
   - Option B: Server-side fingerprint template matching (requires SDK)
-- [ ] Evaluate voice processing options:
-  - Option A: SpeechBrain speaker verification model
-  - Option B: Resemblyzer voice embeddings
+- [x] Evaluate voice processing options — **Done**: Resemblyzer GE2E 256-dim speaker embeddings (Option B) shipped; /voice/enroll, /voice/verify, /voice/search, /voice/delete live.
 - [ ] Add tenant isolation for face embeddings database
 - [ ] Add enrollment status tracking (async lifecycle: PENDING -> PROCESSING -> SUCCESS/FAILED)
 

--- a/docs/api/API_DOCUMENTATION.md
+++ b/docs/api/API_DOCUMENTATION.md
@@ -23,9 +23,11 @@ The Biometric Processor API provides comprehensive face recognition and proctori
 All endpoints require authentication via API key:
 
 ```http
-Authorization: Bearer <api_key>
+X-API-Key: <api_key>
 X-Tenant-ID: <tenant_id>
 ```
+
+> Note: The header is `X-API-Key`, not `Authorization: Bearer`. The middleware reads `request.headers.get("X-API-Key")`. Bearer tokens are used for JWT auth only (separate from the service-to-service API key).
 
 ---
 


### PR DESCRIPTION
## Summary

Documentation-only PR (no Python, compose, or CI files changed). All values verified by reading `config.py`, `docker-compose.prod.yml`, and `app/api/routes/` before editing.

- **README.md**: `VERIFICATION_THRESHOLD` default corrected 0.6→0.45 (prod override 0.4 noted); `LIVENESS_MODE`/`LIVENESS_BACKEND` prod overrides (passive+uniface) documented; ArcFace/VGG-Face/GhostFaceNet/retinaface/yolo\* marked with `ALLOW_HEAVY_ML=true` GPU requirement; GhostFaceNet added to models table (was absent); Quick Start demo script corrected (`demo_local.py`→`demo_local_fast.py`); Python prereqs 3.11→3.12; `FIVUCSAS_EMBEDDING_KEY` + `ANTISPOOF_BLOCK_ENFORCE` added to config table; copyright 2025→2026; all undocumented endpoints documented (flash-challenge, nfc, proctoring, liveness-puzzle, verification sub-paths, admin/stats, /ready, /live, /metrics).
- **docs/api/API_DOCUMENTATION.md**: auth header `Authorization: Bearer`→`X-API-Key` (confirmed in `api_key_auth.py`).
- **CLAUDE.md**: route module count 17→27; MobileFaceNet attribution removed; `document.py`/`video_interview.py` refs replaced with `verification_pipeline.py` sub-paths (files confirmed non-existent); `TODO.md` reference removed.
- **ROADMAP.md**: voice stub items closed (Resemblyzer 256-dim fully shipped).
- **ARCHITECTURE.md**: note added that anti-spoof algorithms come from the external `spoof-detector` git dep, not this repo.
- **DOCKER_SETUP.md**: `docker-compose` (v1)→`docker compose` (v2) throughout; prod usage section with `--env-file .env.prod`; new env vars added to example.
- **CHANGELOG.md**: entries added for 2026-05-07, 2026-05-11, 2026-05-12 milestones derived from `git log --since=2026-05-01`.

## Needs Your Decision

None — all changes are doc-only and values are verified.

## Code Change Needed (not in this PR)

- **`pyproject.toml` line 5**: `requires-python = ">=3.13"` conflicts with `Dockerfile` (`FROM python:3.12-slim`) and `runtime.txt` (`python-3.12.10`). The authoritative runtime is 3.12. Either update `pyproject.toml` to `>=3.12` or upgrade the Dockerfile/runtime to 3.13. This is a config file — not edited here per guardrails.

## Test plan

- [ ] Review diff for accuracy — all values traced to source files in the same commit tree.
- [ ] No `.py`, compose, Dockerfile, or CI files changed (verify with `git diff --name-only`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)