### PR TITLE
feat(enroll): close liveness/anti-spoof asymmetry — face /enroll now gated like /verify

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,6 +130,14 @@ LIVENESS_MODE=combined
 # UniFace when LIVENESS_BACKEND is not set.
 LIVENESS_UNIFACE_DEFAULT_ENABLED=False
 LIVENESS_THRESHOLD=70.0
+# Enroll/verify liveness parity (2026-05-29): when True, face /enroll runs the
+# SAME passive liveness + anti-spoof veto as /verify BEFORE persisting the
+# embedding, so a photo/screen spoof cannot be enrolled. Default ON for
+# security (enrollment is at least as strict as verify). Reuses LIVENESS_MODE /
+# LIVENESS_BACKEND / ANTI_SPOOFING_ENABLED / LIVENESS_VERDICT_POLICY and the
+# ANTISPOOF_* pipeline flags (incl. ANTISPOOF_BLOCK_ENFORCE). Set False only
+# for controlled migration/observation.
+ENROLL_LIVENESS_ENABLED=True
 # Threshold calibration workflow:
 # 1) Collect labeled JSONL logs with {"label": "real|spoof", "score": <0-100>}
 # 2) Run: python scripts/calibrate_threshold.py --logs logs/liveness.jsonl --write-env .env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,16 @@ pytest tests/unit/ -v           # Unit tests only
 ### Fully implemented:
 - **Face**: enroll, verify, search, liveness, quality, demographics, landmarks, comparison
 - Routes: `enrollment.py`, `verification.py`, `search.py`, `liveness.py`, `quality.py`, etc.
+- **Enroll/verify liveness parity (2026-05-29)**: face `/enroll` now runs the SAME
+  server-authoritative passive liveness + spoof-detector anti-spoof / EAR veto
+  that `/verify` runs, BEFORE persisting the embedding — a photo/screen spoof
+  can no longer be enrolled. Gated by `ENROLL_LIVENESS_ENABLED` (default `True`).
+  Reuses `LIVENESS_MODE`/`LIVENESS_BACKEND`/`ANTI_SPOOFING_ENABLED`/
+  `LIVENESS_VERDICT_POLICY` (conservative) and the `ANTISPOOF_*` flags incl.
+  `ANTISPOOF_BLOCK_ENFORCE`; the anti-spoof helpers are imported from
+  `verification.py` so both paths share one implementation + one model singleton.
+  Single-image `/enroll` only (single still frame, like `/verify`);
+  `/enroll/multi` is unchanged.
 - **Voice**: enroll, verify, search, delete — Resemblyzer 256-dim speaker embeddings, centroid-based
 - Routes: `voice.py`, repo: `pgvector_voice_repository.py`, embedder: `speaker_embedder.py`
 - **Fingerprint**: removed (P1.4) — server-side fingerprint biometric processing was a SHA-256 hash placeholder, never a real biometric. Platform fingerprint authentication is delivered via WebAuthn (FIDO2) in identity-core-api, not through this service.

--- a/app/api/routes/enrollment.py
+++ b/app/api/routes/enrollment.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, Header, HTTPException, Request, UploadFile
 
+from app.api.routes import verification as verify_route
 from app.api.schemas.enrollment import EnrollmentResponse
 from app.api.schemas.multi_image_enrollment import MultiImageEnrollmentResponse
 from app.application.use_cases.check_liveness import CheckLivenessUseCase
