### PR TITLE
fix(voice): F10 tenant-scope voice search + F11 wire replay detector

### DIFF
--- a/app/api/routes/voice.py
+++ b/app/api/routes/voice.py
@@ -16,14 +16,21 @@ Integration:
 """
 
 import logging
+from typing import Optional
 
 import numpy as np
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
 from app.api.schemas.biometric_response import BiometricResponse as _SharedBiometricResponse
-from app.core.container import get_speaker_embedder, get_voice_repository, get_thread_pool
+from app.core.container import (
+    get_speaker_embedder,
+    get_thread_pool,
+    get_voice_replay_detector,
+    get_voice_repository,
+)
 from app.core.validation import validate_user_id
+from app.infrastructure.ml.voice.replay_detector import compute_spectral_fingerprint
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +57,47 @@ async def _extract_voice_embedding(voice_data: str) -> np.ndarray:
     embedder = get_speaker_embedder()
     pool = get_thread_pool()
     return await pool.run_blocking(embedder.extract_embedding_from_base64, voice_data)
+
+
+async def _compute_replay_fingerprint(voice_data: str) -> np.ndarray:
+    """Decode audio and compute the replay spectral fingerprint off the loop."""
+    embedder = get_speaker_embedder()
+    pool = get_thread_pool()
+    samples = await pool.run_blocking(embedder.decode_samples_from_base64, voice_data)
+    return await pool.run_blocking(compute_spectral_fingerprint, samples)
+
+
+async def _run_replay_check(
+    voice_data: str,
+    user_id: str,
+    tenant_id: Optional[str] = None,
+) -> bool:
+    """Run the voice replay-attack detector (ML-H4).
+
+    Mirrors how the face verify path runs its anti-spoof check: the detector is
+    invoked on the verification/search path, is gated by the
+    ``VOICE_REPLAY_DETECTION_ENABLED`` config flag (default off), and is
+    **advisory + log-only** — a replay suspicion is logged and metered but does
+    not block the request. Any failure here must never break voice auth, so all
+    errors are swallowed and treated as "not a replay".
+
+    Returns:
+        True if the sample is a suspected replay, False otherwise (including
+        when detection is disabled or the detector errors out).
+    """
+    detector = get_voice_replay_detector()
+    if not detector.enabled:
+        return False
+    try:
+        fingerprint = await _compute_replay_fingerprint(voice_data)
+        return await detector.check_and_record(
+            user_id=user_id,
+            fingerprint=fingerprint,
+            tenant_id=tenant_id,
+        )
+    except Exception as e:  # noqa: BLE001 — replay check is non-blocking
+        logger.warning(f"Voice replay check skipped (error): {e}")
+        return False
 
 
 # -- POST /voice/enroll --------------------------------------------------------
@@ -128,6 +176,11 @@ async def verify_voice(request: VoiceRequest) -> BiometricResponse:
 
         logger.info(f"Voice verification request: user_id={user_id}")
 
+        # ML-H4: voice replay-attack detection (advisory + log-only, gated by
+        # VOICE_REPLAY_DETECTION_ENABLED). Mirrors the face verify path running
+        # its anti-spoof check. Never blocks verification today.
+        await _run_replay_check(voice_data, user_id=user_id)
+
         # Extract speaker embedding from probe audio (CPU-bound)
         probe_embedding = await _extract_voice_embedding(voice_data)
 
@@ -183,6 +236,13 @@ async def verify_voice(request: VoiceRequest) -> BiometricResponse:
 
 class VoiceSearchRequest(BaseModel):
     voice_data: str = Field(..., max_length=50_000_000)  # base64-encoded audio
+    # F10: tenant scoping for 1:N voice identification. Mirrors the face
+    # /search ``tenant_id`` parameter ("defense-in-depth isolation"). When
+    # supplied the query is scoped to the tenant at the SQL layer so a voice
+    # sample can never match enrollments belonging to OTHER tenants. Optional
+    # for backward compatibility with callers that have not yet been updated to
+    # forward it (see PR notes re: identity-core-api BiometricServiceAdapter).
+    tenant_id: Optional[str] = Field(None, max_length=255)
 
 
 @router.post("/voice/search")
@@ -195,13 +255,30 @@ async def search_voice(request: VoiceSearchRequest):
         if not voice_data:
             raise HTTPException(status_code=400, detail="voice_data is required")
 
-        logger.info("Voice search request")
+        tenant_id = request.tenant_id
+        logger.info(f"Voice search request: tenant_id={tenant_id}")
 
         # CPU-bound extraction offloaded to thread pool
         probe_embedding = await _extract_voice_embedding(voice_data)
 
+        # ML-H4: voice replay-attack detection on the search path (advisory +
+        # log-only, gated by VOICE_REPLAY_DETECTION_ENABLED). 1:N search has no
+        # claimed user_id, so we key the per-sample fingerprint cache by tenant.
+        await _run_replay_check(
+            voice_data,
+            user_id=f"search:{tenant_id or 'global'}",
+            tenant_id=tenant_id,
+        )
+
+        # F10: scope the 1:N search to the requesting tenant. The repository
+        # adds an ``AND tenant_id = $N`` predicate when tenant_id is provided
+        # (same as the face repository), preventing cross-tenant matches.
         repo = get_voice_repository()
-        matches = await repo.find_similar(probe_embedding, threshold=SEARCH_THRESHOLD)
+        matches = await repo.find_similar(
+            probe_embedding,
+            threshold=SEARCH_THRESHOLD,
+            tenant_id=tenant_id,
+        )
 
         logger.info(f"Voice search complete: {len(matches)} matches")
 

--- a/app/core/container.py
+++ b/app/core/container.py
@@ -78,6 +78,7 @@ from app.infrastructure.persistence.repositories.redis_active_liveness_session_r
 from app.infrastructure.storage.local_file_storage import LocalFileStorage
 from app.infrastructure.async_execution.thread_pool_manager import ThreadPoolManager
 from app.infrastructure.ml.voice.speaker_embedder import SpeakerEmbedder
+from app.infrastructure.ml.voice.replay_detector import VoiceReplayDetector
 from app.infrastructure.persistence.repositories.pgvector_voice_repository import PgVectorVoiceRepository
 from app.infrastructure.persistence.client_embedding_observation_repository import (
     ClientEmbeddingObservationRepository,
@@ -859,6 +860,42 @@ def get_voice_repository() -> PgVectorVoiceRepository:
     )
 
 
+@lru_cache()
+def get_voice_replay_detector() -> VoiceReplayDetector:
+    """Get voice replay-attack detector instance (singleton).
+
+    ML-H4: log-only spectral-fingerprint replay detector backed by a Redis
+    LRU cache. Gated by ``VOICE_REPLAY_DETECTION_ENABLED`` (default False) so
+    wiring it onto the verify path is a no-op until ops flip the flag. If the
+    flag is off we skip building a Redis client entirely; when on, a Redis
+    client is created with the same URL used elsewhere and the detector
+    degrades silently if Redis is unreachable.
+    """
+    redis_client = None
+    if settings.VOICE_REPLAY_DETECTION_ENABLED:
+        try:
+            import redis.asyncio as _redis
+
+            redis_client = _redis.from_url(
+                settings.redis_url,
+                encoding="utf-8",
+                decode_responses=False,
+                max_connections=5,
+            )
+        except Exception as exc:  # noqa: BLE001 — never block voice auth on Redis
+            logger.warning(
+                "Voice replay detector: Redis client init failed; "
+                "detector will run cache-less (no-op): %s",
+                exc,
+            )
+
+    logger.info(
+        "Creating voice replay detector (enabled=%s)",
+        settings.VOICE_REPLAY_DETECTION_ENABLED,
+    )
+    return VoiceReplayDetector(redis_client=redis_client)
+
+
 # ============================================================================
 # Fingerprint server-side biometric dependencies REMOVED (P1.4).
 # The SHA-256 hash placeholder was never a real biometric. Platform fingerprint
@@ -1151,4 +1188,5 @@ def clear_cache() -> None:
     get_puzzle_spot_check_liveness_detector.cache_clear()
     get_speaker_embedder.cache_clear()
     get_voice_repository.cache_clear()
+    get_voice_replay_detector.cache_clear()
     get_client_embedding_observation_repository.cache_clear()

--- a/app/core/container.py
+++ b/app/core/container.py
@@ -78,7 +78,6 @@ from app.infrastructure.persistence.repositories.redis_active_liveness_session_r
 from app.infrastructure.storage.local_file_storage import LocalFileStorage
 from app.infrastructure.async_execution.thread_pool_manager import ThreadPoolManager
 from app.infrastructure.ml.voice.speaker_embedder import SpeakerEmbedder
-from app.infrastructure.ml.voice.replay_detector import VoiceReplayDetector
 from app.infrastructure.persistence.repositories.pgvector_voice_repository import PgVectorVoiceRepository
 from app.infrastructure.persistence.client_embedding_observation_repository import (
     ClientEmbeddingObservationRepository,
@@ -861,7 +860,7 @@ def get_voice_repository() -> PgVectorVoiceRepository:
 
 
 @lru_cache()
-def get_voice_replay_detector() -> VoiceReplayDetector:
+def get_voice_replay_detector() -> "VoiceReplayDetector":
     """Get voice replay-attack detector instance (singleton).
 
     ML-H4: log-only spectral-fingerprint replay detector backed by a Redis
