### PR TITLE
docs(security): standardize contact email

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 If you believe you've found a security vulnerability in biometric-processor — the FastAPI face/voice/liveness inference service of the FIVUCSAS biometric authentication platform — please report it privately so we can fix it before disclosing publicly.
 
-**Email:** info@app.fivucsas.com (subject prefix: `[SECURITY] biometric-processor`)
+**Email:** info@fivucsas.com (primary) or rollingcat.help@gmail.com (alternate) — subject prefix: `[SECURITY] biometric-processor`
 
 Please include:
 - A clear description of the issue and its impact.


### PR DESCRIPTION
## Summary

- `SECURITY.md`: Replace bogus `info@app.fivucsas.com` with **info@fivucsas.com** (primary) + **rollingcat.help@gmail.com** (alternate).

## Changes

- `SECURITY.md` line 7: `info@app.fivucsas.com` → `info@fivucsas.com` (primary) + `rollingcat.help@gmail.com` (alternate)

## Test plan

- [ ] Confirm email addresses render correctly in GitHub's Security tab
- [ ] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)