@@ -131,20 +132,82 @@ async def enroll_face(
             await storage.cleanup(image_path)  # Clean up invalid file immediately
             raise HTTPException(status_code=400, detail=str(e))
 
-        # Liveness check — must pass before we commit the embedding to the DB
-        liveness_result = await liveness_use_case.execute(image_path=image_path)
-        if not liveness_result.is_live:
-            logger.warning(
-                f"Enrollment rejected — liveness check failed: "
-                f"user_id={user_id}, score={liveness_result.score:.2f}"
+        # ------------------------------------------------------------------
+        # Liveness + anti-spoof gate (2026-05-29) — close the documented
+        # enroll/verify asymmetry. Enrollment now runs the SAME server-
+        # authoritative passive liveness check AND the SAME spoof-detector
+        # anti-spoof / EAR veto that /verify runs, BEFORE the embedding is
+        # persisted, so a photo/screen spoof cannot be enrolled. The gate is
+        # configurable via ENROLL_LIVENESS_ENABLED (default ON) and reuses the
+        # verify path's verdict policy (conservative) — enrollment is at least
+        # as strict as verify. Like /verify, enrollment sends a single still
+        # frame, so we use passive single-frame liveness (no active blink/smile
+        # demand).
+        # ------------------------------------------------------------------
+        liveness_score: Optional[float] = None
+        if settings.ENROLL_LIVENESS_ENABLED:
+            # Passive liveness (UniFace MiniFASNet + DeepFace anti-spoof veto
+            # baked into CheckLivenessUseCase per LIVENESS_VERDICT_POLICY).
+            liveness_result = await liveness_use_case.execute(image_path=image_path)
+            liveness_score = liveness_result.score
+            if not liveness_result.is_live:
+                logger.warning(
+                    f"Enrollment rejected — liveness check failed: "
+                    f"user_id={user_id}, score={liveness_result.score:.2f}"
+                )
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error_code": "LIVENESS_FAILED",
+                        "message": "Liveness check failed",
+                        "score": liveness_result.score,
+                    },
+                )
+
+            # spoof-detector anti-spoof pipeline + single-frame EAR veto —
+            # identical to /verify. Helpers fail-soft to None when the optional
+            # spoof_detector package / MediaPipe asset is unavailable, and are
+            # additionally short-circuited by their own ANTISPOOF_* flags.
+            antispoof_pipeline = verify_route._evaluate_antispoof_pipeline_safe(image_path)
+            ear_liveness = verify_route._evaluate_ear_liveness_safe(image_path)
+            block_reason = verify_route._merge_block_verdict(
+                antispoof_pipeline=antispoof_pipeline,
+                ear_liveness=ear_liveness,
             )
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "error_code": "LIVENESS_FAILED",
-                    "message": "Liveness check failed",
-                    "score": liveness_result.score,
-                },
+            if block_reason is not None and settings.ANTISPOOF_BLOCK_ENFORCE:
+                logger.warning(
+                    "Enrollment BLOCKED by anti-spoof veto: user_id=%s reason=%s "
+                    "assembler_action=%s ear_avg=%s",
+                    user_id,
+                    block_reason,
+                    (antispoof_pipeline or {}).get("recommended_action"),
+                    (ear_liveness or {}).get("avg_ear"),
+                )
+                # Same structured error shape /verify uses for spoof rejection.
+                raise HTTPException(
+                    status_code=403,
+                    detail={
+                        "error_code": "ANTISPOOF_BLOCKED",
+                        "reason": block_reason,
+                        "antispoof_pipeline": antispoof_pipeline,
+                        "ear_liveness": ear_liveness,
+                        "message": "Enrollment rejected by anti-spoof checks",
+                    },
+                )
+            if block_reason is not None:
+                # Enforcement disabled: log the bypass loudly so observation-mode
+                # rollouts remain visible in production log streams (mirrors verify).
+                logger.warning(
+                    "Enrollment anti-spoof veto SUPPRESSED (ANTISPOOF_BLOCK_ENFORCE=false): "
+                    "user_id=%s reason=%s",
+                    user_id,
+                    block_reason,
+                )
+        else:
+            logger.info(
+                "Enrollment liveness/anti-spoof gate DISABLED "
+                "(ENROLL_LIVENESS_ENABLED=false): user_id=%s",
+                user_id,
             )
 
         # Execute enrollment use case