@@ -871,6 +870,11 @@ def get_voice_replay_detector() -> VoiceReplayDetector:
     client is created with the same URL used elsewhere and the detector
     degrades silently if Redis is unreachable.
     """
+    # Imported lazily (not at module top) so container.py never pulls the
+    # replay detector at import time — a top-level import here introduced a
+    # circular-import collection failure in CI (broke clear_cache import).
+    from app.infrastructure.ml.voice.replay_detector import VoiceReplayDetector
+
     redis_client = None
     if settings.VOICE_REPLAY_DETECTION_ENABLED:
         try:

--- a/app/infrastructure/ml/voice/speaker_embedder.py
+++ b/app/infrastructure/ml/voice/speaker_embedder.py
@@ -117,6 +117,29 @@ class SpeakerEmbedder:
         Returns:
             numpy array of shape (256,), dtype float32.
         """
+        audio_bytes, content_type = self._decode_base64(base64_data)
+        return self.extract_embedding(audio_bytes, content_type)
+
+    def decode_samples_from_base64(self, base64_data: str) -> np.ndarray:
+        """Decode base64 audio to a 16 kHz mono float32 PCM array.
+
+        Exposes the same decode path used by ``extract_embedding`` so callers
+        that need raw samples (e.g. the voice replay-attack fingerprint) can
+        reuse the identical decoding without duplicating format detection.
+
+        Args:
+            base64_data: Base64-encoded audio (optionally with a data URI
+                prefix such as "data:audio/webm;base64,...").
+
+        Returns:
+            1-D float32 numpy array of mono PCM samples at 16 kHz.
+        """
+        audio_bytes, content_type = self._decode_base64(base64_data)
+        return self._decode_to_wav_samples(audio_bytes, content_type)
+
+    @staticmethod
+    def _decode_base64(base64_data: str) -> "tuple[bytes, Optional[str]]":
+        """Strip an optional data-URI prefix and base64-decode the payload."""
         import base64
 
         content_type: Optional[str] = None
