### PR TITLE
fix(search): threshold-anchored confidence so strong matches read honestly (FIX #12)

### DIFF
--- a/app/api/schemas/search.py
+++ b/app/api/schemas/search.py
@@ -9,15 +9,25 @@ class SearchMatchResponse(BaseModel):
     """Individual search match response."""
 
     user_id: str = Field(..., description="Matched user identifier")
-    distance: float = Field(..., ge=0, le=2, description="Cosine distance (0=identical)")
-    confidence: float = Field(..., ge=0, le=1, description="Match confidence (0-1)")
+    distance: float = Field(..., ge=0, le=2, description="Cosine distance (0=identical); raw engineering value")
+    confidence: float = Field(
+        ...,
+        ge=0,
+        le=1,
+        description=(
+            "Threshold-anchored match confidence (0-1): accept boundary ~0.5, "
+            "identical match ~1.0. Not the naive 1 - distance."
+        ),
+    )
 
     model_config = {
         "json_schema_extra": {
+            # confidence is threshold-anchored on the default 0.6 search threshold:
+            # 1 - distance / (2 * 0.6). distance 0.15 -> 0.875, 0.25 -> 0.7917.
             "example": {
                 "user_id": "user_123",
                 "distance": 0.15,
-                "confidence": 0.85,
+                "confidence": 0.875,
             }
         }
     }
@@ -39,18 +49,20 @@ class SearchResponse(BaseModel):
 
     model_config = {
         "json_schema_extra": {
+            # confidence is threshold-anchored: 1 - distance / (2 * threshold).
+            # With threshold 0.6: distance 0.15 -> 0.875, 0.25 -> 0.7917.
             "example": {
                 "found": True,
                 "matches": [
-                    {"user_id": "user_123", "distance": 0.15, "confidence": 0.85},
-                    {"user_id": "user_456", "distance": 0.25, "confidence": 0.75},
+                    {"user_id": "user_123", "distance": 0.15, "confidence": 0.875},
+                    {"user_id": "user_456", "distance": 0.25, "confidence": 0.7917},
                 ],
                 "total_searched": 100,
                 "threshold": 0.6,
                 "best_match": {
                     "user_id": "user_123",
                     "distance": 0.15,
-                    "confidence": 0.85,
+                    "confidence": 0.875,
                 },
                 "message": "Found 2 matches",
             }

--- a/app/application/use_cases/search_face.py
+++ b/app/application/use_cases/search_face.py
@@ -168,11 +168,19 @@ class SearchFaceUseCase:
             tenant_id=tenant_id,
         )
 
-        # Convert to SearchMatch objects with confidence scores
+        # Convert to SearchMatch objects with confidence scores.
+        #
+        # FIX #12 (2026-06-02): the reported confidence is THRESHOLD-ANCHORED, not
+        # the naive ``1 - distance``. pgvector cosine distance is in [0, 2] and the
+        # operational accept band sits in the low-distance region, so ``1 - distance``
+        # made a genuinely excellent match (e.g. distance 0.26) read a misleading
+        # ~74%, with the accept boundary itself at a scary ~40%. We anchor on the
+        # SAME threshold used for acceptance above so the accept boundary reads ~50%
+        # and an identical match ~100%. The accept/reject decision is unchanged, and
+        # the raw ``distance`` is kept verbatim in the response as the honest value.
         matches = []
         for user_id, distance in similar:
-            # Calculate confidence as inverse of distance (higher is better, 0-1 range)
-            confidence = max(0.0, min(1.0, 1 - distance))
+            confidence = self._similarity_calculator.get_confidence(distance, threshold)
             matches.append(
                 SearchMatch(
                     user_id=user_id,

--- a/app/application/use_cases/verify_face.py
+++ b/app/application/use_cases/verify_face.py
@@ -179,7 +179,11 @@ class VerifyFaceUseCase:
             logger.warning(f"Adaptive threshold lookup failed, using default: {_threshold_err}")
 
         verified = distance < threshold
-        confidence = self._similarity_calculator.get_confidence(distance)
+        # FIX #12 (2026-06-02): anchor the reported confidence on the SAME
+        # (possibly adaptive aged) threshold used for the verdict, so the accept
+        # boundary reads ~50% and an identical match ~100% instead of the
+        # misleading naive ``1 - distance``. Decision logic is unchanged.
+        confidence = self._similarity_calculator.get_confidence(distance, threshold)
 
         total_ms = (time.perf_counter() - t_start) * 1000
         timing_summary = " ".join(f"{k}={v:.0f}ms" for k, v in stage_ms.items())

--- a/app/application/use_cases/verify_face_cached.py
+++ b/app/application/use_cases/verify_face_cached.py
@@ -132,7 +132,10 @@ class VerifyFaceCachedUseCase:
         # Determine verification result
         effective_threshold = threshold or self._similarity_calculator.get_threshold()
         verified = distance < effective_threshold
-        confidence = self._similarity_calculator.get_confidence(distance)
+        # FIX #12 (2026-06-02): threshold-anchored confidence (see verify_face.py)
+        # so the accept boundary reads ~50% and an identical match ~100% instead
+        # of the misleading naive ``1 - distance``. Decision logic is unchanged.
+        confidence = self._similarity_calculator.get_confidence(distance, effective_threshold)
 
         result = VerificationResult(
             verified=verified,

--- a/app/infrastructure/ml/similarity/cosine_similarity.py
+++ b/app/infrastructure/ml/similarity/cosine_similarity.py
@@ -1,6 +1,7 @@
 """Cosine similarity calculator implementation."""
 
 import logging
+from typing import Optional
 
 import numpy as np
 
@@ -132,17 +133,43 @@ class CosineSimilarityCalculator:
         distance = self.calculate(embedding1, embedding2)
         return distance < self._threshold
 
-    def get_confidence(self, distance: float) -> float:
-        """Convert distance to confidence score (0.0-1.0).
+    def get_confidence(self, distance: float, threshold: Optional[float] = None) -> float:
+        """Convert distance to a threshold-anchored confidence score (0.0-1.0).
+
+        The naive ``1 - distance`` mapping under-reports strong matches because
+        the operational accept band lives in the low-distance region: with the
+        default 0.6 threshold an *excellent* match at distance 0.26 would read a
+        scary 74%, and the accept boundary itself reads only ~40%. The matching
+        decision is unchanged — only the reported number was misleading.
+
+        This maps the accept boundary to ~50% and an identical match to 100%,
+        anchored on the SAME threshold used for the accept/reject decision::
+
+            confidence = clamp01(1 - distance / (2 * threshold))
+
+        - distance = 0          -> 1.0  (identical)
+        - distance = threshold  -> 0.5  (accept boundary)
+        - distance > threshold  -> < 0.5 (rejected region)
 
         Args:
-            distance: Cosine distance (0.0-1.0)
+            distance: Cosine distance (>= 0.0; pgvector cosine distance is [0, 2])
+            threshold: Accept/reject distance threshold to anchor on. Defaults to
+                this calculator's configured threshold. Pass the *effective*
+                threshold the caller used for the decision (e.g. the adaptive
+                aged-embedding threshold) so the reported % stays consistent with
+                the verdict.
 
         Returns:
             Confidence score (0.0-1.0), higher = more confident
         """
-        # Confidence is inverse of distance
-        return 1.0 - distance
+        anchor = self._threshold if threshold is None else threshold
+        # Guard against a zero/negative anchor producing a div-by-zero / inverted
+        # scale; fall back to the legacy inverse mapping in that pathological case.
+        if anchor <= 0.0:
+            confidence = 1.0 - distance
+        else:
+            confidence = 1.0 - distance / (2.0 * anchor)
+        return max(0.0, min(1.0, confidence))
 
     @staticmethod
     def _l2_normalize(embedding: np.ndarray) -> np.ndarray:

--- a/tests/unit/infrastructure/test_similarity_calculator.py
+++ b/tests/unit/infrastructure/test_similarity_calculator.py
@@ -124,15 +124,40 @@ class TestCosineSimilarityCalculator:
         assert is_match is False
 
     def test_get_confidence(self):
-        """Test converting distance to confidence."""
-        calculator = CosineSimilarityCalculator()
+        """Test threshold-anchored distance -> confidence mapping (FIX #12).
 
-        # Low distance = high confidence
-        assert calculator.get_confidence(0.1) == 0.9
-        assert calculator.get_confidence(0.3) == 0.7
-        assert calculator.get_confidence(0.5) == 0.5
+        Confidence is ``clamp01(1 - distance / (2 * threshold))`` so the accept
+        boundary (distance == threshold) reads ~0.5 and an identical match reads
+        1.0, instead of the misleading naive ``1 - distance``.
+        """
+        calculator = CosineSimilarityCalculator()  # default threshold 0.6
+
+        # Identical match -> full confidence
         assert calculator.get_confidence(0.0) == 1.0
-        assert calculator.get_confidence(1.0) == 0.0
+        # Low distance -> high confidence, but anchored on the 0.6 threshold
+        assert calculator.get_confidence(0.1) == pytest.approx(1 - 0.1 / 1.2)  # ~0.9167
+        assert calculator.get_confidence(0.3) == pytest.approx(1 - 0.3 / 1.2)  # 0.75
+        assert calculator.get_confidence(0.5) == pytest.approx(1 - 0.5 / 1.2)  # ~0.5833
+        # Accept boundary (distance == threshold) -> ~0.5
+        assert calculator.get_confidence(0.6) == pytest.approx(0.5)
+        # At / beyond 2*threshold -> clamped to 0.0
+        assert calculator.get_confidence(1.2) == 0.0
+        assert calculator.get_confidence(2.0) == 0.0
+
+    def test_get_confidence_explicit_threshold_anchor(self):
+        """An explicit threshold overrides the calculator's default anchor.
+
+        The verify path passes its effective (possibly adaptive aged) threshold
+        so the reported % stays consistent with the verdict.
+        """
+        calculator = CosineSimilarityCalculator()  # default threshold 0.6
+
+        # 1:1 verify-style threshold 0.4: boundary maps to 0.5
+        assert calculator.get_confidence(0.4, threshold=0.4) == pytest.approx(0.5)
+        assert calculator.get_confidence(0.2, threshold=0.4) == pytest.approx(0.75)
+        assert calculator.get_confidence(0.0, threshold=0.4) == 1.0
+        # Pathological non-positive anchor falls back to legacy inverse, clamped
+        assert calculator.get_confidence(0.3, threshold=0.0) == pytest.approx(0.7)
 
     def test_l2_normalize_unit_vector(self):
         """Test L2 normalization produces unit vectors."""


### PR DESCRIPTION
## Problem (FIX #12)

Face Search confidence **under-reported a strong match**. The reported confidence was the naive `confidence = max(0.0, min(1.0, 1 - distance))`, where `distance` is pgvector **cosine distance** (`1 - cosine_similarity`), range `[0, 2]`. Because the operational accept band lives in the low-distance region, this mapping was misleading:

- A genuinely **excellent** match at `distance = 0.2595` showed only **74.1%**.
- The accept boundary (default search threshold `0.6` in `cosine_similarity.py`, also documented in `search.py`) mapped to a **scary ~40%**.

The matching decision was always **correct** — only the displayed percentage was wrong.

## Fix

Threshold-anchored confidence using the **same threshold the search/verify uses for acceptance** (read from code, not hardcoded):

```
confidence = clamp01(1 - distance / (2 * threshold))
```

| distance | meaning | confidence |
|---|---|---|
| `0` | identical | `1.00` |
| `threshold` | accept boundary | `0.50` |
| `> threshold` | rejected region | `< 0.50` |

Sample mappings (search default threshold `0.6`): `d=0.0 → 100.00%`, `d=0.2595 → 78.38%` (was 74.05%), `d=0.4 → 66.67%` (was 60%), `d=0.6 → 50.00%` (was 40%).

Single source of truth lives in `CosineSimilarityCalculator.get_confidence(distance, threshold=None)`; it defaults to the calculator's configured threshold, guards a non-positive anchor (legacy inverse fallback), and clamps to `[0, 1]`.

## Scope

- **`app/infrastructure/ml/similarity/cosine_similarity.py`** — `get_confidence` now takes an optional `threshold` anchor and applies the new formula.
- **`app/application/use_cases/search_face.py`** (~L175) — reports `get_confidence(distance, threshold)` with the search's effective threshold. Raw `distance` kept verbatim as the honest engineering value.
- **`app/application/use_cases/verify_face.py`** & **`verify_face_cached.py`** — verify confidence used the identical naive style **in this repo** (via `get_confidence`); both now pass their effective (incl. adaptive aged) threshold so the reported % matches the verdict. (Web-side `BiometricService.ts` is out of scope.)
- **`app/api/schemas/search.py`** — refreshed baked OpenAPI example confidences (`d=0.15 → 0.875`, `d=0.25 → 0.7917`) and clarified field descriptions.
- **`tests/unit/infrastructure/test_similarity_calculator.py`** — updated `test_get_confidence` to the new formula + added an explicit-threshold-anchor case.

**Accept/reject threshold logic is unchanged** — only the reported confidence number moves.

## Tests

Ran locally (Python 3.12, pytest 9.0.2):

- `test_similarity_calculator.py` — **19 passed** (incl. 2 new cases)
- `test_search_face.py` — **3 passed**
- `test_use_cases.py` (verify) — **22 passed**
- `test_new_use_cases.py` (verify_face_cached) — **19 passed**
- Combined affected unit modules — **149 passed**

`tests/integration/test_api_routes.py` could not be collected due to a **pre-existing** missing dependency (`asn1crypto`, an NFC/eID cert module) unrelated to this change; the updated Pydantic schema examples were validated directly against their models instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)