### PR TITLE
feat(nfc+enroll): liveness on /enroll/multi + eMRTD NFC passive-auth endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,8 +136,18 @@ LIVENESS_THRESHOLD=70.0
 # security (enrollment is at least as strict as verify). Reuses LIVENESS_MODE /
 # LIVENESS_BACKEND / ANTI_SPOOFING_ENABLED / LIVENESS_VERDICT_POLICY and the
 # ANTISPOOF_* pipeline flags (incl. ANTISPOOF_BLOCK_ENFORCE). Set False only
-# for controlled migration/observation.
+# for controlled migration/observation. Also gates the per-frame liveness check
+# on /enroll/multi (2026-05-30, fail-closed: one non-live frame rejects the
+# whole multi-image enrollment).
 ENROLL_LIVENESS_ENABLED=True
+
+# eMRTD NFC passive authentication (POST /nfc/verify-authenticity, ICAO 9303
+# Part 11). Directory of trusted CSCA root certs (PEM/DER) that Document Signer
+# certs must chain to. The certs are an OPERATOR deliverable (ICAO PKD master
+# list / issuing authority) — drop them in and they load at request time, no
+# rebuild. Empty store => /nfc/verify-authenticity returns is_authentic=false
+# with reason_code=NO_TRUST_STORE (fail-closed). See the directory's README.
+NFC_CSCA_TRUST_DIR=app/core/csca_trust_store
 # Threshold calibration workflow:
 # 1) Collect labeled JSONL logs with {"label": "real|spoof", "score": <0-100>}
 # 2) Run: python scripts/calibrate_threshold.py --logs logs/liveness.jsonl --write-env .env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## [Unreleased]
 