@@ -125,8 +148,7 @@ class SpeakerEmbedder:
             header, base64_data = base64_data.split(",", 1)
             content_type = header.split(":")[1].split(";")[0]
 
-        audio_bytes = base64.b64decode(base64_data)
-        return self.extract_embedding(audio_bytes, content_type)
+        return base64.b64decode(base64_data), content_type
 
     # ------------------------------------------------------------------
     # Audio decoding helpers

--- a/tests/unit/api/test_voice_routes.py
+++ b/tests/unit/api/test_voice_routes.py
@@ -1,0 +1,213 @@
+"""Unit tests for voice route handlers (F10 + F11).
+
+These tests exercise the voice route handler coroutines directly (rather than
+through a full TestClient) to avoid the asyncio loop-poisoning that the
+integration TestClient-in-test-body pattern suffers from, while still covering
+the two fixes:
+
+    * F10 — ``/voice/search`` scopes the 1:N query by ``tenant_id`` so a voice
+      sample can never match enrollments belonging to OTHER tenants. We assert
+      the tenant_id supplied in the request is forwarded to the repository's
+      ``find_similar`` call (which adds the SQL tenant predicate).
+
+    * F11 — the voice replay-attack detector is actually invoked on the
+      verify/search path (it previously existed but was never called). We assert
+      ``check_and_record`` runs when the feature flag is enabled, and that the
+      check is non-blocking / skipped when disabled.
+"""
+
+import sys
+import types
+from unittest.mock import AsyncMock, Mock, patch
+
+import numpy as np
+import pytest
+
+# ``app.api.routes.voice`` imports a handful of getters from
+# ``app.core.container`` at module load. The real container module eagerly
+# wires the full DeepFace/TensorFlow/OpenCV ML stack at import time, which is
+# not available in the lean unit-test environment (and is irrelevant to the
+# route logic under test — every getter is patched per-test below). We stub the
+# container with a lightweight module exposing just the symbols voice.py needs,
+# mirroring the existing NFC route test's strategy of avoiding the heavy
+# ``app.main`` import path. In the Docker/CI image the real container imports
+# cleanly and these stubs are simply overridden by ``patch.object`` anyway.
+if "app.core.container" not in sys.modules:
+    _stub_container = types.ModuleType("app.core.container")
+    for _name in (
+        "get_speaker_embedder",
+        "get_thread_pool",
+        "get_voice_replay_detector",
+        "get_voice_repository",
+    ):
+        setattr(_stub_container, _name, lambda *a, **k: None)
+    sys.modules["app.core.container"] = _stub_container
+
+from app.api.routes import voice as voice_routes  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _unit_embedding(seed: int = 0) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    v = rng.standard_normal(256).astype(np.float32)
+    return v / np.linalg.norm(v)
+
+
+# ---------------------------------------------------------------------------
+# F10 — voice search is tenant-scoped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_voice_forwards_tenant_id_to_repository():
+    """F10: a tenant_id in the request must be passed to repo.find_similar."""
+    repo = Mock()
+    repo.find_similar = AsyncMock(return_value=[("user-a", 0.2)])
+
+    detector = Mock()
+    detector.enabled = False  # keep replay path out of the way for this test
+
+    with patch.object(voice_routes, "_extract_voice_embedding",
+                      AsyncMock(return_value=_unit_embedding(1))), \
+         patch.object(voice_routes, "get_voice_repository", return_value=repo), \
+         patch.object(voice_routes, "get_voice_replay_detector", return_value=detector):
+
+        request = voice_routes.VoiceSearchRequest(
+            voice_data="ZmFrZQ==", tenant_id="tenant-x"
+        )
+        result = await voice_routes.search_voice(request)
+
+    # The repository must have been called WITH the tenant_id (the SQL layer
+    # then scopes the query). This is the core of the cross-tenant fix.
+    assert repo.find_similar.await_count == 1
+    _, kwargs = repo.find_similar.await_args
+    assert kwargs.get("tenant_id") == "tenant-x"
+    assert result["total_matches"] == 1
+
+
+@pytest.mark.asyncio
+async def test_search_voice_without_tenant_passes_none():
+    """Backward-compat: a request without tenant_id forwards tenant_id=None."""
+    repo = Mock()
+    repo.find_similar = AsyncMock(return_value=[])
+
+    detector = Mock()
+    detector.enabled = False
+
+    with patch.object(voice_routes, "_extract_voice_embedding",
+                      AsyncMock(return_value=_unit_embedding(2))), \
+         patch.object(voice_routes, "get_voice_repository", return_value=repo), \
+         patch.object(voice_routes, "get_voice_replay_detector", return_value=detector):
+
+        request = voice_routes.VoiceSearchRequest(voice_data="ZmFrZQ==")
+        await voice_routes.search_voice(request)
+
+    _, kwargs = repo.find_similar.await_args
+    assert kwargs.get("tenant_id") is None
+
+
+# ---------------------------------------------------------------------------
+# F11 — replay detector is wired into the voice paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_verify_voice_invokes_replay_detector_when_enabled():
+    """F11: enabled detector's check_and_record must run on /voice/verify."""
+    repo = Mock()
+    repo.find_by_user_id = AsyncMock(return_value=_unit_embedding(3))
+
+    detector = Mock()
+    detector.enabled = True
+    detector.check_and_record = AsyncMock(return_value=False)
+
+    probe = _unit_embedding(3)
+
+    with patch.object(voice_routes, "_extract_voice_embedding",
+                      AsyncMock(return_value=probe)), \
+         patch.object(voice_routes, "_compute_replay_fingerprint",
+                      AsyncMock(return_value=np.ones(128, dtype=np.float32))), \
+         patch.object(voice_routes, "get_voice_repository", return_value=repo), \
+         patch.object(voice_routes, "get_voice_replay_detector", return_value=detector):
+
+        request = voice_routes.VoiceRequest(user_id="user-1", voice_data="ZmFrZQ==")
+        result = await voice_routes.verify_voice(request)
+
+    # The replay detector must have been consulted on the verify path.
+    detector.check_and_record.assert_awaited_once()
+    _, kwargs = detector.check_and_record.await_args
+    assert kwargs.get("user_id") == "user-1"
+    # Replay detection is advisory/log-only — it must NOT block verification.
+    assert result.verified is True
+
+
+@pytest.mark.asyncio
+async def test_verify_voice_skips_replay_detector_when_disabled():
+    """When the flag is off, check_and_record is never called (no-op)."""
+    repo = Mock()
+    repo.find_by_user_id = AsyncMock(return_value=_unit_embedding(4))
+
+    detector = Mock()
+    detector.enabled = False
+    detector.check_and_record = AsyncMock(return_value=False)
+
+    probe = _unit_embedding(4)
+
+    with patch.object(voice_routes, "_extract_voice_embedding",
+                      AsyncMock(return_value=probe)), \
+         patch.object(voice_routes, "get_voice_repository", return_value=repo), \
+         patch.object(voice_routes, "get_voice_replay_detector", return_value=detector):
+
+        request = voice_routes.VoiceRequest(user_id="user-2", voice_data="ZmFrZQ==")
+        await voice_routes.verify_voice(request)
+
+    detector.check_and_record.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_replay_check_is_non_blocking_on_error():
+    """A detector error must be swallowed and treated as 'not a replay'."""
+    detector = Mock()
+    detector.enabled = True
+    detector.check_and_record = AsyncMock(side_effect=RuntimeError("redis down"))
+
+    with patch.object(voice_routes, "_compute_replay_fingerprint",
+                      AsyncMock(return_value=np.ones(128, dtype=np.float32))), \
+         patch.object(voice_routes, "get_voice_replay_detector", return_value=detector):
+
+        suspect = await voice_routes._run_replay_check(
+            "ZmFrZQ==", user_id="user-9", tenant_id="tenant-y"
+        )
+
+    assert suspect is False
+
+
+@pytest.mark.asyncio
+async def test_search_voice_invokes_replay_detector_when_enabled():
+    """F11: the replay detector also runs on the 1:N /voice/search path."""
+    repo = Mock()
+    repo.find_similar = AsyncMock(return_value=[])
+
+    detector = Mock()
+    detector.enabled = True
+    detector.check_and_record = AsyncMock(return_value=False)
+
+    with patch.object(voice_routes, "_extract_voice_embedding",
+                      AsyncMock(return_value=_unit_embedding(5))), \
+         patch.object(voice_routes, "_compute_replay_fingerprint",
+                      AsyncMock(return_value=np.ones(128, dtype=np.float32))), \
+         patch.object(voice_routes, "get_voice_repository", return_value=repo), \
+         patch.object(voice_routes, "get_voice_replay_detector", return_value=detector):
+
+        request = voice_routes.VoiceSearchRequest(
+            voice_data="ZmFrZQ==", tenant_id="tenant-z"
+        )
+        await voice_routes.search_voice(request)
+
+    detector.check_and_record.assert_awaited_once()
+    _, kwargs = detector.check_and_record.await_args
+    assert kwargs.get("tenant_id") == "tenant-z"

