### PR TITLE
test(ci): pin JWT_SECRET in active-liveness token test — CI unit job green (P2-2 follow-up)

### DIFF
--- a/tests/unit/application/test_light_challenge_service.py
+++ b/tests/unit/application/test_light_challenge_service.py
@@ -71,8 +71,15 @@ def test_active_liveness_manager_prepares_light_challenge_on_start():
     assert challenge.metadata["ready_for_flash"] is False
 
 
-def test_active_liveness_manager_generates_verification_token_on_pass():
-    manager = ActiveLivenessManager(token_service=ActiveLivenessTokenService(ttl_seconds=60))
+def test_active_liveness_manager_generates_verification_token_on_pass(monkeypatch):
+    # The token service signs an HS256 JWT from settings.JWT_SECRET; CI does not
+    # export a JWT_SECRET, so without this the encode raises
+    # `jwt.exceptions.InvalidKeyError: HMAC key must not be empty`. Pin a
+    # deterministic test secret on the settings singleton so the test does not
+    # depend on ambient environment.
+    token_service = ActiveLivenessTokenService(ttl_seconds=60)
+    monkeypatch.setattr(token_service._settings, "JWT_SECRET", "test-secret-key-for-active-liveness-token", raising=False)
+    manager = ActiveLivenessManager(token_service=token_service)
 
     session = manager.create_session(
         ActiveLivenessConfig(


### PR DESCRIPTION
Follow-up to #124 (P2-2 honest-green CI).

Removing `continue-on-error` from the unit CI job surfaced a **pre-existing, env-dependent** failure: `test_active_liveness_manager_generates_verification_token_on_pass` signs an HS256 JWT from `settings.JWT_SECRET`, which CI does not export → `jwt.exceptions.InvalidKeyError: HMAC key must not be empty`. It only "passed" locally because the dev shell had an ambient `JWT_SECRET`. (Confirmed pre-existing: the prior commit #123 also failed this job; this PR did not introduce the test.)

Fix: `monkeypatch` a deterministic test secret onto the token service's settings so the test is hermetic. No production code changed.

CI unit job: 645 passed / 1 failed → fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)