+### 2026-05-30 — Multi-image enroll liveness + eMRTD NFC passive authentication
+
+- **P0: liveness on `/enroll/multi` (fail-closed).** `/enroll/multi` previously ran
+  NO liveness while single `/enroll` did — a photo/screen replay could be enrolled
+  via the multi-image path. The multi-image use case (`enroll_multi_image.py`) now
+  runs the SAME `CheckLivenessUseCase` (UniFace MiniFASNet passive + DeepFace
+  anti-spoof veto) on EVERY frame BEFORE extracting/fusing its embedding; one
+  non-live frame rejects the whole enrollment (`LivenessCheckFailedError` → 400).
+  Gated by the existing `ENROLL_LIVENESS_ENABLED` (default ON); injected via
+  `get_enroll_multi_image_use_case()`. CPU-only. New unit tests prove spoof-reject,
+  live-accept, first-frame short-circuit, and the disabled-flag escape hatch.
+- **P0: eMRTD NFC passive authentication (`POST /nfc/verify-authenticity`).** New
+  CPU-only endpoint implementing ICAO 9303 Part 11 passive auth: verifies DG hashes
+  against the SOD's LDS Security Object, the SOD CMS signature against the embedded
+  Document Signer cert, and the DS→CSCA chain. Fail-closed authoritative verdict
+  (`is_authentic`, `reason_code`, `ds_subject`, `csca_matched`, `dg_hash_results`,
+  …). Pure Python crypto (`asn1crypto` + `cryptography`) — no GPU, no ML. Domain
+  logic in `app/domain/services/emrtd_passive_auth.py`. Operator-provisioned CSCA
+  trust store at `NFC_CSCA_TRUST_DIR` (default `app/core/csca_trust_store/`); empty
+  store ⇒ `NO_TRUST_STORE`/`is_authentic=false`. Consumed by identity-core-api
+  `NfcDocumentAuthHandler`. New unit tests (service + route) build a self-signed
+  CSCA/DS/SOD fixture and cover happy-path, DG-mismatch, bad-signature, untrusted-DS,
+  empty-store, and ECDSA-DS. Adds `asn1crypto==1.5.1` to the lock (pure-Python,
+  digest-pinned build otherwise unchanged).
+
 ### 2026-05-30 — Canonical reproducible build restored + honest-green CI (P0-2b, P2-2)
 
 - **P0-2b (PR #125, DEPLOYED)** — canonical from-scratch `Dockerfile` build RESTORED:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,8 +184,16 @@ the gated files run.
   `LIVENESS_VERDICT_POLICY` (conservative) and the `ANTISPOOF_*` flags incl.
   `ANTISPOOF_BLOCK_ENFORCE`; the anti-spoof helpers are imported from
   `verification.py` so both paths share one implementation + one model singleton.
-  Single-image `/enroll` only (single still frame, like `/verify`);
-  `/enroll/multi` is unchanged.
+- **Multi-image enroll liveness (2026-05-30)**: `/enroll/multi` now also runs the
+  SAME passive-liveness `CheckLivenessUseCase` that single-`/enroll` calls — on
+  EVERY submitted frame, BEFORE its embedding is extracted/fused, **fail-CLOSED**
+  (one non-live frame rejects the whole enrollment with `LivenessCheckFailedError`
+  → HTTP 400). Closes the documented gap where a photo could be enrolled via the
+  multi-image path. Wired in `enroll_multi_image.py` (the use case takes an
+  optional `liveness_use_case`; `get_enroll_multi_image_use_case()` injects it).
+  Same `ENROLL_LIVENESS_ENABLED` flag (default `True`); when the use case is
+  built without a checker (legacy/unit-test callers) the gate is skipped.
+  CPU-only.
 - **Voice**: enroll, verify, search, delete — Resemblyzer 256-dim speaker embeddings, centroid-based
 - Routes: `voice.py`, repo: `pgvector_voice_repository.py`, embedder: `speaker_embedder.py`
 - **Fingerprint**: removed (P1.4) — server-side fingerprint biometric processing was a SHA-256 hash placeholder, never a real biometric. Platform fingerprint authentication is delivered via WebAuthn (FIDO2) in identity-core-api, not through this service.
@@ -198,6 +206,23 @@ the gated files run.
 - **Liveness pipeline** — server-authoritative liveness verdict with configurable thresholds
 - **Video interview upload** — endpoint for verification pipeline video step
 - Routes: `verification_pipeline.py` (sub-paths: /document-scan, /data-extract, /face-match, /liveness-check, /pipeline/test, /video-interview)
+
+### NFC document (`nfc.py`):
+- **`POST /nfc/mrz`** — pure MRZ string parsing (TD1/TD3, DG1 envelope or raw text).
+- **`POST /nfc/verify-authenticity` (2026-05-30)** — ICAO 9303 Part 11 **passive
+  authentication** (eMRTD chip trust). Accepts `{sod_b64, data_groups:{"<dg#>":b64}}`
+  and verifies, fail-CLOSED: (a) each provided DG hash matches the signed value
+  in EF.SOD's `LDSSecurityObject`, (b) the SOD's CMS signature verifies under the
+  embedded Document Signer cert, (c) DS chains to a trusted CSCA root. Returns
+  `{is_authentic, reason, reason_code, ds_subject, ds_serial, csca_matched,
+  dg_hash_results, sod_hash_algorithm}`. Pure Python crypto (`asn1crypto` +
+  `cryptography`) — **no GPU, no ML**. Logic lives in the framework-free domain
+  service `app/domain/services/emrtd_passive_auth.py`. Consumed by
+  identity-core-api `NfcDocumentAuthHandler` via `BiometricServicePort`.
+  - **CSCA trust store** is an OPERATOR deliverable: drop CSCA root certs
+    (PEM/DER) into `NFC_CSCA_TRUST_DIR` (default `app/core/csca_trust_store/`, see
+    its README). Empty store ⇒ `is_authentic=false` / `reason_code=NO_TRUST_STORE`.
+    Loaded at request time (mtime-keyed cache), so adding a cert needs no rebuild.
 
 ### Not implemented:
 - **Iris**: No endpoints at all

--- a/app/api/routes/nfc.py
+++ b/app/api/routes/nfc.py
@@ -1,18 +1,15 @@
-"""NFC document MRZ parsing route.
+"""NFC document routes — MRZ parsing + eMRTD passive authentication.
 
-Exposes the existing ``mrz_parser`` machinery as a first-class endpoint so the
-identity-core-api ``NfcController`` can verify Machine-Readable Zones from
-chip-read passports / ID cards (DG1) and surface structured fields back to
-clients without falling back to the verification-pipeline data-extract route
-(which is geared towards manual-KYC document scans).
+Two first-class endpoints back the identity-core-api ``NfcController`` /
+``NfcDocumentAuthHandler`` so chip-read passports / ID cards can be both parsed
+and cryptographically trust-verified without the manual-KYC data-extract route:
 
-This route is intentionally narrow:
-- Pure string parsing — no OCR, no ML, no DB writes
-- Input contract matches the task spec (T2-A, INVESTIGATION 2026-05-07 P1):
-  ``{"mrz_text": "...", "dg1_bytes_b64": null}`` (exactly one required)
-- Output contract matches the task spec — flat structured fields plus
-  ``checksum_valid`` boolean and a ``checksum_failures`` list of field names
-  that failed their ICAO 9303 check-digit verification
+- ``POST /nfc/mrz`` — pure MRZ string parsing (DG1 / raw MRZ). No OCR, no DB.
+- ``POST /nfc/verify-authenticity`` — ICAO 9303 Part 11 **passive
+  authentication**: confirm the chip's Data Groups match the signed hashes in
+  EF.SOD, the SOD's CMS signature verifies under the Document Signer cert, and
+  that DS chains to a trusted CSCA root. Pure Python crypto
+  (``asn1crypto`` + ``cryptography``); CPU-only, no GPU, no ML.
 
 The legacy ``/verification/data-extract`` endpoint is left untouched.
 """
@@ -23,11 +20,15 @@ import base64
 import binascii
 import logging
 import re
-from typing import Optional
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, Optional
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
+from app.core.config import settings
+from app.domain.services.emrtd_passive_auth import EmrtdPassiveAuthService
 from app.domain.services.mrz_parser import (
     MRZData,
     detect_and_parse_mrz,
@@ -250,3 +251,181 @@ async def parse_mrz(payload: MrzParseRequest) -> MrzParseResponse:
         response.checksum_failures,
     )
     return response
+
+
+# ============================================================================
+# Passive authentication — POST /nfc/verify-authenticity
+# ============================================================================
+
+
+class VerifyAuthenticityRequest(BaseModel):
+    """Input for ``POST /nfc/verify-authenticity``.
+
+    Field names are frozen against the agent-api JSON contract so the Java
+    ``NfcDocumentAuthHandler`` (via ``BiometricProcessorClient.postJson``) maps
+    without a translation layer.
+    """
+
+    sod_b64: str = Field(
+        ...,
+        description="Base64 (standard) of EF.SOD DER — the CMS SignedData / "
+        "Document Security Object read from the chip.",
+    )
+    data_groups: Dict[str, str] = Field(
+        ...,
+        description="Map of DG number (as a string, '1'..'16') -> base64 of the "
+        "raw DG bytes (full ICAO TLV) the client read from the chip. At least "
+        "one entry required.",
+    )
+
+
+class VerifyAuthenticityResponse(BaseModel):
+    """Authoritative passive-authentication verdict."""
+
+    is_authentic: bool = False
+    reason: str = ""
+    reason_code: str = "SOD_PARSE_ERROR"
+    ds_subject: Optional[str] = None
+    ds_serial: Optional[str] = None
+    csca_matched: bool = False
+    dg_hash_results: Dict[str, bool] = Field(default_factory=dict)
+    sod_hash_algorithm: Optional[str] = None
+
+
+def _load_csca_trust_store(trust_dir: str) -> list:
+    """Load CSCA root certificates from the operator trust-store directory.
+
+    Accepts PEM and DER encodings (``.pem``/``.crt``/``.cer``/``.der``). Files
+    that fail to parse are skipped with a warning rather than aborting the
+    whole load — a single bad file must not knock out an otherwise-valid store.
+    Returns a list of ``cryptography`` Certificate objects (possibly empty).
+    """
+    from cryptography.x509 import load_der_x509_certificate, load_pem_x509_certificate
+
+    certs: list = []
+    base = Path(trust_dir)
+    if not base.is_dir():
+        logger.warning("CSCA trust dir does not exist: %s", trust_dir)
+        return certs
+
+    for path in sorted(base.iterdir()):
+        if not path.is_file() or path.suffix.lower() not in {
+            ".pem",
+            ".crt",
+            ".cer",
+            ".der",
+        }:
+            continue
+        try:
+            raw = path.read_bytes()
+        except OSError as exc:  # pragma: no cover — fs error
+            logger.warning("Could not read CSCA cert %s: %s", path.name, exc)
+            continue
+        loaded = False
+        # Try PEM first (may contain multiple concatenated certs), then DER.
+        try:
+            text = raw
+            marker = b"-----BEGIN CERTIFICATE-----"
+            if marker in text:
+                for block in text.split(marker)[1:]:
+                    pem = marker + block.split(b"-----END CERTIFICATE-----")[0] + (
+                        b"-----END CERTIFICATE-----\n"
+                    )
+                    certs.append(load_pem_x509_certificate(pem))
+                    loaded = True
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed PEM parse of %s: %s", path.name, exc)
+        if not loaded:
+            try:
+                certs.append(load_der_x509_certificate(raw))
+                loaded = True
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Failed DER parse of %s: %s", path.name, exc)
+        if not loaded:
+            logger.warning("Skipped unparseable CSCA cert: %s", path.name)
+
+    logger.info("Loaded %d CSCA trust anchor(s) from %s", len(certs), trust_dir)
+    return certs
+
+
+@lru_cache(maxsize=4)
+def _csca_certs_cached(trust_dir: str, mtime_ns: int) -> tuple:
+    """Cache trust-store loads keyed by (dir, mtime) so a re-provisioned store
+    is picked up automatically (mtime changes) without a process restart."""
+    return tuple(_load_csca_trust_store(trust_dir))
+
+
+def _get_passive_auth_service() -> EmrtdPassiveAuthService:
+    """Build the passive-auth service with the current CSCA trust anchors."""
+    trust_dir = settings.NFC_CSCA_TRUST_DIR
+    try:
+        mtime_ns = Path(trust_dir).stat().st_mtime_ns
+    except OSError:
+        mtime_ns = 0
+    certs = list(_csca_certs_cached(trust_dir, mtime_ns))
+    return EmrtdPassiveAuthService(csca_certificates=certs)
+
+
+def _decode_b64(value: str, field_name: str) -> bytes:
+    try:
+        return base64.b64decode(value, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{field_name} is not valid base64: {exc}",
+        ) from exc
+
+
+@router.post(
+    "/verify-authenticity",
+    response_model=VerifyAuthenticityResponse,
+    summary="Verify eMRTD chip authenticity (passive authentication)",
+    description=(
+        "ICAO 9303 Part 11 passive authentication. Accepts the chip's EF.SOD "
+        "(Document Security Object) and the Data Groups the client read, then "
+        "verifies (a) each DG hash matches the signed value in the SOD's LDS "
+        "Security Object, (b) the SOD's CMS signature verifies against the "
+        "embedded Document Signer certificate, and (c) that DS certificate "
+        "chains to a trusted CSCA root from the operator trust store. "
+        "Fail-closed: is_authentic is true only when all three checks pass. "
+        "Pure Python crypto — no GPU, no ML."
+    ),
+)
+async def verify_authenticity(
+    payload: VerifyAuthenticityRequest,
+) -> VerifyAuthenticityResponse:
+    """Run passive authentication over a chip-read EF.SOD + Data Groups."""
+
+    if not payload.data_groups:
+        raise HTTPException(
+            status_code=400,
+            detail="data_groups must contain at least one Data Group.",
+        )
+
+    sod_der = _decode_b64(payload.sod_b64, "sod_b64")
+
+    decoded_dgs: Dict[int, bytes] = {}
+    for key, value in payload.data_groups.items():
+        try:
+            dg_number = int(key)
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"data_groups key '{key}' is not a valid DG number.",
+            ) from exc
+        decoded_dgs[dg_number] = _decode_b64(value, f"data_groups['{key}']")
+
+    service = _get_passive_auth_service()
+    result = service.verify(sod_der=sod_der, data_groups=decoded_dgs)
+
+    logger.info(
+        "NFC /verify-authenticity: is_authentic=%s reason_code=%s csca_matched=%s "
+        "ds_subject=%s dgs=%s",
+        result.is_authentic,
+        result.reason_code.value,
+        result.csca_matched,
+        result.ds_subject,
+        sorted(decoded_dgs.keys()),
+    )
+
+    return VerifyAuthenticityResponse(**result.to_dict())

--- a/app/application/use_cases/enroll_multi_image.py
+++ b/app/application/use_cases/enroll_multi_image.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 import cv2
 import numpy as np
 
+from app.application.use_cases.check_liveness import CheckLivenessUseCase
 from app.core.config import settings
 from app.domain.entities.enrollment_session import EnrollmentSession
 from app.domain.entities.face_embedding import FaceEmbedding
@@ -19,6 +20,7 @@ from app.domain.exceptions.enrollment_errors import (
     MLModelTimeoutError,
 )
 from app.domain.exceptions.face_errors import FaceNotDetectedError, PoorImageQualityError
+from app.domain.exceptions.liveness_errors import LivenessCheckFailedError
 from app.domain.interfaces.embedding_extractor import IEmbeddingExtractor
 from app.domain.interfaces.embedding_repository import IEmbeddingRepository
 from app.domain.interfaces.face_detector import IFaceDetector
@@ -52,6 +54,7 @@ class EnrollMultiImageUseCase:
         quality_assessor: IQualityAssessor,
         repository: IEmbeddingRepository,
         fusion_service: Optional[EmbeddingFusionService] = None,
+        liveness_use_case: Optional[CheckLivenessUseCase] = None,
     ) -> None:
         """Initialize multi-image enrollment use case.
 
@@ -61,6 +64,17 @@ class EnrollMultiImageUseCase:
             quality_assessor: Quality assessor implementation
             repository: Embedding repository implementation
             fusion_service: Optional fusion service (creates default if None)
+            liveness_use_case: Optional server-authoritative passive liveness
+                check. When provided AND ``settings.ENROLL_LIVENESS_ENABLED`` is
+                True, EVERY submitted frame must pass liveness BEFORE its
+                embedding is fused — closing the documented gap where
+                ``/enroll/multi`` accepted photos/screen replays that
+                ``/enroll`` already rejects. Fail-closed: a single non-live
+                frame rejects the whole enrollment. Reuses the EXACT
+                ``CheckLivenessUseCase`` (UniFace MiniFASNet passive backend +
+                DeepFace anti-spoof veto per ``LIVENESS_VERDICT_POLICY``) that
+                single-image ``/enroll`` calls — one implementation, one model
+                singleton. CPU-only (no GPU).
         """
         self._detector = detector
         self._extractor = extractor
@@ -69,6 +83,7 @@ class EnrollMultiImageUseCase:
         self._fusion_service = fusion_service or EmbeddingFusionService(
             normalization_strategy=settings.MULTI_IMAGE_NORMALIZATION
         )
+        self._liveness_use_case = liveness_use_case
 
         logger.info("EnrollMultiImageUseCase initialized")
 
@@ -135,6 +150,42 @@ class EnrollMultiImageUseCase:
                 image = await asyncio.to_thread(cv2.imread, image_path)
                 if image is None:
                     raise ValueError(f"Failed to load image: {image_path}")
+
+                # ----------------------------------------------------------
+                # Liveness gate (fail-CLOSED) — close the documented
+                # enroll/verify asymmetry. Single-image /enroll already runs a
+                # server-authoritative passive liveness check before persisting
+                # an embedding; /enroll/multi historically ran NONE, so a photo
+                # or screen replay could be enrolled. We now run the SAME
+                # CheckLivenessUseCase (UniFace MiniFASNet passive + DeepFace
+                # anti-spoof veto) on EVERY frame BEFORE extracting/fusing its
+                # embedding. One non-live frame rejects the whole enrollment.
+                # Gated by ENROLL_LIVENESS_ENABLED (default ON); skipped only
+                # when the use case was constructed without a liveness checker
+                # (e.g. legacy callers / unit tests that don't exercise it).
+                # CPU-only — no GPU, ALLOW_HEAVY_ML stays false.
+                # ----------------------------------------------------------
+                if self._liveness_use_case is not None and settings.ENROLL_LIVENESS_ENABLED:
+                    logger.debug("  Step 0/3: Liveness check...")
+                    liveness_result = await self._liveness_use_case.execute(
+                        image_path=image_path
+                    )
+                    if not liveness_result.is_live:
+                        logger.warning(
+                            "  Image %d rejected — liveness check failed: "
+                            "score=%.2f (multi-image enrollment fail-closed)",
+                            i,
+                            liveness_result.score,
+                        )
+                        raise LivenessCheckFailedError(
+                            liveness_score=liveness_result.score,
+                            challenge=liveness_result.challenge,
+                        )
+                    logger.info(
+                        "  Image %d liveness check passed: score=%.2f",
+                        i,
+                        liveness_result.score,
+                    )
 
                 # Detect face with timeout
                 # For multi-enroll, side-angle faces (30°+) may fail OpenCV detection.

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -764,6 +764,25 @@ class Settings(BaseSettings):
             "the ANTISPOOF_* flags; no parallel config."
         ),
     )
+    # ------------------------------------------------------------------
+    # eMRTD NFC passive authentication (ICAO 9303 Part 11) — CPU-only.
+    # The CSCA trust store holds the Country Signing CA root certificates that
+    # Document Signer certs must chain to. The certificates themselves are an
+    # OPERATOR deliverable (per-country CSCA roots from the ICAO PKD or the
+    # issuing authority); drop PEM/DER/.cer files into this directory and they
+    # are loaded at request time. Empty dir → /nfc/verify-authenticity returns
+    # is_authentic=false with reason_code=NO_TRUST_STORE (fail-closed). The code
+    # works the moment certs are dropped in — no rebuild needed.
+    # ------------------------------------------------------------------
+    NFC_CSCA_TRUST_DIR: str = Field(
+        default=str(_REPO_ROOT / "app" / "core" / "csca_trust_store"),
+        description=(
+            "Directory of trusted CSCA root certificates (PEM/DER/.cer/.crt) "
+            "for eMRTD passive authentication. Operator-provisioned; empty "
+            "store makes /nfc/verify-authenticity fail closed "
+            "(reason_code=NO_TRUST_STORE)."
+        ),
+    )
     GESTURE_HAND_LANDMARKER_MODEL_PATH: str = Field(
         default=str(_REPO_ROOT / "models" / "hand_landmarker.task"),
         description=(

--- a/app/core/container.py
+++ b/app/core/container.py
@@ -543,6 +543,11 @@ def get_enroll_multi_image_use_case() -> EnrollMultiImageUseCase:
         extractor=get_embedding_extractor(),
         quality_assessor=get_quality_assessor(),
         repository=get_embedding_repository(),
+        # Server-authoritative passive liveness on EVERY frame (fail-closed),
+        # reusing the SAME use case single-image /enroll calls so a photo/screen
+        # replay cannot be enrolled via the multi-image path. Gated at runtime by
+        # settings.ENROLL_LIVENESS_ENABLED inside the use case.
+        liveness_use_case=get_check_liveness_use_case(),
     )
 
 

--- a/app/core/csca_trust_store/README.md
+++ b/app/core/csca_trust_store/README.md
@@ -1,0 +1,30 @@
+# CSCA Trust Store (eMRTD Passive Authentication)
+
+This directory holds the **Country Signing CA (CSCA) root certificates** used to
+establish trust in the Document Signer (DS) certificate embedded in an ePassport
+/ eID `EF.SOD` during passive authentication
+(`POST /api/v1/nfc/verify-authenticity`).
+
+## What to drop here (operator deliverable)
+
+- One file per CSCA root certificate.
+- Accepted formats: PEM (`.pem`, `.crt`, `.cer`), or DER (`.der`, `.cer`).
+- Source the certificates from the **ICAO Public Key Directory (PKD)** master
+  list, or directly from the issuing authority (e.g. for Turkish eID, the
+  Turkish CSCA root). Validate them out-of-band before installing.
+
+## Behavior
+
+- **Empty store** (only this README): `/nfc/verify-authenticity` returns
+  `is_authentic: false` with `reason_code: NO_TRUST_STORE` — fail-closed. No
+  document can be marked authentic until at least one trusted CSCA is present.
+- The store directory is configurable via the `NFC_CSCA_TRUST_DIR` env var
+  (defaults to this directory). Files are loaded at request time, so adding a
+  new CSCA root takes effect without a rebuild — only a re-read.
+
+## Security notes
+
+- Treat this directory as a trust anchor: write access to it equals the ability
+  to forge document trust. Lock down filesystem permissions accordingly.
+- Only CSCA **root** certs belong here. Document Signer (DS) certs are supplied
+  per-request inside the SOD; never add a DS cert as a trust anchor.

--- a/app/domain/services/emrtd_passive_auth.py
+++ b/app/domain/services/emrtd_passive_auth.py
@@ -1,0 +1,509 @@
+"""eMRTD passive authentication (ICAO 9303 Part 11) — CPU-only, pure crypto.
+
+Passive Authentication proves that the Data Groups read from an ePassport /
+eID chip are genuine and unmodified, and that they were signed by a legitimate
+issuing authority. It is the lightweight, server-side trust check that does NOT
+need the physical chip (unlike Active / Chip Authentication), so it runs fine
+on a CPU-only box with no GPU and no heavy ML.
+
+The check has three independent parts (ALL must pass for ``is_authentic``):
+
+1. **Data Group integrity.** The Document Security Object (EF.SOD) embeds an
+   ``LDSSecurityObject`` listing the expected hash of every Data Group, under a
+   named digest algorithm. For each DG the client read, we hash the raw DG
+   bytes and compare to the stored value.
+2. **SOD signature.** EF.SOD is a CMS ``SignedData`` (RFC 5652). We verify the
+   signer's signature over the signed attributes (or directly over the
+   ``LDSSecurityObject`` eContent when there are no signed attributes), using
+   the Document Signer (DS) certificate embedded in the SOD.
+3. **Certificate chain.** The DS certificate must chain to a trusted Country
+   Signing CA (CSCA) root from an operator-provided trust store.
+
+This module is deliberately framework-free: it takes bytes and returns a plain
+dataclass, so it is trivially unit-testable with a self-signed CSCA/DS/SOD
+fixture and carries no FastAPI / DB / ML dependencies.
+
+Dependencies: ``asn1crypto`` (pure-Python ASN.1) + ``cryptography`` (signature
+primitives). Both are CPU-only and already part of the pinned requirements.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, Optional
+
+from asn1crypto import algos, cms, core
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+from cryptography.x509 import load_der_x509_certificate
+from cryptography.x509 import Certificate as CryptoCertificate
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# ASN.1 definitions not shipped by asn1crypto: the ICAO LDS Security Object.
+# (ICAO 9303 Part 10, appendix). asn1crypto lets us declare these declaratively.
+# ---------------------------------------------------------------------------
+
+
+class DataGroupNumber(core.Integer):
+    """A Data Group number (1..16)."""
+
+
+class DataGroupHash(core.Sequence):
+    """One ``{dataGroupNumber, dataGroupHashValue}`` entry."""
+
+    _fields = [
+        ("data_group_number", DataGroupNumber),
+        ("data_group_hash_value", core.OctetString),
+    ]
+
+
+class DataGroupHashValues(core.SequenceOf):
+    """The list of per-DG hash entries."""
+
+    _child_spec = DataGroupHash
+
+
+class LDSVersionInfo(core.Sequence):
+    _fields = [
+        ("lds_version", core.PrintableString),
+        ("unicode_version", core.PrintableString),
+    ]
+
+
+class LDSSecurityObject(core.Sequence):
+    """The eContent of EF.SOD — the signed manifest of DG hashes."""
+
+    _fields = [
+        ("version", core.Integer),
+        ("hash_algorithm", algos.DigestAlgorithm),
+        ("data_group_hash_values", DataGroupHashValues),
+        ("lds_version_info", LDSVersionInfo, {"optional": True}),
+    ]
+
+
+# ICAO assigns this OID to the LDS Security Object eContent type.
+_ICAO_LDS_SECURITY_OBJECT_OID = "2.23.136.1.1.1"
+
+# Map asn1crypto digest-algorithm names to hashlib constructors. eMRTD only
+# ever uses these; anything else is rejected (fail-closed, not silently weak).
+_HASHLIB_BY_NAME: Dict[str, str] = {
+    "sha1": "sha1",
+    "sha224": "sha224",
+    "sha256": "sha256",
+    "sha384": "sha384",
+    "sha512": "sha512",
+}
+
+# Map digest names to cryptography hash instances for signature verification.
+_CRYPTO_HASH_BY_NAME = {
+    "sha1": hashes.SHA1,
+    "sha224": hashes.SHA224,
+    "sha256": hashes.SHA256,
+    "sha384": hashes.SHA384,
+    "sha512": hashes.SHA512,
+}
+
+
+class ReasonCode(str, Enum):
+    """Stable, machine-readable verdict codes (mirrors the API contract)."""
+
+    OK = "OK"
+    DG_HASH_MISMATCH = "DG_HASH_MISMATCH"
+    SIGNATURE_INVALID = "SIGNATURE_INVALID"
+    DS_UNTRUSTED = "DS_UNTRUSTED"
+    SOD_PARSE_ERROR = "SOD_PARSE_ERROR"
+    NO_TRUST_STORE = "NO_TRUST_STORE"
+    MISSING_DG = "MISSING_DG"
+    UNSUPPORTED_ALGORITHM = "UNSUPPORTED_ALGORITHM"
+
+
+@dataclass
+class PassiveAuthResult:
+    """Authoritative passive-authentication verdict."""
+
+    is_authentic: bool
+    reason: str
+    reason_code: ReasonCode
+    csca_matched: bool = False
+    ds_subject: Optional[str] = None
+    ds_serial: Optional[str] = None
+    sod_hash_algorithm: Optional[str] = None
+    dg_hash_results: Dict[str, bool] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "is_authentic": self.is_authentic,
+            "reason": self.reason,
+            "reason_code": self.reason_code.value,
+            "ds_subject": self.ds_subject,
+            "ds_serial": self.ds_serial,
+            "csca_matched": self.csca_matched,
+            "dg_hash_results": self.dg_hash_results,
+            "sod_hash_algorithm": self.sod_hash_algorithm,
+        }
+
+
+class EmrtdPassiveAuthService:
+    """Stateless verifier for eMRTD passive authentication.
+
+    The CSCA trust anchors are supplied at construction (a list of trusted CSCA
+    certificates loaded from the operator trust store). Keeping the service
+    stateless-per-request but anchor-injected makes it trivially testable with a
+    self-signed CSCA fixture and free of any filesystem coupling.
+    """
+
+    def __init__(self, csca_certificates: Optional[list[CryptoCertificate]] = None) -> None:
+        self._csca_certs = csca_certificates or []
+
+    # -- public API --------------------------------------------------------
+
+    def verify(
+        self,
+        sod_der: bytes,
+        data_groups: Dict[int, bytes],
+    ) -> PassiveAuthResult:
+        """Run the full passive-authentication check.
+
+        Args:
+            sod_der: Raw DER bytes of EF.SOD (CMS SignedData / ContentInfo).
+            data_groups: Mapping of DG number -> raw DG bytes the client read.
+                The bytes MUST be the full DG TLV exactly as stored on the chip
+                (that is what the issuer hashed when building the SOD).
+
+        Returns:
+            PassiveAuthResult — fail-closed: ``is_authentic`` is True only when
+            DG integrity, the SOD signature, and the CSCA chain ALL pass.
+        """
+        # --- parse EF.SOD -> CMS SignedData -> LDSSecurityObject -----------
+        try:
+            signed_data, lds = self._parse_sod(sod_der)
+        except Exception as exc:  # noqa: BLE001 — any parse failure is a reject
+            logger.warning("EF.SOD parse failed: %s", exc)
+            return PassiveAuthResult(
+                is_authentic=False,
+                reason=f"Could not parse EF.SOD: {exc}",
+                reason_code=ReasonCode.SOD_PARSE_ERROR,
+            )
+
+        hash_name = lds["hash_algorithm"]["algorithm"].native
+        sod_hash_algorithm = str(hash_name)
+        if hash_name not in _HASHLIB_BY_NAME:
+            return PassiveAuthResult(
+                is_authentic=False,
+                reason=f"Unsupported SOD hash algorithm: {hash_name}",
+                reason_code=ReasonCode.UNSUPPORTED_ALGORITHM,
+                sod_hash_algorithm=sod_hash_algorithm,
+            )
+
+        # DS certificate (subject/serial surfaced regardless of outcome).
+        ds_cert = self._extract_ds_certificate(signed_data)
+        ds_subject = ds_cert.subject.rfc4514_string() if ds_cert is not None else None
+        ds_serial = format(ds_cert.serial_number, "X") if ds_cert is not None else None
+
+        # --- (a) Data Group integrity -------------------------------------
+        expected_hashes = self._lds_hash_map(lds)
+        dg_hash_results: Dict[str, bool] = {}
+        all_dg_ok = True
+        if not data_groups:
+            return PassiveAuthResult(
+                is_authentic=False,
+                reason="No data groups supplied to verify.",
+                reason_code=ReasonCode.MISSING_DG,
+                ds_subject=ds_subject,
+                ds_serial=ds_serial,
+                sod_hash_algorithm=sod_hash_algorithm,
+            )
+        for dg_number, dg_bytes in data_groups.items():
+            expected = expected_hashes.get(dg_number)
+            if expected is None:
+                # The SOD does not even cover this DG → cannot be trusted.
+                dg_hash_results[str(dg_number)] = False
+                all_dg_ok = False
+                continue
+            actual = hashlib.new(
+                _HASHLIB_BY_NAME[hash_name], dg_bytes
+            ).digest()
+            ok = _constant_time_eq(actual, expected)
+            dg_hash_results[str(dg_number)] = ok
+            all_dg_ok = all_dg_ok and ok
+
+        if not all_dg_ok:
+            mismatched = [k for k, v in dg_hash_results.items() if not v]
+            return PassiveAuthResult(
+                is_authentic=False,
+                reason=f"Data group hash mismatch for DG(s): {', '.join(mismatched)}",
+                reason_code=ReasonCode.DG_HASH_MISMATCH,
+                ds_subject=ds_subject,
+                ds_serial=ds_serial,
+                sod_hash_algorithm=sod_hash_algorithm,
+                dg_hash_results=dg_hash_results,
+            )
+
+        # --- (b) SOD signature over the LDS eContent ----------------------
+        if ds_cert is None:
+            return PassiveAuthResult(
+                is_authentic=False,
+                reason="EF.SOD carries no Document Signer certificate.",
+                reason_code=ReasonCode.SIGNATURE_INVALID,
+                sod_hash_algorithm=sod_hash_algorithm,
+                dg_hash_results=dg_hash_results,
+            )
+        try:
+            sig_ok = self._verify_sod_signature(signed_data, ds_cert, hash_name)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("EF.SOD signature verification raised: %s", exc)
+            sig_ok = False
+        if not sig_ok:
+            return PassiveAuthResult(
+                is_authentic=False,
+                reason="EF.SOD CMS signature did not verify against the Document Signer cert.",
+                reason_code=ReasonCode.SIGNATURE_INVALID,
+                ds_subject=ds_subject,
+                ds_serial=ds_serial,
+                sod_hash_algorithm=sod_hash_algorithm,
+                dg_hash_results=dg_hash_results,
+            )
+
+        # --- (c) DS -> CSCA chain -----------------------------------------
+        if not self._csca_certs:
+            # No trust anchors configured → we cannot assert authenticity.
+            return PassiveAuthResult(
+                is_authentic=False,
+                reason="No CSCA trust anchors configured; cannot establish document signer trust.",
+                reason_code=ReasonCode.NO_TRUST_STORE,
+                ds_subject=ds_subject,
+                ds_serial=ds_serial,
+                sod_hash_algorithm=sod_hash_algorithm,
+                dg_hash_results=dg_hash_results,
+            )
+        csca_matched = self._ds_chains_to_csca(ds_cert)
+        if not csca_matched:
+            return PassiveAuthResult(
+                is_authentic=False,
+                reason="Document Signer certificate does not chain to any trusted CSCA root.",
+                reason_code=ReasonCode.DS_UNTRUSTED,
+                ds_subject=ds_subject,
+                ds_serial=ds_serial,
+                sod_hash_algorithm=sod_hash_algorithm,
+                dg_hash_results=dg_hash_results,
+            )
+
+        # All three checks passed.
+        return PassiveAuthResult(
+            is_authentic=True,
+            reason="ok",
+            reason_code=ReasonCode.OK,
+            csca_matched=True,
+            ds_subject=ds_subject,
+            ds_serial=ds_serial,
+            sod_hash_algorithm=sod_hash_algorithm,
+            dg_hash_results=dg_hash_results,
+        )
+
+    # -- internals ---------------------------------------------------------
+
+    @staticmethod
+    def _parse_sod(sod_der: bytes) -> tuple[cms.SignedData, LDSSecurityObject]:
+        """Parse EF.SOD into its CMS SignedData and the inner LDSSecurityObject.
+
+        EF.SOD may be wrapped in an ICAO application tag (0x77) or be a bare
+        CMS ContentInfo. We strip a leading application wrapper if present.
+        """
+        data = sod_der
+        # ICAO wraps EF.SOD in tag 0x77 (application 23). asn1crypto's
+        # ContentInfo.load expects a plain SEQUENCE, so unwrap if needed.
+        if data and data[0] == 0x77:
+            data = core.load(data).contents
+
+        content_info = cms.ContentInfo.load(data)
+        if content_info["content_type"].native != "signed_data":
+            raise ValueError(
+                f"EF.SOD is not CMS signed_data (got {content_info['content_type'].native})"
+            )
+        signed_data: cms.SignedData = content_info["content"]
+
+        encap = signed_data["encap_content_info"]
+        econtent = encap["content"]
+        if econtent is None:
+            raise ValueError("EF.SOD eContent is absent")
+        # econtent is an OctetString wrapping the LDSSecurityObject DER.
+        lds = LDSSecurityObject.load(_as_octet_bytes(econtent))
+        return signed_data, lds
+
+    @staticmethod
+    def _lds_hash_map(lds: LDSSecurityObject) -> Dict[int, bytes]:
+        out: Dict[int, bytes] = {}
+        for entry in lds["data_group_hash_values"]:
+            out[int(entry["data_group_number"].native)] = entry["data_group_hash_value"].native
+        return out
+
+    @staticmethod
+    def _extract_ds_certificate(
+        signed_data: cms.SignedData,
+    ) -> Optional[CryptoCertificate]:
+        """Return the Document Signer cert embedded in the SOD, if any."""
+        certs = signed_data["certificates"]
+        if certs is None:
+            return None
+        for choice in certs:
+            if choice.name == "certificate":
+                der = choice.chosen.dump()
+                return load_der_x509_certificate(der)
+        return None
+
+    def _verify_sod_signature(
+        self,
+        signed_data: cms.SignedData,
+        ds_cert: CryptoCertificate,
+        hash_name: str,
+    ) -> bool:
+        """Verify the single SignerInfo signature in the SOD.
+
+        Per RFC 5652: when signed attributes are present, the signature is over
+        the DER of the signed-attributes SET (re-tagged as a universal SET); the
+        ``messageDigest`` attribute inside it must equal the hash of the
+        eContent. When absent, the signature is directly over the eContent.
+        """
+        signer_infos = signed_data["signer_infos"]
+        if len(signer_infos) == 0:
+            return False
+        signer_info = signer_infos[0]
+
+        digest_alg = signer_info["digest_algorithm"]["algorithm"].native
+        digest_name = digest_alg if digest_alg in _CRYPTO_HASH_BY_NAME else hash_name
+
+        econtent_bytes = _as_octet_bytes(
+            signed_data["encap_content_info"]["content"]
+        )
+
+        signed_attrs = signer_info["signed_attrs"]
+        if signed_attrs is not None and len(signed_attrs) > 0:
+            # messageDigest attr must match hash(eContent).
+            md_attr = _find_attr(signed_attrs, "message_digest")
+            if md_attr is None:
+                return False
+            expected_md = md_attr["values"][0].native
+            actual_md = hashlib.new(
+                _HASHLIB_BY_NAME.get(digest_name, digest_name), econtent_bytes
+            ).digest()
+            if not _constant_time_eq(actual_md, expected_md):
+                return False
+            # Signature input = DER of signed attrs re-tagged as universal SET.
+            signed_bytes = signed_attrs.untag().dump()
+        else:
+            signed_bytes = econtent_bytes
+
+        signature = signer_info["signature"].native
+        sig_alg = signer_info["signature_algorithm"].signature_algo
+        crypto_hash = _CRYPTO_HASH_BY_NAME.get(digest_name, hashes.SHA256)()
+
+        public_key = ds_cert.public_key()
+        try:
+            if isinstance(public_key, rsa.RSAPublicKey):
+                if sig_alg == "rsassa_pss":
+                    pss_params = signer_info["signature_algorithm"]["parameters"]
+                    salt_len = int(pss_params["salt_length"].native)
+                    public_key.verify(
+                        signature,
+                        signed_bytes,
+                        padding.PSS(
+                            mgf=padding.MGF1(crypto_hash),
+                            salt_length=salt_len,
+                        ),
+                        crypto_hash,
+                    )
+                else:
+                    public_key.verify(
+                        signature, signed_bytes, padding.PKCS1v15(), crypto_hash
+                    )
+            elif isinstance(public_key, ec.EllipticCurvePublicKey):
+                public_key.verify(
+                    signature, signed_bytes, ec.ECDSA(crypto_hash)
+                )
+            else:
+                logger.warning(
+                    "Unsupported DS public key type for SOD verification: %s",
+                    type(public_key).__name__,
+                )
+                return False
+            return True
+        except InvalidSignature:
+            return False
+
+    def _ds_chains_to_csca(self, ds_cert: CryptoCertificate) -> bool:
+        """True if the DS cert's signature verifies under a trusted CSCA key.
+
+        eMRTD chains are short (DS signed directly by a CSCA root), so a direct
+        issuer-match + signature check is sufficient and avoids pulling in a
+        full path-validation engine. We match candidate CSCAs by subject==issuer
+        then cryptographically verify the DS signature under the CSCA key.
+        """
+        for csca in self._csca_certs:
+            if csca.subject != ds_cert.issuer:
+                continue
+            if _cert_signed_by(ds_cert, csca):
+                return True
+        return False
+
+
+# ---------------------------------------------------------------------------
+# small helpers
+# ---------------------------------------------------------------------------
+
+
+def _constant_time_eq(a: bytes, b: bytes) -> bool:
+    import hmac
+
+    return hmac.compare_digest(a, b)
+
+
+def _as_octet_bytes(value) -> bytes:
+    """Return the raw bytes carried by a CMS eContent / OctetString field."""
+    if value is None:
+        raise ValueError("missing content")
+    native = value.native
+    if isinstance(native, bytes):
+        return native
+    # ParsableOctetString: fall back to its DER dump of the parsed child.
+    return value.parsed.dump()
+
+
+def _find_attr(signed_attrs, name: str):
+    for attr in signed_attrs:
+        if attr["type"].native == name:
+            return attr
+    return None
+
+
+def _cert_signed_by(child: CryptoCertificate, issuer: CryptoCertificate) -> bool:
+    """Verify ``child``'s signature using ``issuer``'s public key."""
+    issuer_key = issuer.public_key()
+    try:
+        if isinstance(issuer_key, rsa.RSAPublicKey):
+            issuer_key.verify(
+                child.signature,
+                child.tbs_certificate_bytes,
+                padding.PKCS1v15(),
+                child.signature_hash_algorithm,
+            )
+        elif isinstance(issuer_key, ec.EllipticCurvePublicKey):
+            issuer_key.verify(
+                child.signature,
+                child.tbs_certificate_bytes,
+                ec.ECDSA(child.signature_hash_algorithm),
+            )
+        else:
+            return False
+        return True
+    except InvalidSignature:
+        return False
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("CSCA chain check raised: %s", exc)
+        return False

