### PR TITLE
build(bio): canonical reproducible Dockerfile — digest-pinned base, boots clean (P0-2b)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,41 +14,64 @@ pip install -r requirements.txt
 python -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8001
 ```
 
-## ⚠️ Rebuild caution — dependency lock (2026-05-29)
+## ✅ Canonical reproducible build RESTORED — P0-2b (2026-05-30)
 
-The deployed prod image (`75347c98…`, healthy) is ~2 weeks old. `requirements.txt`
-historically pinned everything with `>=`, so a fresh rebuild drifted ~42 packages
-(numpy 2.4.4→2.4.6, protobuf 7.34.1→7.35.0, uniface 3.6.0→3.7.0, fastapi, nvidia-*, …).
-The drifted set **segfaults** during the UniFace MiniFASNet ONNX session preload at
-full-app boot under the `read_only` rootfs + `cap_drop:ALL` runtime (a native-ABI
-interaction — an isolated MiniFASNet load works in BOTH uniface versions, so it's the
-combination, not one library). Two other rebuild blockers were already fixed in
-`docker-compose.prod.yml` (cap_add CHOWN/SETUID/SETGID for the gosu drop; forward the
-DeepFace SHA pin from .env.prod).
+**The from-scratch `Dockerfile` build now BOOTS CLEAN under the prod
+`read_only`+`cap_drop` runtime — verified, ready to deploy + retire the overlay.**
 
-**UPDATE 2026-05-29 (verified in isolation):** pinning `numpy==2.4.4` + `uniface==3.6.0`
-to the exact working versions is **NOT sufficient** — a from-scratch rebuild STILL
-segfaults at the MiniFASNet ONNX load. The remaining cause is base-image + deeper
-native drift: the floating `python:3.12-slim` base moved **Debian 13.4→13.5**
-(glibc deb13u2→u3) and torch/nvidia-cu13/onnxruntime-transitive libs drifted. So the
-canonical `Dockerfile` cannot currently be rebuilt for prod.
+### What was wrong (history)
+The deployed prod image (`75347c98…`, healthy) was built ~2 weeks before this and
+`requirements.txt` historically pinned everything with `>=`, so a fresh rebuild
+drifted ~42 packages (numpy 2.4.4→2.4.6, protobuf 7.34.1→7.35.0, uniface
+3.6.0→3.7.0, fastapi, nvidia-*, …) AND the floating `python:3.12-slim` base moved
+Debian 13.4→13.5. The drifted set **segfaulted** during the UniFace MiniFASNet ONNX
+session preload at full-app boot under `read_only`+`cap_drop:ALL` (a native-ABI
+interaction — an isolated MiniFASNet load works fine; it was the combination).
 
-**WHAT IS DEPLOYED NOW:** the prod image is built via **`Dockerfile.liveness-overlay`** —
-a code-only layer `FROM` the proven working image (`75347c98`, retagged
-`biometric-processor-biometric-api:working-75347c98`) that overlays the current `app/`
-source (incl. liveness-on-enroll #119) onto the exact known-good dependency set. This
-ships the security feature with zero dep-drift risk. `ENROLL_LIVENESS_ENABLED=True`.
-To redeploy a code change: `docker build -f Dockerfile.liveness-overlay -t
-biometric-processor-biometric-api:latest . && docker compose -f docker-compose.prod.yml
---env-file .env.prod up -d biometric-api` (boot-test first; roll back by retagging
-`working-75347c98` → `:latest`).
+### The fix (P0-2b)
+1. **Both `FROM` lines in `Dockerfile` are now pinned by DIGEST**
+   (`python:3.12-slim@sha256:090ba77e…`) so the base can never float again. (The
+   13.4-era trixie digest is no longer tag-served — Docker Hub overwrote the
+   `3.12.13-slim` tag with the 13.5 rebuild on 2026-05-22 — so this pins the
+   *settled* 13.5 digest. The boot test below proves settled-13.5 + the pinned
+   native set is fine; the segfault was the floating *drift*, not 13.5 per se.)
+2. **Deps install from `requirements-known-good-2026-05-29.lock` applied as a pip
+   `-c` constraints file** over the staged ML install + `requirements.txt`, so every
+   transitive (torch 2.11.0+cu130, onnxruntime 1.26.0, numpy 2.4.4, uniface 3.6.0,
+   nvidia-cu13, …) resolves to the exact proven version. The tf-cpu/deepface/opencv
+   special-casing is preserved: the lock's `tensorflow==`, `deepface==`,
+   `opencv-python-headless==` and the `spoof-detector @ git+` lines are stripped from
+   the constraints (we install `tensorflow-cpu`, deepface `--no-deps`, and headless
+   opencv separately) so the lock's plain-`tensorflow` line can't force a GPU-only
+   resolution. One lock edit: `idna 3.14→3.15` (pure-Python, the only lock↔
+   requirements.txt conflict, needed to satisfy the `idna>=3.15` security floor).
 
-**STILL TODO (tracked — reproducible canonical build):** pin the base image by DIGEST
-(both `FROM` lines) to a known-good build + install from
-`requirements-known-good-2026-05-29.lock` (handling the tf-cpu/deepface/opencv
-special-casing so the lock's `tensorflow` line doesn't pull the GPU wheel). Until then
-the overlay is the deploy path. The `requirements.txt` native pins + the compose
-cap_add/DeepFace-env fixes remain in place as partial groundwork.
+### Boot-test result (2026-05-30, isolated, prod runtime)
+Built to a throwaway tag and booted under an isolated copy of
+`docker-compose.prod.yml`'s hardening (`read_only`+`tmpfs`+`cap_drop:ALL`+
+`cap_add CHOWN/SETUID/SETGID`+`no-new-privileges`), on the `backend` network with
+shared-postgres/redis, the prod `biometric-api` container untouched. With the uniface
+ONNX seeded into the cache volume (as in real prod), boot logged:
+`Pre-loading UniFace MiniFASNet (process-wide shared ONNX session)…` →
+**`UniFace MiniFASNet model loaded (process-wide shared session)`** →
+`Startup health-check: liveness detector OK` → `Application startup complete` →
+`/api/v1/health` **HTTP 200**. **Zero segfault/SIGSEGV signatures, 0 restarts, no
+OOM.** The exact previously-segfaulting ONNX session load now succeeds.
+
+### Deploy (operator) — retire the overlay
+```bash
+cd /opt/projects/fivucsas/biometric-processor
+docker compose -f docker-compose.prod.yml --env-file .env.prod build biometric-api   # canonical Dockerfile, digest-pinned
+docker compose -f docker-compose.prod.yml --env-file .env.prod up -d biometric-api
+# rollback: retag biometric-processor-biometric-api:working-75347c98 → :latest, up -d
+```
+Two earlier rebuild blockers remain fixed in `docker-compose.prod.yml` (cap_add
+CHOWN/SETUID/SETGID for the gosu drop; DeepFace SHA pin forwarded from .env.prod).
+
+### Overlay (still available as fallback)
+`Dockerfile.liveness-overlay` (code-only layer `FROM` the proven `75347c98` image)
+remains in-repo as the zero-risk fallback path if a future base/lock refresh
+reintroduces drift. It is NO LONGER the required deploy path.
 
 ## Migrations (Alembic)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,16 @@
 #   2.7_80x80_MiniFASNetV2.pth     a5eb02e1843f19b5386b953cc4c9f011c3f985d0ee2bb9819eea9a142099bec0
 #   4_0_0_80x80_MiniFASNetV1SE.pth 84ee1d37d96894d5e82de5a57df044ef80a58be2b218b5ed7cdfd875ec2f5990
 # ============================================================================
-FROM python:3.12-slim AS model-fetcher
+# REPRODUCIBLE BASE (P0-2b, 2026-05-30): pin BOTH FROM lines by DIGEST so the
+# floating `python:3.12-slim` tag can never silently drift the Debian point
+# release out from under us again (the 13.4→13.5 move + torch/onnxruntime
+# native drift is what segfaulted the MiniFASNet ONNX preload under prod
+# read_only+cap_drop). Digest below = `python:3.12.13-slim` (Debian 13 trixie,
+# Python 3.12.13) as resolved on 2026-05-30. See CLAUDE.md P0-2b for the
+# boot-test outcome and the digest-selection rationale (the 13.4-era trixie
+# digest is no longer tag-served by Docker Hub — overwritten by the 13.5
+# rebuild on 2026-05-22 — so this pins the settled, no-longer-floating digest).
+FROM python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203 AS model-fetcher
 
 ARG FACENET512_SHA256=3f76b5117a9ca574d536af8199e6720089eb4ad3dc7e93534496d88265de864f
 ARG CENTERFACE_SHA256=77e394b51108381b4c4f7b4baf1c64ca9f4aba73e5e803b2636419578913b5fe
@@ -62,7 +71,8 @@ RUN set -eux; \
 # ============================================================================
 # Stage 2: runtime
 # ============================================================================
-FROM python:3.12-slim
+# Same digest pin as the model-fetcher stage (see P0-2b note above).
+FROM python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -94,30 +104,50 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gosu \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy requirements
+# Copy requirements + the known-good lock.
 COPY requirements.txt .
+COPY requirements-known-good-2026-05-29.lock .
 
-# 1. First install opencv-python-headless to claim cv2 namespace
-RUN pip install --no-cache-dir opencv-python-headless>=4.8.0
+# REPRODUCIBLE DEPS (P0-2b): the lock is a full `pip freeze` of the proven
+# working image (75347c98). We install the staged ML deps + requirements.txt
+# WITH the lock applied as a pip CONSTRAINTS file (`-c`), so every transitive
+# resolves to the exact known-good version — without letting the lock's plain
+# `tensorflow==2.21.0` line pull the GPU wheel (we install `tensorflow-cpu`
+# instead; a constraints file only pins, it never forces an install). The
+# tf-cpu / deepface / opencv special-casing below is preserved verbatim and
+# each version is bumped to the lock's exact pin.
+#
+# Strip the three lines that need special handling out of the constraints file
+# so `-c` does not (a) try to install plain `tensorflow` or (b) conflict with
+# our `--no-deps` deepface / headless-opencv staging:
+#   - tensorflow==      (we use tensorflow-cpu, line kept separately)
+#   - deepface==        (installed --no-deps)
+#   - opencv-python-headless==  (installed/forced separately, last)
+#   - spoof-detector @ git+...  (VCS line; comes from requirements.txt pin)
+RUN grep -viE '^(tensorflow==|deepface==|opencv-python-headless==|spoof-detector @)' \
+        requirements-known-good-2026-05-29.lock > /tmp/constraints.txt
 
-# 2. Install tensorflow-cpu (big dependency)
-RUN pip install --no-cache-dir tensorflow-cpu==2.21.0
+# 1. First install opencv-python-headless to claim cv2 namespace (lock pin).
+RUN pip install --no-cache-dir opencv-python-headless==4.13.0.92
 
-# 3. Install deepface WITHOUT dependencies to avoid opencv-python
-#    Then install missing deepface dependencies manually
+# 2. Install tensorflow-cpu (big dependency) — lock pins tensorflow_cpu==2.21.0.
+RUN pip install --no-cache-dir -c /tmp/constraints.txt tensorflow-cpu==2.21.0
+
+# 3. Install deepface WITHOUT dependencies to avoid opencv-python (lock pin).
+#    Then install missing deepface dependencies manually (lock pins).
 RUN pip install --no-cache-dir --no-deps deepface==0.0.98 && \
-    pip install --no-cache-dir lightphe lightdsa
+    pip install --no-cache-dir -c /tmp/constraints.txt lightphe==0.0.24 lightdsa==0.0.3
 
-# 4. Install remaining requirements
-# Note: requirements.txt pins librosa==0.9.2 to avoid numba @stencil/@guvectorize
-# crash on Python 3.12 (AttributeError: get_call_template). librosa >= 0.10.0
-# introduced eager-compiling numba decorators that crash at import time
-# regardless of NUMBA_DISABLE_JIT. librosa 0.9.2 has no numba stencil usage.
-RUN pip install --no-cache-dir -r requirements.txt
+# 4. Install remaining requirements under the lock constraints so every
+#    transitive (torch, onnxruntime, numpy, uniface, mediapipe, ...) lands on
+#    the exact known-good version. requirements.txt pins librosa==0.9.2 to avoid
+#    the numba @stencil/@guvectorize crash on Python 3.12; the lock agrees.
+RUN pip install --no-cache-dir -c /tmp/constraints.txt -r requirements.txt
 
 # 5. Force uninstall opencv-python if it got installed, reinstall headless
+#    (lock pin, --no-deps so the force-reinstall can't drag numpy back).
 RUN pip uninstall -y opencv-python opencv-contrib-python 2>/dev/null || true && \
-    pip install --no-cache-dir --force-reinstall opencv-python-headless>=4.8.0
+    pip install --no-cache-dir --force-reinstall --no-deps opencv-python-headless==4.13.0.92
 
 # Verify dependencies work together
 RUN python -c "import cv2; print('OpenCV version:', cv2.__version__)" && \

--- a/requirements-known-good-2026-05-29.lock
+++ b/requirements-known-good-2026-05-29.lock
@@ -59,7 +59,7 @@ h5py==3.14.0
 httpcore==1.0.9
 httptools==0.7.1
 httpx==0.28.1
-idna==3.14
+idna==3.15  # P0-2b 2026-05-30: bumped 3.14->3.15 (pure-Python, no native ABI) to satisfy requirements.txt's idna>=3.15 security floor; the only lock<->requirements.txt conflict that blocked `pip install -c lock -r requirements.txt`.
 itsdangerous==2.2.0
 joblib==1.5.3
 keras==3.14.1


### PR DESCRIPTION
## P0-2b — canonical reproducible bio build (BOOTS CLEAN)

> **DO NOT auto-merge / auto-deploy.** This is yours to review, deploy, and (once deployed) retire the `Dockerfile.liveness-overlay` workaround.

**Outcome: the from-scratch canonical `Dockerfile` now BOOTS CLEAN under the prod `read_only`+`cap_drop` runtime — no MiniFASNet ONNX segfault. Ready for you to deploy.**

### Root cause
A fresh rebuild segfaulted at the UniFace MiniFASNet ONNX session preload because of **drift**: `requirements.txt` pinned with `>=` (so numpy/protobuf/uniface/torch/nvidia-* drifted off the proven `75347c98` set) **and** the floating `python:3.12-slim` base moved Debian 13.4→13.5. An isolated MiniFASNet load works fine — it was the *combination* under `read_only`+`cap_drop:ALL`.

### Fix
1. **Both `FROM` lines pinned by DIGEST** — `python:3.12-slim@sha256:090ba77e…`. The base can never float again. (The 13.4-era trixie digest is no longer tag-served: Docker Hub overwrote `3.12.13-slim` with the 13.5 rebuild on 2026-05-22, so this pins the **settled** 13.5 digest. The boot test below proves settled-13.5 + the pinned native set is fine — the segfault was the *drift*, not 13.5 itself.)
2. **Deps from `requirements-known-good-2026-05-29.lock` as a pip `-c` constraints file** over the staged ML install + `requirements.txt`, so every transitive (torch 2.11.0+cu130, onnxruntime 1.26.0, numpy 2.4.4, uniface 3.6.0, nvidia-cu13, …) lands on the exact proven version. **tf-cpu/deepface/opencv special-casing preserved**: the lock's `tensorflow==`, `deepface==`, `opencv-python-headless==`, and `spoof-detector @ git+` lines are stripped from the constraints (we install `tensorflow-cpu`, deepface `--no-deps`, headless opencv separately), so the lock's plain-`tensorflow` line can't force a GPU resolution.
3. **Lock: `idna 3.14→3.15`** (pure-Python, no native ABI) — the only lock↔requirements.txt conflict; needed to satisfy the `idna>=3.15` security floor.

### Boot-test (2026-05-30, isolated, prod runtime)
Built to a throwaway tag, booted under an isolated copy of `docker-compose.prod.yml`'s hardening (`read_only` + `tmpfs` + `cap_drop:ALL` + `cap_add CHOWN/SETUID/SETGID` + `no-new-privileges`), on the `backend` network with shared postgres/redis, **the running prod `biometric-api` container untouched**, uniface ONNX seeded into the cache as in prod:

```
Pre-loading UniFace MiniFASNet (process-wide shared ONNX session)…
UniFace MiniFASNet model loaded (process-wide shared session)   ← the step that used to segfault
Startup health-check: liveness detector OK (UniFaceLivenessDetector)
Application startup complete.
GET /api/v1/health → HTTP 200  {"status":"healthy", ...}
```
**Zero SIGSEGV/segfault signatures, 0 restarts, no OOM.** Built image versions confirmed: Debian 13.5, torch 2.11.0+cu130, onnxruntime 1.26.0, tf 2.21.0, numpy 2.4.4, uniface 3.6.0 (all natives match known-good).

Throwaway image + seed volume + temp files removed; build cache pruned; disk back to baseline.

### Deploy (you, when ready) — retire the overlay
```bash
cd /opt/projects/fivucsas/biometric-processor
docker compose -f docker-compose.prod.yml --env-file .env.prod build biometric-api
docker compose -f docker-compose.prod.yml --env-file .env.prod up -d biometric-api
# rollback: retag biometric-processor-biometric-api:working-75347c98 → :latest && up -d
```
`Dockerfile.liveness-overlay` stays in-repo as the zero-risk fallback but is no longer the required path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)