--- a/tests/unit/api/test_voice_routes.py
+++ b/tests/unit/api/test_voice_routes.py
@@ -27,12 +27,38 @@ import pytest
 # ``app.core.container`` at module load. The real container module eagerly
 # wires the full DeepFace/TensorFlow/OpenCV ML stack at import time, which is
 # not available in the lean unit-test environment (and is irrelevant to the
-# route logic under test — every getter is patched per-test below). We stub the
-# container with a lightweight module exposing just the symbols voice.py needs,
-# mirroring the existing NFC route test's strategy of avoiding the heavy
-# ``app.main`` import path. In the Docker/CI image the real container imports
-# cleanly and these stubs are simply overridden by ``patch.object`` anyway.
-if "app.core.container" not in sys.modules:
+# route logic under test — every getter is patched per-test below).
+#
+# Earlier this file installed a lightweight ``app.core.container`` stub into
+# ``sys.modules`` and never removed it. Because ``sys.modules`` is process-wide,
+# the stub leaked into *every other* test module collected afterwards — e.g.
+# ``tests/unit/infrastructure/test_liveness_runtime_wiring.py`` does
+# ``from app.core.container import clear_cache, ...`` and hit the incomplete
+# stub, raising ``ImportError`` and aborting the whole suite (exit 2).
+#
+# Fix: import ``voice`` exactly once here, falling back to a temporary stub
+# ONLY for the duration of that import, then restoring the previous
+# ``sys.modules`` state. Once ``voice`` is imported, the getter names are bound
+# into the ``voice`` module's own namespace (and are patched per-test via
+# ``patch.object(voice_routes, ...)``), so the real/stub container module is no
+# longer referenced and must not be left lying around in ``sys.modules``.
+def _import_voice_routes():
+    """Import app.api.routes.voice without leaking a container stub.
+
+    In the Docker/CI image the real container imports cleanly, so the plain
+    import succeeds and no stub is ever installed. In a lean environment that
+    lacks the heavy ML stack, we temporarily install a minimal container stub
+    just long enough to satisfy voice.py's ``from app.core.container import``,
+    then restore sys.modules so other test modules see the real container.
+    """
+    try:
+        from app.api.routes import voice as _voice
+        return _voice
+    except Exception:
+        pass
+
+    _had_container = "app.core.container" in sys.modules
+    _saved_container = sys.modules.get("app.core.container")
     _stub_container = types.ModuleType("app.core.container")
     for _name in (
         "get_speaker_embedder",
@@ -42,8 +68,17 @@ if "app.core.container" not in sys.modules:
     ):
         setattr(_stub_container, _name, lambda *a, **k: None)
     sys.modules["app.core.container"] = _stub_container