@@ -156,7 +219,7 @@ async def enroll_face(
             quality_score=result.quality_score,
             message="Face enrolled successfully",
             embedding_dimension=result.get_embedding_dimension(),
-            liveness_score=liveness_result.score,
+            liveness_score=liveness_score,
         )
 
         # Store response for idempotency if key provided

--- a/app/api/schemas/enrollment.py
+++ b/app/api/schemas/enrollment.py
@@ -1,5 +1,7 @@
 """Enrollment API schemas."""
 
+from typing import Optional
+
 from pydantic import BaseModel, Field
 
 
@@ -11,7 +13,18 @@ class EnrollmentResponse(BaseModel):
     quality_score: float = Field(..., ge=0, le=100, description="Image quality score (0-100)")
     message: str = Field(..., description="Human-readable message")
     embedding_dimension: int = Field(..., description="Dimension of face embedding")
-    liveness_score: float = Field(default=1.0, ge=0, le=1, description="Liveness score (0-1). Placeholder until anti-spoofing model is integrated.")
+    # 0-100 decision score from the passive liveness check (same scale as
+    # LivenessResult.score and LIVENESS_THRESHOLD). None when the enroll-time
+    # liveness gate is disabled (ENROLL_LIVENESS_ENABLED=false).
+    liveness_score: Optional[float] = Field(
+        default=None,
+        ge=0,
+        le=100,
+        description=(
+            "Passive liveness decision score (0-100). None when the enroll "
+            "liveness gate is disabled (ENROLL_LIVENESS_ENABLED=false)."
+        ),
+    )
 
     model_config = {
         "json_schema_extra": {
@@ -21,7 +34,7 @@ class EnrollmentResponse(BaseModel):
                 "quality_score": 85.5,
                 "message": "Face enrolled successfully",
                 "embedding_dimension": 128,
-                "liveness_score": 1.0,
+                "liveness_score": 92.0,
             }
         }
     }

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -745,6 +745,25 @@ class Settings(BaseSettings):
             "MediaPipe or the model is unavailable."
         ),
     )