--- a/requirements-known-good-2026-05-29.lock
+++ b/requirements-known-good-2026-05-29.lock
@@ -19,6 +19,7 @@ alembic==1.18.4
 annotated-doc==0.0.4
 annotated-types==0.7.0
 anyio==4.13.0
+asn1crypto==1.5.1
 astunparse==1.6.3
 asyncpg==0.31.0
 attrs==26.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -129,6 +129,9 @@ requests>=2.32.3
 werkzeug>=3.1.6
 jinja2>=3.1.6
 cryptography>=45.0.3
+# eMRTD passive authentication (NFC chip trust verify) — pure-Python ASN.1,
+# CPU-only, no native build. Parses EF.SOD / LDSSecurityObject + CMS SignedData.
+asn1crypto>=1.5.1
 setuptools>=80.9.0
 idna>=3.15
 tornado>=6.5.1

--- a/tests/unit/application/use_cases/test_enroll_multi_image.py
+++ b/tests/unit/application/use_cases/test_enroll_multi_image.py
@@ -4,8 +4,10 @@ import pytest
 import numpy as np
 from unittest.mock import Mock, AsyncMock, patch
 
+from app.application.use_cases.check_liveness import CheckLivenessUseCase
 from app.application.use_cases.enroll_multi_image import EnrollMultiImageUseCase
 from app.domain.entities.face_detection import FaceDetectionResult