+    try:
+        from app.api.routes import voice as _voice
+        return _voice
+    finally:
+        if _had_container:
+            sys.modules["app.core.container"] = _saved_container
+        else:
+            sys.modules.pop("app.core.container", None)
 
-from app.api.routes import voice as voice_routes  # noqa: E402
+
+voice_routes = _import_voice_routes()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two verified, no-decision security/correctness fixes on the voice biometric path. Only `voice.py` + its related module (`speaker_embedder.py`), the container wiring, and new tests are touched.

### F10 — voice search was cross-tenant
`POST /voice/search` ran the 1:N pgvector query with **no `tenant_id` predicate**, so a voice sample could match enrollments belonging to *other* tenants — the exact bug the face `/search` handler guards against ("defense-in-depth isolation").

- The repository already supports scoping: `PgVectorVoiceRepository.find_similar(..., tenant_id=...)` adds `AND tenant_id = $N` when supplied. The route simply never passed it.
- Fix: `VoiceSearchRequest` now accepts `tenant_id` and forwards it to `find_similar`, mirroring `app/api/routes/search.py` (face search).
- File:line: `app/api/routes/voice.py:238` (`VoiceSearchRequest.tenant_id`) → `app/api/routes/voice.py:275` (`find_similar(..., tenant_id=tenant_id)`).

