### PR TITLE
feat(voice): real CPU-only enrollment quality metric (P1-3)

### DIFF
--- a/app/api/routes/voice.py
+++ b/app/api/routes/voice.py
@@ -31,6 +31,7 @@ from app.core.container import (
 )
 from app.core.validation import validate_user_id
 from app.infrastructure.ml.voice.replay_detector import compute_spectral_fingerprint
+from app.infrastructure.ml.voice.speaker_embedder import compute_voice_quality_score
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +66,22 @@ async def _compute_replay_fingerprint(voice_data: str) -> np.ndarray:
     pool = get_thread_pool()
     samples = await pool.run_blocking(embedder.decode_samples_from_base64, voice_data)
     return await pool.run_blocking(compute_spectral_fingerprint, samples)
+
+
+async def _compute_voice_quality(voice_data: str) -> float:
+    """Decode audio and compute the 0..100 voice quality score off the loop.
+
+    Best-effort: any decode/analysis failure falls back to a neutral 50.0 so a
+    quality hiccup never blocks an otherwise-successful enrollment.
+    """
+    embedder = get_speaker_embedder()
+    pool = get_thread_pool()
+    try:
+        samples = await pool.run_blocking(embedder.decode_samples_from_base64, voice_data)
+        return await pool.run_blocking(compute_voice_quality_score, samples)
+    except Exception as e:  # noqa: BLE001 — quality scoring must never break enroll
+        logger.warning(f"Voice quality scoring skipped (error): {e}")
+        return 50.0
 
 
 async def _run_replay_check(
@@ -124,16 +141,24 @@ async def enroll_voice(request: VoiceRequest) -> BiometricResponse:
         # Extract speaker embedding (CPU-bound -- offloaded to thread pool)
         embedding = await _extract_voice_embedding(voice_data)
 
-        # Store in database (async I/O -- safe on event loop)
+        # Real signal-quality metric (0..100), CPU-only, computed from the
+        # decoded audio (duration / loudness / SNR). Replaces the old hardcoded
+        # placeholder so the admin Enrollments table + downstream gates see a
+        # real number (P1-3).
+        quality_score = await _compute_voice_quality(voice_data)
+
+        # Store in database (async I/O -- safe on event loop). The DB column is
+        # 0..1, so rescale the 0..100 metric.
         repo = get_voice_repository()
         await repo.save(
             user_id=user_id,
             embedding=embedding,
-            quality_score=1.0,  # Voice has no quality metric yet
+            quality_score=round(quality_score / 100.0, 4),
         )
 
         logger.info(
-            f"Voice enrolled: user_id={user_id}, dim={len(embedding)}"
+            f"Voice enrolled: user_id={user_id}, dim={len(embedding)}, "
+            f"quality={quality_score:.1f}"
         )
 
         return BiometricResponse(
@@ -141,6 +166,8 @@ async def enroll_voice(request: VoiceRequest) -> BiometricResponse:
             message="Voice enrolled successfully",
             user_id=user_id,
             embedding_dimension=len(embedding),
+            # 0..100 — identity-core-api rescales to 0..1 for user_enrollments.
+            quality_score=round(quality_score, 2),
         )
 
     except ValueError as e:

--- a/app/api/schemas/biometric_response.py
+++ b/app/api/schemas/biometric_response.py
@@ -21,3 +21,7 @@ class BiometricResponse(BaseModel):
     implemented: bool = True
     embedding_dimension: Optional[int] = None
     verified: Optional[bool] = None
+    # 0..100 enrollment quality score (voice: computed from signal duration /
+    # loudness / SNR). identity-core-api reads this off the JSON and rescales
+    # 0..100 → 0..1 for the user_enrollments.quality_score column (P1-3).
+    quality_score: Optional[float] = None

--- a/app/infrastructure/ml/voice/speaker_embedder.py
+++ b/app/infrastructure/ml/voice/speaker_embedder.py
@@ -32,6 +32,110 @@ MIN_AUDIO_DURATION_SECS = 0.5
 # Target sample rate (Resemblyzer convention)
 TARGET_SAMPLE_RATE = 16000
 
+# --- Voice quality metric tuning (CPU-only, deterministic) --------------------
+# Effective speech reaching this many seconds earns the full duration credit.
+QUALITY_TARGET_SPEECH_SECS = 3.0
+# A frame counts as "speech" when its RMS is at least this fraction of the
+# clip's peak frame RMS. Cheap, level-independent energy-based VAD.
+QUALITY_SPEECH_REL_THRESHOLD = 0.10
+# RMS window for the energy / VAD / SNR analysis (20 ms @ 16 kHz = 320 samples).
+QUALITY_FRAME_SAMPLES = 320
+# Loudness sweet-spot: an overall RMS at/above this (in [0,1] PCM units) is
+# treated as fully loud-enough. ~ -26 dBFS. Below it the score scales linearly.
+QUALITY_GOOD_RMS = 0.05
+# Fraction of samples at/above this magnitude that we treat as clipping. The
+# loudness sub-score is penalised once clipping exceeds a small tolerance.
+QUALITY_CLIP_MAGNITUDE = 0.99
+QUALITY_CLIP_TOLERANCE = 0.01  # up to 1% clipped samples is unpenalised
+# SNR (dB) at/above which the noise sub-score is full; at/below the floor it's 0.
+QUALITY_SNR_FULL_DB = 25.0
+QUALITY_SNR_FLOOR_DB = 5.0
+
+
+def _frame_rms(samples: np.ndarray, frame: int) -> np.ndarray:
+    """Per-frame RMS energy for non-overlapping ``frame``-sample windows."""
+    n_full = len(samples) // frame
+    if n_full == 0:
+        return np.array([], dtype=np.float64)
+    trimmed = samples[: n_full * frame].astype(np.float64).reshape(n_full, frame)
+    return np.sqrt(np.mean(np.square(trimmed), axis=1))
+
+
+def compute_voice_quality_score(samples: np.ndarray) -> float:
+    """Compute a deterministic 0..100 voice-enrollment quality score.
+
+    CPU-only, no ML, no extra dependencies — derived entirely from the decoded
+    16 kHz mono PCM samples (``decode_samples_from_base64``). Replaces the old
+    hardcoded ``quality_score=1.0`` placeholder so the admin Enrollments table
+    and downstream gates see a real signal.
+
+    The score is the weighted blend of three bounded sub-scores:
+
+    * **Speech duration (50%)** — fraction of the clip that is energetic enough
+      to be speech (relative-RMS VAD), credited up to
+      ``QUALITY_TARGET_SPEECH_SECS``. Short or silent clips score near zero.
+    * **Loudness (25%)** — overall RMS mapped into a sweet spot: too quiet
+      scales down linearly toward ``QUALITY_GOOD_RMS``; heavy clipping
+      (fraction of |sample| >= ``QUALITY_CLIP_MAGNITUDE`` over a small
+      tolerance) is penalised.
+    * **SNR (25%)** — a cheap speech-vs-noise-floor estimate: median RMS of the
+      loud (speech) frames over the quiet (noise) frames, in dB, mapped from
+      ``QUALITY_SNR_FLOOR_DB`` (0) to ``QUALITY_SNR_FULL_DB`` (1).
+
+    Deterministic and bounded to [0, 100]. Empty/silent input → 0.0.
+
+    Args:
+        samples: 1-D float32/float64 mono PCM in [-1, 1] at 16 kHz.
+
+    Returns:
+        Quality score in [0.0, 100.0].
+    """
+    if samples is None or len(samples) == 0:
+        return 0.0
+
+    samples = np.asarray(samples, dtype=np.float64)
+    frames = _frame_rms(samples, QUALITY_FRAME_SAMPLES)
+    if frames.size == 0:
+        return 0.0
+
+    peak_frame_rms = float(frames.max())
+    if peak_frame_rms <= 0.0:
+        return 0.0  # pure silence
+
+    # --- (a) effective speech duration -----------------------------------
+    speech_mask = frames >= (QUALITY_SPEECH_REL_THRESHOLD * peak_frame_rms)
+    speech_secs = float(speech_mask.sum() * QUALITY_FRAME_SAMPLES) / TARGET_SAMPLE_RATE
+    duration_sub = min(1.0, speech_secs / QUALITY_TARGET_SPEECH_SECS)
+
+    # --- (b) loudness (RMS sweet-spot, clipping-penalised) ---------------
+    overall_rms = float(np.sqrt(np.mean(np.square(samples))))
+    loudness_sub = min(1.0, overall_rms / QUALITY_GOOD_RMS)
+    clip_fraction = float(np.mean(np.abs(samples) >= QUALITY_CLIP_MAGNITUDE))
+    if clip_fraction > QUALITY_CLIP_TOLERANCE:
+        # Linearly drop the loudness sub-score as clipping worsens past the
+        # tolerance; fully clipped (100%) → 0.
+        loudness_sub *= max(0.0, 1.0 - (clip_fraction - QUALITY_CLIP_TOLERANCE))
+
+    # --- (c) SNR estimate (speech frames vs noise-floor frames) ----------
+    if speech_mask.any() and (~speech_mask).any():
+        speech_level = float(np.median(frames[speech_mask]))
+        noise_level = float(np.median(frames[~speech_mask]))
+        if noise_level <= 1e-9:
+            snr_sub = 1.0  # essentially no measurable noise floor
+        else:
+            snr_db = 20.0 * np.log10(max(speech_level, 1e-9) / noise_level)
+            snr_sub = (snr_db - QUALITY_SNR_FLOOR_DB) / (
+                QUALITY_SNR_FULL_DB - QUALITY_SNR_FLOOR_DB
+            )
+            snr_sub = max(0.0, min(1.0, snr_sub))
+    else:
+        # No separable noise floor (all frames speech, or all silence already
+        # handled above). Neutral SNR contribution.
+        snr_sub = 0.5
+
+    score = 100.0 * (0.50 * duration_sub + 0.25 * loudness_sub + 0.25 * snr_sub)
+    return float(max(0.0, min(100.0, score)))
+
 
 class SpeakerEmbedder:
     """Extracts 256-dim speaker embeddings from audio using Resemblyzer.

--- a/tests/unit/infrastructure/test_voice_quality_metric.py
+++ b/tests/unit/infrastructure/test_voice_quality_metric.py
@@ -1,0 +1,82 @@
+"""Unit tests for compute_voice_quality_score (P1-3).
+
+The voice enrollment quality metric is CPU-only and deterministic, derived
+entirely from decoded 16 kHz mono PCM samples (no ML, no extra deps). These
+tests pin the contract:
+
+    * silence / too-short input  -> low (near-zero) score
+    * a clean, loud, sufficiently long speech-like clip -> high score
+    * the output is always bounded to [0, 100]
+    * the function is deterministic (same input -> same output)
+"""
+
+import numpy as np
+
+from app.infrastructure.ml.voice.speaker_embedder import (
+    TARGET_SAMPLE_RATE,
+    compute_voice_quality_score,
+)
+
+
+def _tone(secs: float, freq: float = 220.0, amplitude: float = 0.3) -> np.ndarray:
+    """A clean sine tone — stands in for sustained, loud, low-noise speech."""
+    n = int(secs * TARGET_SAMPLE_RATE)
+    t = np.arange(n, dtype=np.float64) / TARGET_SAMPLE_RATE
+    return (amplitude * np.sin(2 * np.pi * freq * t)).astype(np.float32)
+
+
+def _speech_then_silence(speech_secs: float, silence_secs: float) -> np.ndarray:
+    """A loud tone followed by a near-silent (low-noise) tail.
+
+    Gives the metric separable speech vs noise-floor frames so the SNR
+    sub-score is exercised.
+    """
+    speech = _tone(speech_secs, amplitude=0.3)
+    n_sil = int(silence_secs * TARGET_SAMPLE_RATE)
+    rng = np.random.default_rng(0)
+    silence = (1e-4 * rng.standard_normal(n_sil)).astype(np.float32)
+    return np.concatenate([speech, silence])
+
+
+def test_empty_input_scores_zero():
+    assert compute_voice_quality_score(np.array([], dtype=np.float32)) == 0.0
+
+
+def test_pure_silence_scores_low():
+    silence = np.zeros(int(3 * TARGET_SAMPLE_RATE), dtype=np.float32)
+    assert compute_voice_quality_score(silence) < 5.0
+
+
+def test_too_short_clip_scores_low():
+    # 0.3s of speech — well under the 3s target, so the 50%-weight duration
+    # sub-score is small and drags the total down.
+    score = compute_voice_quality_score(_tone(0.3))
+    assert score < 50.0
+
+
+def test_good_clip_scores_high():
+    # 4s loud clean tone + a quiet tail: long enough (duration saturated),
+    # loud enough, and high SNR -> should land in the upper range.
+    score = compute_voice_quality_score(_speech_then_silence(4.0, 1.0))
+    assert score >= 75.0
+    assert score <= 100.0
+
+
+def test_quiet_clip_scores_lower_than_loud():
+    quiet = compute_voice_quality_score(_tone(4.0, amplitude=0.005))
+    loud = compute_voice_quality_score(_tone(4.0, amplitude=0.3))
+    assert quiet < loud
+
+
+def test_score_is_bounded():
+    # An aggressively clipped, max-amplitude square-ish wave must still be in range.
+    n = int(4 * TARGET_SAMPLE_RATE)
+    clipped = np.ones(n, dtype=np.float32)
+    clipped[1::2] = -1.0
+    score = compute_voice_quality_score(clipped)
+    assert 0.0 <= score <= 100.0
+
+
+def test_deterministic():
+    clip = _speech_then_silence(3.0, 1.0)
+    assert compute_voice_quality_score(clip) == compute_voice_quality_score(clip)


### PR DESCRIPTION
## Problem (P1-3)

`/voice/enroll` stored a hardcoded `quality_score=1.0` (comment: *"Voice has no quality metric yet"*) and the voice `BiometricResponse` carried no quality field at all — so `user_enrollments.quality_score` was always NULL for voice, and the admin Enrollments table had nothing real to show.

## Change

New `compute_voice_quality_score(samples)` helper in `speaker_embedder.py` (next to `extract_embedding` / the decode path) — **deterministic, bounded 0..100, CPU-only, no GPU, no heavy ML, no new deps**. Computed entirely from the already-decoded 16 kHz mono PCM (`decode_samples_from_base64`):

```
score = 100 * (0.50 * duration + 0.25 * loudness + 0.25 * snr)
```

- **duration (50%)** — fraction of the clip energetic enough to be speech (relative-RMS VAD over 20 ms frames), credited up to a 3 s target. Short / silent clips score near zero.
- **loudness (25%)** — overall RMS mapped into a sweet spot (too quiet scales down toward ~-26 dBFS); penalised once clipping exceeds a 1% tolerance.
- **snr (25%)** — cheap speech-vs-noise-floor estimate: median RMS of the loud (speech) frames over the quiet (noise) frames, in dB, mapped `5 dB → 0` .. `25 dB → 1`.

Silence / too-short → low; clean loud clip → high; output always clamped to `[0, 100]`.

### Wiring

`enroll_voice` now computes the score off the event loop (`_compute_voice_quality`, best-effort — falls back to a neutral `50.0` on any decode error so a quality hiccup never blocks enroll), stores `quality/100` in the 0..1 `quality_score` DB column, and returns `quality_score` (0..100) on the shared `BiometricResponse`. identity-core-api reads that off the JSON and rescales 0..100 → 0..1 onto `user_enrollments` (its `EnrollBiometricService.extractScore` already divides values in (1,100] by 100). The paired API PR fixes the Java persistence side.

## Deploy note

Code-only change — shippable on the proven `Dockerfile.liveness-overlay` overlay image (the canonical from-scratch `Dockerfile` currently segfaults at the MiniFASNet ONNX load; see `CLAUDE.md`). **Do not deploy on merge.**

## Tests

New `tests/unit/infrastructure/test_voice_quality_metric.py`: empty/silence/too-short → low, good loud long clip → high, output bounded `[0,100]`, quiet < loud, deterministic.

`python3 -m pytest` on the voice suite (`test_voice_quality_metric` + `test_voice_replay_detector` + `test_voice_routes`) → **16 passed**. (The repo-wide `-k voice` run hits two pre-existing, unrelated collection errors from `tensorflow`/`memory_embedding_repository` not being present on the host — this code runs in Docker; not caused by this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)