+from app.domain.entities.liveness_result import LivenessResult
 from app.domain.entities.quality_assessment import QualityAssessment
 from app.domain.services.embedding_fusion_service import EmbeddingFusionService
 from app.domain.exceptions.enrollment_errors import (
@@ -16,6 +18,7 @@ from app.domain.exceptions.face_errors import (
     FaceNotDetectedError,
     PoorImageQualityError,
 )
+from app.domain.exceptions.liveness_errors import LivenessCheckFailedError
 
 
 @pytest.fixture
@@ -513,3 +516,200 @@ class TestEnrollMultiImageUseCase:
         assert call_args.kwargs["tenant_id"] == "test_tenant"
         assert isinstance(call_args.kwargs["embedding"], np.ndarray)
         assert call_args.kwargs["quality_score"] > 0
+
+
+def _live_result(score: float, is_live: bool) -> LivenessResult:
+    """Build a passive-liveness LivenessResult fixture for the gate tests."""
+    return LivenessResult(
+        is_live=is_live,
+        score=score,
+        challenge="passive",
+        challenge_completed=True,
+    )
+
+
+class TestEnrollMultiImageLivenessGate:
+    """The /enroll/multi path must run the SAME server-authoritative passive
+    liveness check that single-image /enroll runs (fail-closed), so a photo or
+    screen replay can no longer be enrolled via the multi-image path.
+
+    The liveness backend verdict is mocked at the CheckLivenessUseCase boundary
+    (the exact use case single-/enroll calls), so these tests assert the WIRING
+    + fail-closed policy without booting UniFace MiniFASNet / ONNX.
+    """
+
+    @pytest.mark.asyncio
+    async def test_rejects_spoof_frame_fail_closed(
+        self,
+        mock_face_detector,
+        mock_embedding_extractor,
+        mock_quality_assessor,
+        mock_embedding_repository,
+        mock_fusion_service,
+        temp_image_files,
+    ):
+        """A single non-live (spoof) frame rejects the WHOLE enrollment and
+        nothing is persisted (fail-closed). The spoof frame is the second of
+        three, proving every frame is gated, not just the first."""
+        call_count = [0]
+
+        async def liveness_side_effect(image_path):
+            call_count[0] += 1
+            # Second frame is a photo/screen replay → not live.
+            return _live_result(score=18.0, is_live=call_count[0] != 2)
+
+        liveness_use_case = Mock(spec=CheckLivenessUseCase)
+        liveness_use_case.execute = AsyncMock(side_effect=liveness_side_effect)
+
+        use_case = EnrollMultiImageUseCase(
+            detector=mock_face_detector,
+            extractor=mock_embedding_extractor,
+            quality_assessor=mock_quality_assessor,
+            repository=mock_embedding_repository,
+            fusion_service=mock_fusion_service,
+            liveness_use_case=liveness_use_case,
+        )
+
+        with patch("cv2.imread") as mock_imread:
+            mock_imread.return_value = np.random.randint(
+                0, 255, (200, 200, 3), dtype=np.uint8
+            )
+
+            with pytest.raises(LivenessCheckFailedError):
+                await use_case.execute(
+                    user_id="spoofer",
+                    image_paths=temp_image_files,
+                )
+
+        # Gate ran on frame 1 (live) then frame 2 (spoof) → stopped there.
+        assert liveness_use_case.execute.await_count == 2
+        # Fail-closed: no embedding persisted on a spoof frame.
+        mock_embedding_repository.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_first_frame_spoof_rejects_immediately(
+        self,
+        mock_face_detector,
+        mock_embedding_extractor,
+        mock_quality_assessor,
+        mock_embedding_repository,
+        mock_fusion_service,
+        temp_image_files,
+    ):
+        """A spoof on the very first frame short-circuits before any embedding
+        work happens."""
+        liveness_use_case = Mock(spec=CheckLivenessUseCase)
+        liveness_use_case.execute = AsyncMock(
+            return_value=_live_result(score=5.0, is_live=False)
+        )
+
+        use_case = EnrollMultiImageUseCase(
+            detector=mock_face_detector,
+            extractor=mock_embedding_extractor,
+            quality_assessor=mock_quality_assessor,
+            repository=mock_embedding_repository,
+            fusion_service=mock_fusion_service,
+            liveness_use_case=liveness_use_case,
+        )
+
+        with patch("cv2.imread") as mock_imread:
+            mock_imread.return_value = np.random.randint(
+                0, 255, (200, 200, 3), dtype=np.uint8
+            )
+
+            with pytest.raises(LivenessCheckFailedError):
+                await use_case.execute(
+                    user_id="spoofer",
+                    image_paths=temp_image_files,
+                )
+
+        assert liveness_use_case.execute.await_count == 1
+        # Liveness gate sits BEFORE detection/quality/extraction.
+        mock_face_detector.detect.assert_not_called()
+        mock_embedding_extractor.extract.assert_not_called()
+        mock_embedding_repository.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_accepts_all_live_frames(
+        self,
+        mock_face_detector,
+        mock_embedding_extractor,
+        mock_quality_assessor,
+        mock_embedding_repository,
+        mock_fusion_service,
+        temp_image_files,
+    ):
+        """When every frame is live, enrollment proceeds normally and the gate
+        was exercised once per frame."""
+        liveness_use_case = Mock(spec=CheckLivenessUseCase)
+        liveness_use_case.execute = AsyncMock(
+            return_value=_live_result(score=92.0, is_live=True)
+        )
+
+        use_case = EnrollMultiImageUseCase(
+            detector=mock_face_detector,
+            extractor=mock_embedding_extractor,
+            quality_assessor=mock_quality_assessor,
+            repository=mock_embedding_repository,
+            fusion_service=mock_fusion_service,
+            liveness_use_case=liveness_use_case,
+        )
+
+        with patch("cv2.imread") as mock_imread:
+            mock_imread.return_value = np.random.randint(
+                0, 255, (200, 200, 3), dtype=np.uint8
+            )
+
+            result = await use_case.execute(
+                user_id="real_user",
+                image_paths=temp_image_files,
+            )
+
+        assert result.user_id == "real_user"
+        assert liveness_use_case.execute.await_count == len(temp_image_files)
+        mock_embedding_repository.save.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_gate_skipped_when_disabled(
+        self,
+        mock_face_detector,
+        mock_embedding_extractor,
+        mock_quality_assessor,
+        mock_embedding_repository,
+        mock_fusion_service,
+        temp_image_files,
+    ):
+        """ENROLL_LIVENESS_ENABLED=False is an explicit operator escape hatch:
+        the liveness backend is never called and a spoof frame would pass. This
+        mirrors the single-/enroll gate's config flag."""
+        liveness_use_case = Mock(spec=CheckLivenessUseCase)
+        liveness_use_case.execute = AsyncMock(
+            return_value=_live_result(score=1.0, is_live=False)
+        )
+
+        use_case = EnrollMultiImageUseCase(
+            detector=mock_face_detector,
+            extractor=mock_embedding_extractor,
+            quality_assessor=mock_quality_assessor,
+            repository=mock_embedding_repository,
+            fusion_service=mock_fusion_service,
+            liveness_use_case=liveness_use_case,
+        )
+
+        with patch(
+            "app.application.use_cases.enroll_multi_image.settings.ENROLL_LIVENESS_ENABLED",
+            False,
+        ):
+            with patch("cv2.imread") as mock_imread:
+                mock_imread.return_value = np.random.randint(
+                    0, 255, (200, 200, 3), dtype=np.uint8
+                )
+
+                result = await use_case.execute(
+                    user_id="bypass_user",
+                    image_paths=temp_image_files,
+                )
+
+        assert result.user_id == "bypass_user"
+        liveness_use_case.execute.assert_not_called()
+        mock_embedding_repository.save.assert_called_once()

--- a/tests/unit/domain/services/test_emrtd_passive_auth.py
+++ b/tests/unit/domain/services/test_emrtd_passive_auth.py
@@ -1,0 +1,311 @@
+"""Unit tests for eMRTD passive authentication (ICAO 9303 Part 11).
+
+These tests build a complete self-signed CSCA -> DS -> EF.SOD fixture in-process
+(no network, no external certs) and exercise the four authoritative outcomes the
+contract guarantees:
+
+- happy path  -> is_authentic=True / OK
+- DG tamper   -> is_authentic=False / DG_HASH_MISMATCH
+- bad sig     -> is_authentic=False / SIGNATURE_INVALID
+- untrusted DS-> is_authentic=False / DS_UNTRUSTED
+- no store    -> is_authentic=False / NO_TRUST_STORE  (fail-closed default)
+
+The fixture mirrors a real EF.SOD: a CMS SignedData whose eContent is an ICAO
+``LDSSecurityObject`` listing per-DG hashes, signed by a Document Signer cert
+that itself is issued by a (test) CSCA root.
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+
+import pytest
+from asn1crypto import cms, core
+from asn1crypto import x509 as a_x509
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+from cryptography.x509.oid import NameOID
+
+from app.domain.services.emrtd_passive_auth import (
+    _ICAO_LDS_SECURITY_OBJECT_OID,
+    EmrtdPassiveAuthService,
+    LDSSecurityObject,
+    ReasonCode,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _make_cert(subject_cn, issuer_cn, issuer_key, subject_pub, is_ca, sign_hash=None):
+    sign_hash = sign_hash or hashes.SHA256()
+    subject = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COMMON_NAME, subject_cn),
+            x509.NameAttribute(NameOID.COUNTRY_NAME, "TR"),
+        ]
+    )
+    issuer = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COMMON_NAME, issuer_cn),
+            x509.NameAttribute(NameOID.COUNTRY_NAME, "TR"),
+        ]
+    )
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(subject_pub)
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime(2020, 1, 1))
+        .not_valid_after(datetime.datetime(2035, 1, 1))
+    )
+    if is_ca:
+        builder = builder.add_extension(
+            x509.BasicConstraints(ca=True, path_length=None), critical=True
+        )
+    return builder.sign(issuer_key, sign_hash)
+
+
+def _build_lds(data_groups: dict[int, bytes], hash_name: str = "sha256") -> bytes:
+    hashfn = getattr(hashlib, hash_name)
+    entries = [
+        {"data_group_number": n, "data_group_hash_value": hashfn(b).digest()}
+        for n, b in data_groups.items()
+    ]
+    lds = LDSSecurityObject(
+        {
+            "version": 0,
+            "hash_algorithm": {"algorithm": hash_name},
+            "data_group_hash_values": entries,
+        }
+    )
+    return lds.dump()
+
+
+def _build_sod(
+    lds_der: bytes,
+    ds_cert: x509.Certificate,
+    ds_key,
+    *,
+    corrupt_signature: bool = False,
+    hash_name: str = "sha256",
+) -> bytes:
+    """Assemble an EF.SOD (CMS ContentInfo/SignedData) over an LDS eContent."""
+    crypto_hash = {"sha256": hashes.SHA256, "sha1": hashes.SHA1}[hash_name]()
+    md = getattr(hashlib, hash_name)(lds_der).digest()
+
+    signed_attrs = cms.CMSAttributes(
+        [
+            cms.CMSAttribute(
+                {
+                    "type": "content_type",
+                    "values": [cms.ContentType(_ICAO_LDS_SECURITY_OBJECT_OID)],
+                }
+            ),
+            cms.CMSAttribute(
+                {"type": "message_digest", "values": [core.OctetString(md)]}
+            ),
+        ]
+    )
+    to_sign = signed_attrs.dump()
+
+    if isinstance(ds_key, ec.EllipticCurvePrivateKey):
+        sig = ds_key.sign(to_sign, ec.ECDSA(crypto_hash))
+        sig_alg = "ecdsa"
+    else:
+        sig = ds_key.sign(to_sign, padding.PKCS1v15(), crypto_hash)
+        sig_alg = "rsassa_pkcs1v15"
+
+    if corrupt_signature:
+        sig = bytes((sig[0] ^ 0xFF,)) + sig[1:]
+
+    ds_a = a_x509.Certificate.load(
+        ds_cert.public_bytes(serialization.Encoding.DER)
+    )
+    signer_info = cms.SignerInfo(
+        {
+            "version": "v1",
+            "sid": cms.SignerIdentifier(
+                {
+                    "issuer_and_serial_number": cms.IssuerAndSerialNumber(
+                        {"issuer": ds_a.issuer, "serial_number": ds_a.serial_number}
+                    )
+                }
+            ),
+            "digest_algorithm": {"algorithm": hash_name},
+            "signed_attrs": signed_attrs,
+            "signature_algorithm": {"algorithm": sig_alg},
+            "signature": sig,
+        }
+    )
+    signed_data = cms.SignedData(
+        {
+            "version": "v3",
+            "digest_algorithms": [{"algorithm": hash_name}],
+            "encap_content_info": {
+                "content_type": _ICAO_LDS_SECURITY_OBJECT_OID,
+                "content": lds_der,
+            },
+            "certificates": [ds_a],
+            "signer_infos": [signer_info],
+        }
+    )
+    return cms.ContentInfo(
+        {"content_type": "signed_data", "content": signed_data}
+    ).dump()
+
+
+@pytest.fixture
+def emrtd_fixture():
+    """A coherent CSCA/DS/SOD set plus the data groups it covers."""
+    csca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    ds_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    csca_cert = _make_cert(
+        "Test CSCA Root", "Test CSCA Root", csca_key, csca_key.public_key(), True
+    )
+    ds_cert = _make_cert(
+        "Test Document Signer",
+        "Test CSCA Root",
+        csca_key,
+        ds_key.public_key(),
+        False,
+    )
+
+    data_groups = {
+        1: b"\x61\x10DG1-MRZ-PAYLOAD!",
+        2: b"\x75\x20" + b"FAKE_DG2_PORTRAIT_BYTES_32_LONG_",
+    }
+    lds_der = _build_lds(data_groups)
+    sod_der = _build_sod(lds_der, ds_cert, ds_key)
+
+    return {
+        "csca_cert": csca_cert,
+        "ds_cert": ds_cert,
+        "ds_key": ds_key,
+        "lds_der": lds_der,
+        "sod_der": sod_der,
+        "data_groups": data_groups,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestEmrtdPassiveAuth:
+    def test_happy_path_accepts_authentic_document(self, emrtd_fixture):
+        svc = EmrtdPassiveAuthService(csca_certificates=[emrtd_fixture["csca_cert"]])
+        result = svc.verify(
+            sod_der=emrtd_fixture["sod_der"],
+            data_groups=emrtd_fixture["data_groups"],
+        )
+        assert result.is_authentic is True
+        assert result.reason_code == ReasonCode.OK
+        assert result.csca_matched is True
+        assert result.dg_hash_results == {"1": True, "2": True}
+        assert result.sod_hash_algorithm == "sha256"
+        assert "Document Signer" in (result.ds_subject or "")
+        assert result.ds_serial  # hex serial present
+
+    def test_dg_hash_mismatch_rejects(self, emrtd_fixture):
+        svc = EmrtdPassiveAuthService(csca_certificates=[emrtd_fixture["csca_cert"]])
+        tampered = dict(emrtd_fixture["data_groups"])
+        tampered[2] = tampered[2] + b"TAMPER"  # any change breaks the DG2 hash
+        result = svc.verify(sod_der=emrtd_fixture["sod_der"], data_groups=tampered)
+        assert result.is_authentic is False
+        assert result.reason_code == ReasonCode.DG_HASH_MISMATCH
+        assert result.dg_hash_results["1"] is True
+        assert result.dg_hash_results["2"] is False
+
+    def test_bad_signature_rejects(self, emrtd_fixture):
+        # Re-sign the SOD with a corrupted signature but otherwise-valid DGs,
+        # so the verdict must hit the signature check (not the DG check).
+        bad_sod = _build_sod(
+            emrtd_fixture["lds_der"],
+            emrtd_fixture["ds_cert"],
+            emrtd_fixture["ds_key"],
+            corrupt_signature=True,
+        )
+        svc = EmrtdPassiveAuthService(csca_certificates=[emrtd_fixture["csca_cert"]])
+        result = svc.verify(
+            sod_der=bad_sod, data_groups=emrtd_fixture["data_groups"]
+        )
+        assert result.is_authentic is False
+        assert result.reason_code == ReasonCode.SIGNATURE_INVALID
+
+    def test_untrusted_ds_rejects(self, emrtd_fixture):
+        # A valid SOD, but the configured trust store holds a DIFFERENT CSCA
+        # that did not issue the DS cert -> chain fails.
+        other_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        other_csca = _make_cert(
+            "Other CSCA", "Other CSCA", other_key, other_key.public_key(), True
+        )
+        svc = EmrtdPassiveAuthService(csca_certificates=[other_csca])
+        result = svc.verify(
+            sod_der=emrtd_fixture["sod_der"],
+            data_groups=emrtd_fixture["data_groups"],
+        )
+        assert result.is_authentic is False
+        assert result.reason_code == ReasonCode.DS_UNTRUSTED
+
+    def test_empty_trust_store_fails_closed(self, emrtd_fixture):
+        # No CSCA anchors at all -> cannot assert trust (fail-closed default).
+        svc = EmrtdPassiveAuthService(csca_certificates=[])
+        result = svc.verify(
+            sod_der=emrtd_fixture["sod_der"],
+            data_groups=emrtd_fixture["data_groups"],
+        )
+        assert result.is_authentic is False
+        assert result.reason_code == ReasonCode.NO_TRUST_STORE
+        # DG integrity still computed + surfaced even when trust store is empty.
+        assert result.dg_hash_results == {"1": True, "2": True}
+
+    def test_unparseable_sod_fails_closed(self, emrtd_fixture):
+        svc = EmrtdPassiveAuthService(csca_certificates=[emrtd_fixture["csca_cert"]])
+        result = svc.verify(
+            sod_der=b"not a real SOD", data_groups=emrtd_fixture["data_groups"]
+        )
+        assert result.is_authentic is False
+        assert result.reason_code == ReasonCode.SOD_PARSE_ERROR
+
+    def test_missing_data_groups_rejects(self, emrtd_fixture):
+        svc = EmrtdPassiveAuthService(csca_certificates=[emrtd_fixture["csca_cert"]])
+        result = svc.verify(sod_der=emrtd_fixture["sod_der"], data_groups={})
+        assert result.is_authentic is False
+        assert result.reason_code == ReasonCode.MISSING_DG
+
+    def test_dg_not_covered_by_sod_rejects(self, emrtd_fixture):
+        # Client presents a DG the SOD never signed (DG7). Must reject, not
+        # silently accept the DGs that DO match.
+        svc = EmrtdPassiveAuthService(csca_certificates=[emrtd_fixture["csca_cert"]])
+        dgs = dict(emrtd_fixture["data_groups"])
+        dgs[7] = b"\x67\x05EXTRA"
+        result = svc.verify(sod_der=emrtd_fixture["sod_der"], data_groups=dgs)
+        assert result.is_authentic is False
+        assert result.reason_code == ReasonCode.DG_HASH_MISMATCH
+        assert result.dg_hash_results["7"] is False
+
+    def test_ecdsa_document_signer_happy_path(self):
+        # eMRTD DS keys are often ECDSA (P-256). Prove the EC verification path.
+        csca_key = ec.generate_private_key(ec.SECP256R1())
+        ds_key = ec.generate_private_key(ec.SECP256R1())
+        csca_cert = _make_cert(
+            "EC CSCA", "EC CSCA", csca_key, csca_key.public_key(), True
+        )
+        ds_cert = _make_cert(
+            "EC Document Signer", "EC CSCA", csca_key, ds_key.public_key(), False
+        )
+        data_groups = {1: b"\x61\x08EC-DG1!!"}
+        lds_der = _build_lds(data_groups)
+        sod_der = _build_sod(lds_der, ds_cert, ds_key)
+
+        svc = EmrtdPassiveAuthService(csca_certificates=[csca_cert])
+        result = svc.verify(sod_der=sod_der, data_groups=data_groups)
+        assert result.is_authentic is True
+        assert result.reason_code == ReasonCode.OK

--- a/tests/unit/test_nfc_verify_authenticity_route.py
+++ b/tests/unit/test_nfc_verify_authenticity_route.py
@@ -1,0 +1,154 @@
+"""Route-level tests for POST /api/v1/nfc/verify-authenticity.
+
+Exercises the FastAPI wiring + the base64/JSON contract agent-api consumes,
+including the operator CSCA trust-store loading from a configurable directory.
+The cryptographic verdicts themselves are covered exhaustively in
+``tests/unit/domain/services/test_emrtd_passive_auth.py``; here we prove the
+HTTP surface, the trust-store-from-disk path, and the fail-closed default.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import app.api.routes.nfc as nfc_route
+from app.api.routes.nfc import router as nfc_router
+
+# Reuse the SOD/CSCA/DS fixture builders from the service-level test suite.
+from tests.unit.domain.services.test_emrtd_passive_auth import (  # noqa: E402
+    _build_lds,
+    _build_sod,
+    _make_cert,
+)
+from cryptography.hazmat.primitives.asymmetric import rsa  # noqa: E402
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(nfc_router, prefix="/api/v1")
+    return TestClient(app)
+
+
+@pytest.fixture
+def sod_bundle():
+    """Build a coherent CSCA/DS/SOD set and return the b64 request payload
+    plus the CSCA cert PEM so a test can drop it into a trust dir."""
+    csca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    ds_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    csca_cert = _make_cert(
+        "Route CSCA", "Route CSCA", csca_key, csca_key.public_key(), True
+    )
+    ds_cert = _make_cert(
+        "Route Document Signer", "Route CSCA", csca_key, ds_key.public_key(), False
+    )
+    data_groups = {
+        1: b"\x61\x10DG1-MRZ-PAYLOAD!",
+        2: b"\x75\x20" + b"FAKE_DG2_PORTRAIT_BYTES_32_LONG_",
+    }
+    lds_der = _build_lds(data_groups)
+    sod_der = _build_sod(lds_der, ds_cert, ds_key)
+
+    return {
+        "csca_pem": csca_cert.public_bytes(serialization.Encoding.PEM),
+        "request": {
+            "sod_b64": base64.b64encode(sod_der).decode("ascii"),
+            "data_groups": {
+                str(n): base64.b64encode(b).decode("ascii")
+                for n, b in data_groups.items()
+            },
+        },
+    }
+
+
+@pytest.fixture(autouse=True)
+def _clear_trust_cache():
+    """The route memoizes trust-store loads; reset between tests."""
+    nfc_route._csca_certs_cached.cache_clear()
+    yield
+    nfc_route._csca_certs_cached.cache_clear()
+
+
+def _point_trust_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(nfc_route.settings, "NFC_CSCA_TRUST_DIR", str(tmp_path))
+
+
+def test_happy_path_authentic(client, sod_bundle, tmp_path, monkeypatch):
+    (tmp_path / "csca.pem").write_bytes(sod_bundle["csca_pem"])
+    _point_trust_dir(monkeypatch, tmp_path)
+
+    resp = client.post(
+        "/api/v1/nfc/verify-authenticity", json=sod_bundle["request"]
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["is_authentic"] is True
+    assert body["reason_code"] == "OK"
+    assert body["csca_matched"] is True
+    assert body["dg_hash_results"] == {"1": True, "2": True}
+    assert body["sod_hash_algorithm"] == "sha256"
+    assert "Document Signer" in body["ds_subject"]
+
+
+def test_empty_trust_store_fails_closed(client, sod_bundle, tmp_path, monkeypatch):
+    # Trust dir exists but holds no certs -> NO_TRUST_STORE, fail-closed.
+    _point_trust_dir(monkeypatch, tmp_path)
+
+    resp = client.post(
+        "/api/v1/nfc/verify-authenticity", json=sod_bundle["request"]
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["is_authentic"] is False
+    assert body["reason_code"] == "NO_TRUST_STORE"
+
+
+def test_tampered_dg_rejected(client, sod_bundle, tmp_path, monkeypatch):
+    (tmp_path / "csca.pem").write_bytes(sod_bundle["csca_pem"])
+    _point_trust_dir(monkeypatch, tmp_path)
+
+    req = dict(sod_bundle["request"])
+    dgs = dict(req["data_groups"])
+    # Replace DG2 with different bytes -> hash no longer matches the SOD.
+    dgs["2"] = base64.b64encode(b"\x75\x05HELLO").decode("ascii")
+    req["data_groups"] = dgs
+
+    resp = client.post("/api/v1/nfc/verify-authenticity", json=req)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["is_authentic"] is False
+    assert body["reason_code"] == "DG_HASH_MISMATCH"
+    assert body["dg_hash_results"]["2"] is False
+
+
+def test_invalid_sod_base64_returns_400(client):
+    resp = client.post(
+        "/api/v1/nfc/verify-authenticity",
+        json={"sod_b64": "***not-base64***", "data_groups": {"1": "AAAA"}},
+    )
+    assert resp.status_code == 400
+    assert "sod_b64" in resp.json()["detail"]
+
+
+def test_empty_data_groups_returns_400(client, sod_bundle):
+    resp = client.post(
+        "/api/v1/nfc/verify-authenticity",
+        json={"sod_b64": sod_bundle["request"]["sod_b64"], "data_groups": {}},
+    )
+    assert resp.status_code == 400
+
+
+def test_non_numeric_dg_key_returns_400(client, sod_bundle):
+    resp = client.post(
+        "/api/v1/nfc/verify-authenticity",
+        json={
+            "sod_b64": sod_bundle["request"]["sod_b64"],
+            "data_groups": {"face": "AAAA"},
+        },
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary

Two P0 security gaps in the biometric pipeline, both CPU-only (no GPU, `ALLOW_HEAVY_ML` stays false).

### 1. Liveness on `/enroll/multi` (fail-closed)
`/enroll/multi` ran **no** liveness while single `/enroll` did — a photo / screen replay could be enrolled via the multi-image path. The multi-image use case (`app/application/use_cases/enroll_multi_image.py`) now runs the **same** `CheckLivenessUseCase` (UniFace MiniFASNet passive + DeepFace anti-spoof veto) that single-`/enroll` calls, on **every frame** before extracting/fusing its embedding. One non-live frame rejects the whole enrollment (`LivenessCheckFailedError` → HTTP 400).

- Gated by the existing `ENROLL_LIVENESS_ENABLED` (default ON); injected via `get_enroll_multi_image_use_case()`.
- Skipped only when the use case is built without a checker (legacy / unit-test callers) — so existing tests stay green.

### 2. eMRTD NFC passive authentication — `POST /nfc/verify-authenticity`
New CPU-only endpoint implementing **ICAO 9303 Part 11 passive authentication** for NFC chip trust. Accepts the chip's `EF.SOD` + the Data Groups the client read, and verifies, **fail-closed**:
1. each provided DG hash matches the signed value in the SOD's `LDSSecurityObject`,
2. the SOD's CMS signature verifies against the embedded Document Signer (DS) cert,
3. the DS cert chains to a trusted **CSCA** root.

Returns an authoritative verdict: `{is_authentic, reason, reason_code, ds_subject, ds_serial, csca_matched, dg_hash_results, sod_hash_algorithm}`.

- Pure Python crypto (`asn1crypto` + `cryptography`) — no GPU, no ML. Domain logic in framework-free `app/domain/services/emrtd_passive_auth.py`.
- Consumed by identity-core-api `NfcDocumentAuthHandler` via `BiometricServicePort` (JSON contract coordinated with agent-api).
- **Operator deliverable:** CSCA trust store at `NFC_CSCA_TRUST_DIR` (default `app/core/csca_trust_store/`, see its README). Empty store ⇒ `reason_code=NO_TRUST_STORE` / `is_authentic=false`. Loaded at request time (mtime-keyed cache) so adding a cert needs no rebuild.

## Tests
- `tests/unit/application/use_cases/test_enroll_multi_image.py` — spoof-reject (fail-closed), first-frame short-circuit, all-live-accept, disabled-flag escape hatch (mocks the liveness verdict at the `CheckLivenessUseCase` boundary).
- `tests/unit/domain/services/test_emrtd_passive_auth.py` — self-signed CSCA/DS/SOD fixture: happy-path, DG-mismatch, bad-signature, untrusted-DS, empty-store (fail-closed), DG-not-in-SOD, unparseable-SOD, ECDSA-DS.
- `tests/unit/test_nfc_verify_authenticity_route.py` — route + base64/JSON contract + trust-store-from-disk.

Bare-host `tests/unit/` = 666 passed, 1 skipped, 1 xfailed (was 647; +19 new). Ruff CI command green, bandit clean on new files.

## Build
Adds `asn1crypto==1.5.1` (pure-Python ASN.1) to `requirements.txt` and the known-good lock. **Digest-pinned base + every existing pin unchanged** — the canonical reproducible build is honored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)