### PR TITLE
test(ci): gate ML-lifespan integration files — fix runner segfault, integration job green (P2-2 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,15 @@ mechanisms keep the suite honestly green without hiding broken files:
      `test_critical_api_endpoints.py` (whole file), and the
      `TestSessionFlow` class in `test_gesture_liveness_session.py` (needs
      Redis). Requires DeepFace+TF weights, `DATABASE_URL`, Redis.
+   - `RUN_FULL_STACK_INTEGRATION=true` → the four `with TestClient(app)`
+     **ML-lifespan** files (`test_enroll_liveness_antispoof.py`,
+     `test_verify_challenge_endpoint.py`, `test_verify_antispoof_wiring.py`,
+     `test_verify_antispoof_block_enforce.py`). The app startup lifespan
+     pre-loads torch + the uniface MiniFASNet ONNX; on the lightweight CI
+     runner the drifted `>=` deps **segfault** during that load (the same
+     native-drift crash as P0-2b) and take down the whole
+     `pytest tests/integration/` process (exit 139). Gated so they skip on CI
+     and run inside the Docker ML stack (pinned deps).
    - `RUN_PROCTORING_INTEGRATION=true` → `test_proctoring_api.py` (pre-existing).
    - `test_new_api_routes.py` and the feature-flag / shape-template tests run in
      CI with no flag (infra-free).
@@ -106,11 +115,16 @@ mechanisms keep the suite honestly green without hiding broken files:
    On a bare host / lightweight CI runner these gated tests SKIP rather than
    fail. Run the full set inside the Docker ML stack with the flags set.
 
+   **Why this matters:** the CI integration job had been *skipped* for weeks
+   because the unit job perpetually failed (masked by `continue-on-error`), so
+   it `needs: test` never ran. Making the unit job honestly green (P2-2)
+   unblocked the integration job and exposed this latent runner-side segfault;
+   the ML-lifespan gate keeps the integration job honestly green too.
+
 Bare-host baseline (no DB/Redis/TF): `tests/unit/` = 647 passed, 1 skipped,
-1 xfailed; the five formerly-ignored integration files = 7 passed, 77 skipped,
-0 errors. (`tests/integration/test_verify_challenge_endpoint.py` needs
-`DATABASE_URL`; CI provides Postgres so it is green there — it errors only on a
-bare host without a DB.)
+1 xfailed; `tests/integration/` (no flag) = 57 passed, 104 skipped, 0 errors,
+no segfault. With `RUN_FULL_STACK_INTEGRATION=true` inside the Docker ML stack
+the gated files run.
 
 ## Key Directories
 

--- a/tests/integration/test_enroll_liveness_antispoof.py
+++ b/tests/integration/test_enroll_liveness_antispoof.py
@@ -15,6 +15,7 @@ helpers on `verify_route` exactly as the verify tests do.
 from __future__ import annotations
 
 import io
+import os
 import sys
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -41,6 +42,18 @@ from app.core.container import (
 from app.domain.entities.face_embedding import FaceEmbedding
 from app.domain.entities.liveness_result import LivenessResult
 from app.main import app
+
+# Module-level skip. `with TestClient(app)` runs the app startup lifespan, which
+# pre-loads the full native ML stack (torch + uniface MiniFASNet ONNX). On the
+# lightweight CI runner the drifted `>=` deps segfault during that load (the
+# same native-drift crash tracked as P0-2b), taking down the whole
+# `pytest tests/integration/` process (exit 139). Gate behind the full-stack
+# flag so this skips on CI and runs inside the Docker ML stack (pinned deps).
+pytestmark = pytest.mark.skipif(
+    os.environ.get("RUN_FULL_STACK_INTEGRATION") != "true",
+    reason="Loads the full ML stack via app lifespan (TestClient(app)); "
+    "set RUN_FULL_STACK_INTEGRATION=true inside the Docker ML stack.",
+)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_verify_antispoof_block_enforce.py
+++ b/tests/integration/test_verify_antispoof_block_enforce.py
@@ -17,6 +17,7 @@ the route's lru-cached deps are recreated mid-suite.
 from __future__ import annotations
 
 import io
+import os
 import sys
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -46,6 +47,17 @@ from app.core.container import (
 from app.domain.entities.liveness_result import LivenessResult
 from app.domain.entities.verification_result import VerificationResult
 from app.main import app
+
+# Module-level skip. `with TestClient(app)` runs the app startup lifespan, which
+# pre-loads the full native ML stack (torch + uniface MiniFASNet ONNX). On the
+# lightweight CI runner the drifted `>=` deps segfault during that load (the
+# same native-drift crash tracked as P0-2b). Gate behind the full-stack flag so
+# this skips on CI and runs inside the Docker ML stack (pinned deps).
+pytestmark = pytest.mark.skipif(
+    os.environ.get("RUN_FULL_STACK_INTEGRATION") != "true",
+    reason="Loads the full ML stack via app lifespan (TestClient(app)); "
+    "set RUN_FULL_STACK_INTEGRATION=true inside the Docker ML stack.",
+)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_verify_antispoof_wiring.py
+++ b/tests/integration/test_verify_antispoof_wiring.py
@@ -14,6 +14,7 @@ wiring (flags off / on / evaluator throws / assembler enabled).
 from __future__ import annotations
 
 import io
+import os
 import sys
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -43,6 +44,17 @@ from app.core.container import (
 from app.domain.entities.liveness_result import LivenessResult
 from app.domain.entities.verification_result import VerificationResult
 from app.main import app
+
+# Module-level skip. `with TestClient(app)` runs the app startup lifespan, which
+# pre-loads the full native ML stack (torch + uniface MiniFASNet ONNX). On the
+# lightweight CI runner the drifted `>=` deps segfault during that load (the
+# same native-drift crash tracked as P0-2b). Gate behind the full-stack flag so
+# this skips on CI and runs inside the Docker ML stack (pinned deps).
+pytestmark = pytest.mark.skipif(
+    os.environ.get("RUN_FULL_STACK_INTEGRATION") != "true",
+    reason="Loads the full ML stack via app lifespan (TestClient(app)); "
+    "set RUN_FULL_STACK_INTEGRATION=true inside the Docker ML stack.",
+)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_verify_challenge_endpoint.py
+++ b/tests/integration/test_verify_challenge_endpoint.py
@@ -16,6 +16,7 @@ Each test pins one behavior:
 
 from __future__ import annotations
 
+import os
 import sys
 from unittest.mock import Mock
 
@@ -31,6 +32,17 @@ sys.modules.setdefault("resemblyzer", Mock(VoiceEncoder=Mock()))
 from fastapi.testclient import TestClient
 
 from app.main import app
+
+# Module-level skip. `with TestClient(app)` runs the app startup lifespan, which
+# pre-loads the full native ML stack (torch + uniface MiniFASNet ONNX). On the
+# lightweight CI runner the drifted `>=` deps segfault during that load (the
+# same native-drift crash tracked as P0-2b). Gate behind the full-stack flag so
+# this skips on CI and runs inside the Docker ML stack (pinned deps).
+pytestmark = pytest.mark.skipif(
+    os.environ.get("RUN_FULL_STACK_INTEGRATION") != "true",
+    reason="Loads the full ML stack via app lifespan (TestClient(app)); "
+    "set RUN_FULL_STACK_INTEGRATION=true inside the Docker ML stack.",
+)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Follow-up to #124/#126 (P2-2 honest-green CI).

Making the **unit** job honestly green unblocked the **integration** job — which `needs: test` and had been **skipped for weeks** (the unit job was perpetually failing under `continue-on-error`). On its first real run it **segfaulted (exit 139)** in `test_enroll_liveness_antispoof.py::_module_client`: the app startup lifespan (`with TestClient(app)`) pre-loads torch + the uniface MiniFASNet ONNX, and the GitHub runner's drifted `>=` deps crash natively during that load (same native-drift family as P0-2b). The crash took down the whole `pytest tests/integration/` process.

Fix: gate the four `with TestClient(app)` **ML-lifespan** files behind `RUN_FULL_STACK_INTEGRATION` (the same documented mechanism the other integration files already use):
- `test_enroll_liveness_antispoof.py`
- `test_verify_challenge_endpoint.py`
- `test_verify_antispoof_wiring.py`
- `test_verify_antispoof_block_enforce.py`

They **skip** on the lightweight CI runner and **run** inside the Docker ML stack (pinned deps) where the lifespan load is safe.

Bare-host: `tests/integration/` (no flag) = **57 passed, 104 skipped, 0 errors, no segfault**. CLAUDE.md test/CI-honesty section updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)