+    # Liveness asymmetry fix (2026-05-29) — close the documented enroll/verify
+    # gap ("Faz 2'de düzeltilecek"). When True, the face /enroll path runs the
+    # SAME server-authoritative liveness + anti-spoof gate that /verify runs
+    # BEFORE persisting the embedding, so a photo/screen spoof cannot be
+    # enrolled. Default is ON for security: enrollment is at least as strict as
+    # verification. Set to False only for controlled migration/observation. The
+    # gate reuses the existing LIVENESS_MODE / LIVENESS_BACKEND /
+    # ANTI_SPOOFING_ENABLED / LIVENESS_VERDICT_POLICY and the ANTISPOOF_*
+    # pipeline flags rather than inventing parallel config.
+    ENROLL_LIVENESS_ENABLED: bool = Field(
+        default=True,
+        description=(
+            "When True, face /enroll runs the same passive liveness + "
+            "anti-spoof veto as /verify before persisting the embedding. "
+            "Default ON (enrollment must be at least as strict as verify). "
+            "Reuses LIVENESS_MODE/LIVENESS_BACKEND/ANTI_SPOOFING_ENABLED and "
+            "the ANTISPOOF_* flags; no parallel config."
+        ),
+    )
     GESTURE_HAND_LANDMARKER_MODEL_PATH: str = Field(
         default=str(_REPO_ROOT / "models" / "hand_landmarker.task"),
         description=(

--- a/tests/integration/test_enroll_liveness_antispoof.py
+++ b/tests/integration/test_enroll_liveness_antispoof.py
@@ -1,0 +1,350 @@
+"""Integration tests for the enroll-time liveness + anti-spoof gate.
+
+Closes the documented enroll/verify asymmetry (parent CLAUDE.md: "Faz 2'de
+düzeltilecek"). The /enroll face path now runs the SAME passive liveness +
+spoof-detector anti-spoof / EAR veto that /verify runs, BEFORE persisting the
+embedding, gated behind ENROLL_LIVENESS_ENABLED (default ON).
+
+Per the existing test_verify_antispoof_block_enforce.py convention this file
+uses a module-scoped TestClient to avoid the anyio-portal closed-loop issue
+when the route's lru-cached deps are recreated mid-suite. The enroll route
+calls the anti-spoof helpers via the `verification` module, so we patch the
+helpers on `verify_route` exactly as the verify tests do.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from unittest.mock import AsyncMock, Mock, patch
+
+import cv2
+import numpy as np
+import pytest
+
+# Mock heavy/optional deps before importing the app (same baseline-rot pattern
+# documented in bio main and used by test_verify_antispoof_block_enforce.py).
+sys.modules.setdefault("deepface", Mock())
+sys.modules.setdefault("deepface.DeepFace", Mock())
+sys.modules.setdefault("resemblyzer", Mock(VoiceEncoder=Mock()))
+
+from fastapi.testclient import TestClient
+
+from app.api.routes import verification as verify_route
+from app.core.container import (
+    get_check_liveness_use_case,
+    get_client_embedding_observation_repository,
+    get_enroll_face_use_case,
+    get_file_storage,
+    get_idempotency_store,
+)
+from app.domain.entities.face_embedding import FaceEmbedding
+from app.domain.entities.liveness_result import LivenessResult
+from app.main import app
+
+
+@pytest.fixture(scope="module")
+def _module_client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def client(_module_client) -> TestClient:
+    verify_route._antispoof_assembler = None
+    verify_route._antispoof_assembler_init_failed = False
+    verify_route._device_spoof_risk_evaluator = None
+    verify_route._face_landmarker_for_ear = None
+    verify_route._face_landmarker_for_ear_init_failed = False
+    app.dependency_overrides.clear()
+
+    yield _module_client
+
+    app.dependency_overrides.clear()
+    verify_route._antispoof_assembler = None
+    verify_route._antispoof_assembler_init_failed = False
+    verify_route._device_spoof_risk_evaluator = None
+    verify_route._face_landmarker_for_ear = None
+    verify_route._face_landmarker_for_ear_init_failed = False
+
+
+@pytest.fixture
+def test_image_file():
+    img = np.full((100, 100, 3), 80, dtype=np.uint8)
+    ok, buf = cv2.imencode(".jpg", img)
+    assert ok
+    return ("test.jpg", io.BytesIO(buf.tobytes()), "image/jpeg")
+
+
+def _make_live_liveness_uc():
+    uc = Mock()
+    uc.execute = AsyncMock(
+        return_value=LivenessResult(
+            is_live=True, score=92.0, challenge="none",
+            challenge_completed=True, confidence=0.91,
+        )
+    )
+    return uc
+
+
+def _make_spoof_liveness_uc():
+    uc = Mock()
+    uc.execute = AsyncMock(
+        return_value=LivenessResult(
+            is_live=False, score=12.0, challenge="none",
+            challenge_completed=True, confidence=0.20,
+        )
+    )
+    return uc
+
+
+@pytest.fixture
+def mocks(tmp_path):
+    """Wire all upstream enroll deps with fast, deterministic mocks."""
+    img = np.full((100, 100, 3), 80, dtype=np.uint8)
+    ok, buf = cv2.imencode(".jpg", img)
+    assert ok
+    image_path = tmp_path / "saved.jpg"
+    image_path.write_bytes(buf.tobytes())
+
+    enroll_uc = Mock()
+    enroll_uc.execute = AsyncMock(
+        return_value=FaceEmbedding.create_new(
+            user_id="test_user",
+            vector=np.full(512, 0.1, dtype=np.float32),
+            quality_score=85.0,
+        )
+    )
+
+    liveness_uc = _make_live_liveness_uc()
+
+    storage = Mock()
+    storage.save_temp = AsyncMock(return_value=str(image_path))
+    storage.cleanup = AsyncMock()
+
+    idempotency_store = Mock()
+    idempotency_store.get_response = AsyncMock(return_value=None)
+    idempotency_store.store_response = AsyncMock()
+
+    observation_repo = Mock()
+    observation_repo.record = AsyncMock()
+
+    return enroll_uc, liveness_uc, storage, idempotency_store, observation_repo
+
+
+def _wire(enroll_uc, liveness_uc, storage, idempotency_store, observation_repo) -> None:
+    app.dependency_overrides[get_enroll_face_use_case] = lambda: enroll_uc
+    app.dependency_overrides[get_check_liveness_use_case] = lambda: liveness_uc
+    app.dependency_overrides[get_file_storage] = lambda: storage
+    app.dependency_overrides[get_idempotency_store] = lambda: idempotency_store
+    app.dependency_overrides[get_client_embedding_observation_repository] = (
+        lambda: observation_repo
+    )
+
+
+# ---------------------------------------------------------------------------
+# Live frame passes + embedding is persisted
+# ---------------------------------------------------------------------------
+
+
+def test_enroll_passes_with_live_frame(client, mocks, test_image_file) -> None:
+    """A live frame with no spoof veto enrolls successfully (200)."""
+    enroll_uc, liveness_uc, storage, idem, obs = mocks
+    _wire(enroll_uc, liveness_uc, storage, idem, obs)
+
+    with patch.object(
+        verify_route.settings, "ANTISPOOF_BLOCK_ENFORCE", True
+    ), patch.object(
+        verify_route, "_evaluate_antispoof_pipeline_safe", return_value=None
+    ), patch.object(
+        verify_route, "_evaluate_ear_liveness_safe", return_value=None
+    ):
+        resp = client.post(
+            "/api/v1/enroll",
+            data={"user_id": "test_user_live"},
+            files={"file": test_image_file},
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["success"] is True
+    assert body["liveness_score"] == 92.0
+    # Embedding was persisted (use case executed).
+    enroll_uc.execute.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Spoof verdict (basic liveness) rejects + does NOT persist
+# ---------------------------------------------------------------------------
+
+
+def test_enroll_rejects_when_liveness_not_live(client, mocks, test_image_file) -> None:
+    """is_live=False → 400 LIVENESS_FAILED and embedding is NOT persisted."""
+    enroll_uc, _liveness_uc, storage, idem, obs = mocks
+    spoof_liveness_uc = _make_spoof_liveness_uc()
+    _wire(enroll_uc, spoof_liveness_uc, storage, idem, obs)
+
+    with patch.object(verify_route.settings, "ANTISPOOF_BLOCK_ENFORCE", True):
+        resp = client.post(
+            "/api/v1/enroll",
+            data={"user_id": "test_user_spoof"},
+            files={"file": test_image_file},
+        )
+
+    assert resp.status_code == 400, resp.text
+    detail = resp.json().get("detail") or {}
+    assert detail.get("error_code") == "LIVENESS_FAILED"
+    # CRITICAL: spoof must NOT be persisted.
+    enroll_uc.execute.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Anti-spoof pipeline "block" verdict rejects + does NOT persist
+# ---------------------------------------------------------------------------
+
+
+def test_enroll_rejects_on_antispoof_block(client, mocks, test_image_file) -> None:
+    """recommended_action='block' + enforce=True → 403 ANTISPOOF_BLOCKED, no persist."""
+    enroll_uc, liveness_uc, storage, idem, obs = mocks
+    _wire(enroll_uc, liveness_uc, storage, idem, obs)
+
+    fake_block = {
+        "face_usability_block": True,
+        "face_usability_reason": "occluded",
+        "hybrid_fusion_is_spoof": None,
+        "recommended_action": "block",
+        "layers_evaluated": ["face_usability"],
+    }
+
+    with patch.object(
+        verify_route.settings, "ANTISPOOF_BLOCK_ENFORCE", True
+    ), patch.object(
+        verify_route, "_evaluate_antispoof_pipeline_safe", return_value=fake_block
+    ), patch.object(
+        verify_route, "_evaluate_ear_liveness_safe", return_value=None
+    ):
+        resp = client.post(
+            "/api/v1/enroll",
+            data={"user_id": "test_user_block"},
+            files={"file": test_image_file},
+        )
+
+    assert resp.status_code == 403, resp.text
+    detail = resp.json().get("detail") or {}
+    assert detail.get("error_code") == "ANTISPOOF_BLOCKED"
+    assert detail.get("reason") == "FACE_UNUSABLE"
+    assert detail.get("antispoof_pipeline") == fake_block
+    # CRITICAL: spoof must NOT be persisted.
+    enroll_uc.execute.assert_not_awaited()
+
+
+def test_enroll_rejects_on_ear_closed_eyes(client, mocks, test_image_file) -> None:
+    """EAR eyes_closed=True → 403 ANTISPOOF_BLOCKED (EYES_CLOSED), no persist."""
+    enroll_uc, liveness_uc, storage, idem, obs = mocks
+    _wire(enroll_uc, liveness_uc, storage, idem, obs)
+
+    fake_ear = {
+        "eyes_closed": True,
+        "left_ear": 0.12,
+        "right_ear": 0.10,
+        "avg_ear": 0.11,
+        "threshold": 0.18,
+    }
+
+    with patch.object(
+        verify_route.settings, "ANTISPOOF_BLOCK_ENFORCE", True
+    ), patch.object(
+        verify_route, "_evaluate_antispoof_pipeline_safe", return_value=None
+    ), patch.object(
+        verify_route, "_evaluate_ear_liveness_safe", return_value=fake_ear
+    ):
+        resp = client.post(
+            "/api/v1/enroll",
+            data={"user_id": "test_user_ear"},
+            files={"file": test_image_file},
+        )
+
+    assert resp.status_code == 403, resp.text
+    detail = resp.json().get("detail") or {}
+    assert detail.get("error_code") == "ANTISPOOF_BLOCKED"
+    assert detail.get("reason") == "EYES_CLOSED"
+    enroll_uc.execute.assert_not_awaited()
+
+
+def test_enroll_antispoof_observe_mode_does_not_block(
+    client, mocks, test_image_file
+) -> None:
+    """block verdict + ANTISPOOF_BLOCK_ENFORCE=False → 200, embedding persisted."""
+    enroll_uc, liveness_uc, storage, idem, obs = mocks
+    _wire(enroll_uc, liveness_uc, storage, idem, obs)
+
+    fake_block = {
+        "face_usability_block": False,
+        "hybrid_fusion_is_spoof": True,
+        "recommended_action": "block",
+        "layers_evaluated": ["hybrid_fusion"],
+    }
+
+    with patch.object(
+        verify_route.settings, "ANTISPOOF_BLOCK_ENFORCE", False
+    ), patch.object(
+        verify_route, "_evaluate_antispoof_pipeline_safe", return_value=fake_block
+    ), patch.object(
+        verify_route, "_evaluate_ear_liveness_safe", return_value=None
+    ):
+        resp = client.post(
+            "/api/v1/enroll",
+            data={"user_id": "test_user_observe"},
+            files={"file": test_image_file},
+        )
+
+    # Observation mode: verdict suppressed, enrollment proceeds.
+    assert resp.status_code == 200, resp.text
+    enroll_uc.execute.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# The flag disables the gate entirely
+# ---------------------------------------------------------------------------
+
+
+def test_enroll_gate_disabled_skips_liveness(client, mocks, test_image_file) -> None:
+    """ENROLL_LIVENESS_ENABLED=False → liveness use case is never called,
+    anti-spoof helpers are never called, enrollment proceeds (200) and
+    liveness_score is None.
+    """
+    enroll_uc, _live_uc, storage, idem, obs = mocks
+    # Use a spoof liveness UC to prove it is NOT consulted when the gate is off.
+    spoof_liveness_uc = _make_spoof_liveness_uc()
+    _wire(enroll_uc, spoof_liveness_uc, storage, idem, obs)
+
+    antispoof_mock = Mock(return_value=None)
+    ear_mock = Mock(return_value=None)
+
+    with patch.object(
+        verify_route.settings, "ENROLL_LIVENESS_ENABLED", False
+    ), patch.object(
+        verify_route, "_evaluate_antispoof_pipeline_safe", antispoof_mock
+    ), patch.object(
+        verify_route, "_evaluate_ear_liveness_safe", ear_mock
+    ):
+        # The enroll route reads settings via its own module import; patch both
+        # to be safe (same Settings singleton object instance).
+        from app.api.routes import enrollment as enroll_route
+
+        with patch.object(enroll_route.settings, "ENROLL_LIVENESS_ENABLED", False):
+            resp = client.post(
+                "/api/v1/enroll",
+                data={"user_id": "test_user_gate_off"},
+                files={"file": test_image_file},
+            )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["success"] is True
+    assert body["liveness_score"] is None
+    # Gate off: liveness UC not consulted, anti-spoof helpers not called.
+    spoof_liveness_uc.execute.assert_not_awaited()
+    assert antispoof_mock.call_count == 0
+    assert ear_mock.call_count == 0
+    enroll_uc.execute.assert_awaited_once()


### PR DESCRIPTION
## Problem

The `/verify` face path runs a server-authoritative passive liveness check **and** the spoof-detector anti-spoof / EAR veto, but the face `/enroll` path only ran basic liveness — it did **not** run the same anti-spoof pipeline veto, and (when the basic liveness path was disabled) a photo/screen spoof could be enrolled. This is the documented gap ("Faz 2'de düzeltilecek").

## Change

Face `/enroll` now runs the **same** liveness + anti-spoof gate as `/verify`, **before persisting the embedding**:

1. Passive single-frame liveness via `CheckLivenessUseCase` (UniFace MiniFASNet + DeepFace anti-spoof veto under `LIVENESS_VERDICT_POLICY=conservative`) → on failure, `400 LIVENESS_FAILED`.
2. spoof-detector anti-spoof pipeline + single-frame EAR closed-eye veto (`_evaluate_antispoof_pipeline_safe` / `_evaluate_ear_liveness_safe` / `_merge_block_verdict`, imported from `verification.py` so both paths share one implementation and one model singleton) → on a `block` verdict with `ANTISPOOF_BLOCK_ENFORCE=true`, `403 ANTISPOOF_BLOCKED` with the same structured body `/verify` uses.

On any spoof verdict the embedding is **not** saved. Single still frame only (like `/verify`) — no active blink/smile is demanded. `/enroll/multi` is unchanged (out of scope).

## Config

- **New flag `ENROLL_LIVENESS_ENABLED`, default `TRUE`** (enrollment must be at least as strict as verify). When `false`, the gate is skipped entirely and `liveness_score` is `null`.
- Reuses `LIVENESS_MODE` / `LIVENESS_BACKEND` / `ANTI_SPOOFING_ENABLED` / `LIVENESS_VERDICT_POLICY` and the `ANTISPOOF_*` flags incl. `ANTISPOOF_BLOCK_ENFORCE`. No parallel config.
- `EnrollmentResponse.liveness_score` is now `Optional[float]` on the correct **0-100** scale (was `float` with `ge=0,le=1` — a latent bug, since the real liveness score is 0-100 and would have failed validation).

## Tests

New `tests/integration/test_enroll_liveness_antispoof.py` (module-scoped TestClient per repo convention): spoof rejected (basic liveness, assembler `block`, EAR closed-eyes), live frame passes + embedding persisted, observe-mode (`ANTISPOOF_BLOCK_ENFORCE=false`) passes, and the flag disables the gate. **6/6 pass.** Existing verify anti-spoof tests still pass (20/20 combined). The repo's ~14 pre-existing tensorflow/deepface-import baseline failures are unrelated and untouched.

Not deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)