### F11 — voice replay detector was never called
`VoiceReplayDetector` (ML-H4, `app/infrastructure/ml/voice/replay_detector.py`) was implemented and unit-tested but **never invoked** on any voice path.

- Wired into `/voice/verify` and `/voice/search` via a non-blocking helper `_run_replay_check`, mirroring how the face verify path runs its anti-spoof check.
- Uses the **existing** config default `VOICE_REPLAY_DETECTION_ENABLED` (default `False`) — no new threshold or semantics introduced. Detector stays advisory + log-only (it returns a suspicion flag but does not block). All errors are swallowed so replay detection never breaks voice auth.
- File:line: `app/api/routes/voice.py:62` (`_run_replay_check`) invoked at `voice.py:180` (verify) and `voice.py:264` (search). New container getter `get_voice_replay_detector` at `app/core/container.py`. New public decode helper `SpeakerEmbedder.decode_samples_from_base64` at `app/infrastructure/ml/voice/speaker_embedder.py` (reuses the identical audio-decode path to produce PCM samples for the spectral fingerprint).

## Tests

New `tests/unit/api/test_voice_routes.py` (6 tests, all green):
- F10: search forwards `tenant_id` to `find_similar`; absent tenant forwards `None`.
- F11: replay detector `check_and_record` runs on verify + search when enabled; is skipped when disabled; verification is not blocked by a replay suspicion; detector errors are swallowed (non-blocking).

Plus the pre-existing `tests/unit/infrastructure/test_voice_replay_detector.py` (3 tests) still green.

```
$ pytest tests/unit/api/test_voice_routes.py tests/unit/infrastructure/test_voice_replay_detector.py
9 passed
```

> Note: `biometric-processor` `main` has a known baseline of pre-existing failing/un-collectable tests (e.g. `NoFaceDetectedError`, `memory_embedding_repository` import errors in face/embedding modules) unrelated to this change. Those are not touched. The new voice route tests stub `app.core.container` at import time (mirroring the NFC route test's "avoid the heavy ML import path" strategy) so they run without the full DeepFace/TensorFlow stack; in CI/Docker the real container imports cleanly.

## Follow-up (out of scope for this PR — flagged, not fixed)

For F10 to take effect end-to-end, the caller must forward `tenant_id`. The Java caller `identity-core-api` `BiometricServiceAdapter.searchVoice(...)` currently sends only `{"voice_data": ...}` (unlike `searchFace`, which calls `addOptionalTenantAndEmbeddingParts` to forward `tenant_id`). That adapter change lives in a different repo and is outside the "only touch voice.py + related module + tests" scope of this PR. This PR makes the bio endpoint *capable* of and *correct* about tenant scoping; the adapter forwarding should be a small companion change in identity-core-api.

## Test plan
- [ ] CI green on biometric-processor (new tests collect + pass in the Docker ML image)
- [ ] Confirm no new failures in voice modules vs baseline
- [ ] (follow-up) identity-core-api `BiometricServiceAdapter.searchVoice` forwards `tenant_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)