### PR TITLE
fix(voice+emrtd): normalize voice centroid at verify (P1-10) + eMRTD cert validity (BIO-M2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,15 @@ the gated files run.
   CPU-only.
 - **Voice**: enroll, verify, search, delete — Resemblyzer 256-dim speaker embeddings, centroid-based
 - Routes: `voice.py`, repo: `pgvector_voice_repository.py`, embedder: `speaker_embedder.py`
+- **Voice verify centroid normalization (P1-10, 2026-06-02)**: the default enroll
+  path stores the centroid as `AVG(embedding)::vector` (the mean of unit-norm
+  embeddings has norm < 1 and shrinks as enrollments accumulate). `/voice/verify`
+  now L2-normalizes BOTH the probe and the stored centroid before the dot product
+  so `confidence` is a true cosine similarity, invariant to enrollment count
+  (previously decayed ≈0.71 @2 → ≈0.47 @5 and false-rejected genuine users). The
+  accept threshold is UNCHANGED (verify ≥ 0.65). The `optimize=True` re-enroll
+  fusion path already L2-normalizes its centroid, and `/voice/search` uses
+  pgvector `<=>` cosine distance (norm-invariant) — both unaffected.
 - **Fingerprint**: removed (P1.4) — server-side fingerprint biometric processing was a SHA-256 hash placeholder, never a real biometric. Platform fingerprint authentication is delivered via WebAuthn (FIDO2) in identity-core-api, not through this service.
 
 ### Verification Pipeline (Phase 8B/8C, 2026-03-28):
@@ -213,7 +222,10 @@ the gated files run.
   authentication** (eMRTD chip trust). Accepts `{sod_b64, data_groups:{"<dg#>":b64}}`
   and verifies, fail-CLOSED: (a) each provided DG hash matches the signed value
   in EF.SOD's `LDSSecurityObject`, (b) the SOD's CMS signature verifies under the
-  embedded Document Signer cert, (c) DS chains to a trusted CSCA root. Returns
+  embedded Document Signer cert, (b2, BIO-M2 2026-06-02) the DS cert AND the CSCA
+  root it chains to are each within their `[not_valid_before, not_valid_after]`
+  validity window (an expired/not-yet-valid DS → `reason_code=DS_CERT_EXPIRED`; an
+  expired CSCA anchor → `CSCA_CERT_EXPIRED`), (c) DS chains to a trusted CSCA root. Returns
   `{is_authentic, reason, reason_code, ds_subject, ds_serial, csca_matched,
   dg_hash_results, sod_hash_algorithm}`. Pure Python crypto (`asn1crypto` +
   `cryptography`) — **no GPU, no ML**. Logic lives in the framework-free domain

--- a/app/api/routes/voice.py
+++ b/app/api/routes/voice.py
@@ -37,6 +37,27 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Voice"])
 
+
+def _l2_normalize(vec: np.ndarray) -> np.ndarray:
+    """Return ``vec`` scaled to unit L2 norm (zero-norm vectors pass through).
+
+    P1-10: the default enroll path persists the centroid as ``AVG(embedding)``
+    (see ``PgVectorVoiceRepository.save``). Averaging unit-norm speaker
+    embeddings yields a vector whose norm is **< 1** and shrinks as more
+    (slightly divergent) enrollments are accumulated. A raw ``np.dot`` against
+    such a centroid is therefore NOT a cosine similarity — it under-reports
+    proportionally to ``||centroid||``, so genuine users get false-rejected as
+    their enrollment count grows (≈0.71 @2 → ≈0.47 @5 enrollments). Normalising
+    both operands to unit length before the dot product makes the result a true
+    cosine similarity that is invariant to the number of enrollments, without
+    touching the accept threshold.
+    """
+    norm = float(np.linalg.norm(vec))
+    if norm == 0.0:
+        return vec
+    return vec / norm
+
+
 # -- Request / Response schemas ------------------------------------------------
 
 
@@ -230,8 +251,15 @@ async def verify_voice(request: VoiceRequest) -> BiometricResponse:
                 confidence=0.0,
             )
 
-        # Cosine similarity (both vectors are already L2-normalized)
-        similarity = float(np.dot(probe_embedding, enrolled_embedding))
+        # Cosine similarity. P1-10: the stored centroid (default enroll path) is
+        # AVG(embedding) and is NOT unit-norm, so a raw dot product decays with
+        # enrollment count. L2-normalize BOTH operands here so the result is a
+        # true cosine similarity regardless of how many samples were enrolled.
+        # (The probe is already unit-norm from the embedder; normalizing it too
+        # is a harmless no-op and keeps the path robust to any future change.)
+        unit_probe = _l2_normalize(probe_embedding)
+        unit_centroid = _l2_normalize(enrolled_embedding)
+        similarity = float(np.dot(unit_probe, unit_centroid))
         # Clamp to [0, 1]
         similarity = max(0.0, min(1.0, similarity))
 

--- a/app/domain/services/emrtd_passive_auth.py
+++ b/app/domain/services/emrtd_passive_auth.py
@@ -29,6 +29,7 @@ primitives). Both are CPU-only and already part of the pinned requirements.
 
 from __future__ import annotations
 
+import datetime
 import hashlib
 import logging
 from dataclasses import dataclass, field
@@ -122,6 +123,12 @@ class ReasonCode(str, Enum):
     NO_TRUST_STORE = "NO_TRUST_STORE"
     MISSING_DG = "MISSING_DG"
     UNSUPPORTED_ALGORITHM = "UNSUPPORTED_ALGORITHM"
+    # ICAO 9303 Part 12 §7: a Document Signer / CSCA certificate may only be
+    # relied upon inside its validity window. An expired (or not-yet-valid) DS
+    # or CSCA cert means the chip's trust assertion can no longer be relied
+    # upon, even if the CMS signature itself still verifies cryptographically.
+    DS_CERT_EXPIRED = "DS_CERT_EXPIRED"
+    CSCA_CERT_EXPIRED = "CSCA_CERT_EXPIRED"
 
 
 @dataclass
@@ -271,6 +278,26 @@ class EmrtdPassiveAuthService:
                 dg_hash_results=dg_hash_results,
             )
 
+        # --- (b2) DS certificate validity period --------------------------
+        # ICAO 9303 Part 12: a Document Signer cert must be relied upon only
+        # within its [not_valid_before, not_valid_after] window. A cryptograph-
+        # ically valid signature from an EXPIRED DS cert must NOT yield
+        # is_authentic=true (fail-closed).
+        now = self._now()
+        if not _cert_within_validity(ds_cert, now):
+            return PassiveAuthResult(
+                is_authentic=False,
+                reason=(
+                    "Document Signer certificate is outside its validity period "
+                    f"({_validity_window_str(ds_cert)})."
+                ),
+                reason_code=ReasonCode.DS_CERT_EXPIRED,
+                ds_subject=ds_subject,
+                ds_serial=ds_serial,
+                sod_hash_algorithm=sod_hash_algorithm,
+                dg_hash_results=dg_hash_results,
+            )
+
         # --- (c) DS -> CSCA chain -----------------------------------------
         if not self._csca_certs:
             # No trust anchors configured → we cannot assert authenticity.
@@ -283,12 +310,28 @@ class EmrtdPassiveAuthService:
                 sod_hash_algorithm=sod_hash_algorithm,
                 dg_hash_results=dg_hash_results,
             )
-        csca_matched = self._ds_chains_to_csca(ds_cert)
-        if not csca_matched:
+        matched_csca = self._ds_chains_to_csca(ds_cert)
+        if matched_csca is None:
             return PassiveAuthResult(
                 is_authentic=False,
                 reason="Document Signer certificate does not chain to any trusted CSCA root.",
                 reason_code=ReasonCode.DS_UNTRUSTED,
+                ds_subject=ds_subject,
+                ds_serial=ds_serial,
+                sod_hash_algorithm=sod_hash_algorithm,
+                dg_hash_results=dg_hash_results,
+            )
+
+        # The trusted root the DS chains to must itself be in-validity. An
+        # expired CSCA anchor can no longer vouch for the document signer.
+        if not _cert_within_validity(matched_csca, now):
+            return PassiveAuthResult(
+                is_authentic=False,
+                reason=(
+                    "The CSCA root the Document Signer chains to is outside its "
+                    f"validity period ({_validity_window_str(matched_csca)})."
+                ),
+                reason_code=ReasonCode.CSCA_CERT_EXPIRED,
                 ds_subject=ds_subject,
                 ds_serial=ds_serial,
                 sod_hash_algorithm=sod_hash_algorithm,
@@ -437,20 +480,29 @@ class EmrtdPassiveAuthService:
         except InvalidSignature:
             return False
 
-    def _ds_chains_to_csca(self, ds_cert: CryptoCertificate) -> bool:
-        """True if the DS cert's signature verifies under a trusted CSCA key.
+    @staticmethod
+    def _now() -> datetime.datetime:
+        """Current UTC instant (timezone-aware); seam for deterministic tests."""
+        return datetime.datetime.now(datetime.timezone.utc)
+
+    def _ds_chains_to_csca(
+        self, ds_cert: CryptoCertificate
+    ) -> Optional[CryptoCertificate]:
+        """Return the trusted CSCA the DS cert chains to, else ``None``.
 
         eMRTD chains are short (DS signed directly by a CSCA root), so a direct
         issuer-match + signature check is sufficient and avoids pulling in a
         full path-validation engine. We match candidate CSCAs by subject==issuer
-        then cryptographically verify the DS signature under the CSCA key.
+        then cryptographically verify the DS signature under the CSCA key. The
+        matched anchor is RETURNED (not just a bool) so the caller can in turn
+        enforce the CSCA's own validity period.
         """
         for csca in self._csca_certs:
             if csca.subject != ds_cert.issuer:
                 continue
             if _cert_signed_by(ds_cert, csca):
-                return True
-        return False
+                return csca
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -462,6 +514,36 @@ def _constant_time_eq(a: bytes, b: bytes) -> bool:
     import hmac
 
     return hmac.compare_digest(a, b)
+
+
+def _cert_bounds(
+    cert: CryptoCertificate,
+) -> tuple[datetime.datetime, datetime.datetime]:
+    """Return the cert's (not_before, not_after) as timezone-aware UTC datetimes.
+
+    Prefers the timezone-aware ``*_utc`` accessors (cryptography >= 42); falls
+    back to the deprecated naive ones (assumed UTC, per X.509) on older builds.
+    """
+    try:
+        not_before = cert.not_valid_before_utc
+        not_after = cert.not_valid_after_utc
+    except AttributeError:  # pragma: no cover - legacy cryptography
+        not_before = cert.not_valid_before.replace(tzinfo=datetime.timezone.utc)
+        not_after = cert.not_valid_after.replace(tzinfo=datetime.timezone.utc)
+    return not_before, not_after
+
+
+def _cert_within_validity(cert: CryptoCertificate, now: datetime.datetime) -> bool:
+    """True iff ``now`` is within the cert's [not_before, not_after] window."""
+    not_before, not_after = _cert_bounds(cert)
+    return not_before <= now <= not_after
+
+
+def _validity_window_str(cert: CryptoCertificate) -> str:
+    not_before, not_after = _cert_bounds(cert)
+    return (
+        f"not_before={not_before.isoformat()}, not_after={not_after.isoformat()}"
+    )
 
 
 def _as_octet_bytes(value) -> bytes:

--- a/tests/unit/api/test_voice_routes.py
+++ b/tests/unit/api/test_voice_routes.py
@@ -92,6 +92,18 @@ def _unit_embedding(seed: int = 0) -> np.ndarray:
     return v / np.linalg.norm(v)
 
 
+def _avg_centroid(*seeds: int) -> np.ndarray:
+    """A centroid the way the default enroll path builds it: AVG of unit vectors.
+
+    The mean of several unit-norm speaker embeddings has norm < 1 and shrinks as
+    the samples diverge — exactly the non-normalized centroid the repository
+    persists via ``AVG(embedding)::vector``. Used to reproduce the P1-10
+    confidence-decay regression.
+    """
+    vecs = [_unit_embedding(s) for s in seeds]
+    return np.mean(vecs, axis=0).astype(np.float32)
+
+
 # ---------------------------------------------------------------------------
 # F10 — voice search is tenant-scoped
 # ---------------------------------------------------------------------------
@@ -246,3 +258,111 @@ async def test_search_voice_invokes_replay_detector_when_enabled():
     detector.check_and_record.assert_awaited_once()
     _, kwargs = detector.check_and_record.await_args
     assert kwargs.get("tenant_id") == "tenant-z"
+
+
+# ---------------------------------------------------------------------------
+# P1-10 — voice verify confidence must be a true cosine similarity, invariant
+# to the (non-normalized) stored centroid's norm.
+# ---------------------------------------------------------------------------
+
+
+def _direct_dot(a: np.ndarray, b: np.ndarray) -> float:
+    """The OLD verify behavior: raw dot product, no centroid normalization."""
+    return max(0.0, min(1.0, float(np.dot(a, b))))
+
+
+async def _run_verify(probe: np.ndarray, centroid: np.ndarray) -> "voice_routes.BiometricResponse":
+    """Drive verify_voice with a fixed probe + stored centroid (replay off)."""
+    repo = Mock()
+    repo.find_by_user_id = AsyncMock(return_value=centroid)
+    detector = Mock()
+    detector.enabled = False
+    with patch.object(voice_routes, "_extract_voice_embedding",
+                      AsyncMock(return_value=probe)), \
+         patch.object(voice_routes, "get_voice_repository", return_value=repo), \
+         patch.object(voice_routes, "get_voice_replay_detector", return_value=detector):
+        req = voice_routes.VoiceRequest(user_id="u", voice_data="ZmFrZQ==")
+        return await voice_routes.verify_voice(req)
+
+
+@pytest.mark.asyncio
+async def test_verify_confidence_is_true_cosine_not_raw_dot():
+    """Confidence must be the cosine of probe·centroid_direction, not the raw dot.
+
+    The default enroll path stores ``AVG(embedding)`` whose norm is < 1, so a
+    raw ``np.dot(probe, centroid)`` under-reports by exactly ``||centroid||``.
+    After the P1-10 fix the centroid is L2-normalized at verify time, so the
+    reported confidence equals the genuine cosine similarity and is strictly
+    HIGHER than the old raw-dot value whenever the centroid was not unit-norm.
+    """
+    probe = _unit_embedding(0)
+    # AVG of unit vectors → norm < 1 (the exact shape the repository persists).
+    centroid = _avg_centroid(0, 1, 2)
+    centroid_norm = float(np.linalg.norm(centroid))
+    assert centroid_norm < 1.0  # precondition: this is the decaying-norm case
+
+    res = await _run_verify(probe, centroid)
+
+    true_cosine = max(0.0, min(1.0, float(np.dot(probe, centroid / centroid_norm))))
+    old_raw_dot = _direct_dot(probe, centroid)
+
+    # Fixed path reports the true cosine ...
+    assert res.confidence == pytest.approx(true_cosine, abs=1e-3)
+    # ... which is strictly higher than the buggy raw-dot value.
+    assert res.confidence > old_raw_dot
+    # The raw dot equals cosine * norm, so the gap is the norm shortfall.
+    assert old_raw_dot == pytest.approx(true_cosine * centroid_norm, abs=1e-3)
+
+
+@pytest.mark.asyncio
+async def test_verify_confidence_invariant_to_centroid_magnitude():
+    """Confidence depends only on the centroid DIRECTION, not its magnitude.
+
+    Models the decay driver directly: the SAME centroid direction stored at two
+    different magnitudes (||c||=0.9 "2 enrollments" vs ||c||=0.45 "5 divergent
+    enrollments"). Under the old raw dot the reported confidence halved with the
+    norm; after the fix it is identical for both because the centroid is
+    normalized before the cosine.
+    """
+    probe = _unit_embedding(0)
+    direction = _avg_centroid(0, 1)  # an arbitrary, fixed, sub-unit direction
+    direction = (direction / np.linalg.norm(direction)).astype(np.float32)
+
+    centroid_big = (direction * 0.90).astype(np.float32)   # ~2 enrollments
+    centroid_small = (direction * 0.45).astype(np.float32)  # ~5 enrollments
+
+    conf_big = (await _run_verify(probe, centroid_big)).confidence
+    conf_small = (await _run_verify(probe, centroid_small)).confidence
+
+    true_cosine = max(0.0, min(1.0, float(np.dot(probe, direction))))
+
+    # Fixed: both report the same true cosine regardless of stored magnitude.
+    assert conf_big == pytest.approx(true_cosine, abs=1e-3)
+    assert conf_small == pytest.approx(true_cosine, abs=1e-3)
+    assert conf_big == pytest.approx(conf_small, abs=1e-3)
+
+    # The OLD raw dot would have decayed in lockstep with the shrinking norm.
+    assert _direct_dot(probe, centroid_small) < _direct_dot(probe, centroid_big)
+
+
+@pytest.mark.asyncio
+async def test_verify_genuine_user_not_false_rejected_for_subunit_centroid():
+    """A perfect-direction match with a sub-0.65 norm must still verify.
+
+    Construct the exact false-reject the bug produces: the centroid points in
+    the SAME direction as the probe (true cosine = 1.0) but its stored norm is
+    0.60 — so the old ``np.dot`` returns 0.60 < 0.65 and FALSE-REJECTS a genuine
+    user. The fix normalizes the centroid first → confidence 1.0, verified.
+    """
+    probe = _unit_embedding(3)
+    centroid = (probe * 0.60).astype(np.float32)  # same direction, norm 0.60
+
+    # Precondition: the OLD path would false-reject (raw dot 0.60 < 0.65).
+    assert _direct_dot(probe, centroid) == pytest.approx(0.60, abs=1e-3)
+    assert _direct_dot(probe, centroid) < 0.65
+
+    res = await _run_verify(probe, centroid)
+
+    assert res.confidence == pytest.approx(1.0, abs=1e-3)
+    assert res.confidence >= 0.65
+    assert res.verified is True

--- a/tests/unit/domain/services/test_emrtd_passive_auth.py
+++ b/tests/unit/domain/services/test_emrtd_passive_auth.py
@@ -41,8 +41,20 @@ from app.domain.services.emrtd_passive_auth import (
 # ---------------------------------------------------------------------------
 
 
-def _make_cert(subject_cn, issuer_cn, issuer_key, subject_pub, is_ca, sign_hash=None):
+def _make_cert(
+    subject_cn,
+    issuer_cn,
+    issuer_key,
+    subject_pub,
+    is_ca,
+    sign_hash=None,
+    *,
+    not_before=None,
+    not_after=None,
+):
     sign_hash = sign_hash or hashes.SHA256()
+    not_before = not_before or datetime.datetime(2020, 1, 1)
+    not_after = not_after or datetime.datetime(2035, 1, 1)
     subject = x509.Name(
         [
             x509.NameAttribute(NameOID.COMMON_NAME, subject_cn),
@@ -61,8 +73,8 @@ def _make_cert(subject_cn, issuer_cn, issuer_key, subject_pub, is_ca, sign_hash=
         .issuer_name(issuer)
         .public_key(subject_pub)
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.datetime(2020, 1, 1))
-        .not_valid_after(datetime.datetime(2035, 1, 1))
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
     )
     if is_ca:
         builder = builder.add_extension(
@@ -309,3 +321,97 @@ class TestEmrtdPassiveAuth:
         result = svc.verify(sod_der=sod_der, data_groups=data_groups)
         assert result.is_authentic is True
         assert result.reason_code == ReasonCode.OK
+
+    def test_expired_document_signer_rejects(self):
+        """BIO-M2: an EXPIRED DS cert must NOT yield is_authentic=true.
+
+        The SOD signature still verifies cryptographically (the key is fine),
+        but the Document Signer cert is past its not_after, so passive auth must
+        fail-closed with DS_CERT_EXPIRED rather than trusting the document.
+        """
+        csca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        ds_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        csca_cert = _make_cert(
+            "Expiry CSCA", "Expiry CSCA", csca_key, csca_key.public_key(), True
+        )
+        # DS cert that expired in the past (valid 2010-01-01 .. 2012-01-01).
+        ds_cert = _make_cert(
+            "Expired Document Signer",
+            "Expiry CSCA",
+            csca_key,
+            ds_key.public_key(),
+            False,
+            not_before=datetime.datetime(2010, 1, 1),
+            not_after=datetime.datetime(2012, 1, 1),
+        )
+        data_groups = {1: b"\x61\x08DG1-EXP!"}
+        lds_der = _build_lds(data_groups)
+        sod_der = _build_sod(lds_der, ds_cert, ds_key)
+
+        svc = EmrtdPassiveAuthService(csca_certificates=[csca_cert])
+        result = svc.verify(sod_der=sod_der, data_groups=data_groups)
+        assert result.is_authentic is False
+        assert result.reason_code == ReasonCode.DS_CERT_EXPIRED
+        # DG integrity + signature were fine; only the validity window failed.
+        assert result.dg_hash_results == {"1": True}
+
+    def test_not_yet_valid_document_signer_rejects(self):
+        """A DS cert whose not_before is in the FUTURE is also rejected."""
+        csca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        ds_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        csca_cert = _make_cert(
+            "Future CSCA", "Future CSCA", csca_key, csca_key.public_key(), True
+        )
+        ds_cert = _make_cert(
+            "Future Document Signer",
+            "Future CSCA",
+            csca_key,
+            ds_key.public_key(),
+            False,
+            not_before=datetime.datetime(2099, 1, 1),
+            not_after=datetime.datetime(2100, 1, 1),
+        )
+        data_groups = {1: b"\x61\x08DG1-FUT!"}
+        lds_der = _build_lds(data_groups)
+        sod_der = _build_sod(lds_der, ds_cert, ds_key)
+
+        svc = EmrtdPassiveAuthService(csca_certificates=[csca_cert])
+        result = svc.verify(sod_der=sod_der, data_groups=data_groups)
+        assert result.is_authentic is False
+        assert result.reason_code == ReasonCode.DS_CERT_EXPIRED
+
+    def test_expired_csca_root_rejects(self):
+        """An in-validity DS that chains to an EXPIRED CSCA root is rejected.
+
+        The DS is current and its signature verifies, but the trusted anchor it
+        chains to is itself past its validity window, so it can no longer vouch
+        for the signer → CSCA_CERT_EXPIRED (fail-closed).
+        """
+        csca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        ds_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        # Expired CSCA root (valid 2000-01-01 .. 2005-01-01).
+        csca_cert = _make_cert(
+            "Old CSCA",
+            "Old CSCA",
+            csca_key,
+            csca_key.public_key(),
+            True,
+            not_before=datetime.datetime(2000, 1, 1),
+            not_after=datetime.datetime(2005, 1, 1),
+        )
+        # Current DS cert (defaults to 2020 .. 2035).
+        ds_cert = _make_cert(
+            "Current Document Signer",
+            "Old CSCA",
+            csca_key,
+            ds_key.public_key(),
+            False,
+        )
+        data_groups = {1: b"\x61\x08DG1-CSC!"}
+        lds_der = _build_lds(data_groups)
+        sod_der = _build_sod(lds_der, ds_cert, ds_key)
+
+        svc = EmrtdPassiveAuthService(csca_certificates=[csca_cert])
+        result = svc.verify(sod_der=sod_der, data_groups=data_groups)
+        assert result.is_authentic is False
+        assert result.reason_code == ReasonCode.CSCA_CERT_EXPIRED


### PR DESCRIPTION
Fixes two verified-open bugs in the biometric-processor (evidence: `OPEN_TASKS_RECONCILIATION_2026-06-02.md` §B2). Conservative, demo-path-safe. **Does NOT touch the `/verify` liveness floor / `VERIFY_MIN_LIVENESS_SCORE` (BIO-M1).**

## P1-10 — voice verify false-rejects as enrollments grow (demo-relevant)

`/voice/verify` computed `float(np.dot(probe_embedding, enrolled_embedding))` and treated it as a cosine similarity (`app/api/routes/voice.py:234`, old). But the **default** enroll path stores the centroid as `AVG(embedding)::vector(dim)` (`app/infrastructure/persistence/repositories/pgvector_voice_repository.py:178`). The mean of unit-norm Resemblyzer embeddings has norm **< 1** and shrinks as more (slightly divergent) samples accumulate, so the raw dot under-reports by exactly `||centroid||` — confidence decayed ≈0.71 @2 → ≈0.47 @5 enrollments and **false-rejected genuine users**.

**Fix:** L2-normalize BOTH the probe and the stored centroid before the dot product so `confidence` is a true cosine similarity, invariant to enrollment count. The accept threshold is **UNCHANGED** (verify ≥ 0.65).

- The opt-in `optimize=True` re-enroll fusion path already L2-normalizes its centroid (`EmbeddingFusionService(normalization_strategy="l2")`, `pgvector_voice_repository.py:55,98-101`) → unchanged (re-normalizing a unit vector is a no-op).
- `/voice/search` uses pgvector `<=>` cosine **distance** (norm-invariant) → unaffected.

## BIO-M2 — eMRTD passive auth ignored cert validity period (eID track, low-risk)

`EmrtdPassiveAuthService.verify()` never checked DS/CSCA `not_valid_before`/`not_valid_after` (grep `not_valid` = 0 before this PR), so a cryptographically-valid signature from an **expired** Document Signer cert still returned `is_authentic=true`.

**Fix (fail-closed, preserving the existing structure):**
- After the SOD signature passes, gate on the DS cert's validity window → `is_authentic=false`, `reason_code=DS_CERT_EXPIRED` when outside `[not_valid_before, not_valid_after]` (also catches not-yet-valid).
- In the chain step, the matched CSCA root must itself be in-validity → `CSCA_CERT_EXPIRED`. `_ds_chains_to_csca` now returns the matched anchor (or `None`) so its validity can be enforced.
- Uses the timezone-aware `*_utc` cert accessors (cryptography ≥ 42) with a naive-UTC fallback. New reason codes are added to the `ReasonCode` enum and flow through `to_dict()`/the NFC route as before.

## Tests (all run, all green)

| Module | Result |
|--------|--------|
| `tests/unit/api/test_voice_routes.py` | **9 passed** (6 existing + 3 new P1-10 regression) |
| `tests/unit/domain/services/test_emrtd_passive_auth.py` | **12 passed** (9 existing + 3 new: expired DS, not-yet-valid DS, expired CSCA) |
| `tests/unit/test_nfc_verify_authenticity_route.py` | **6 passed** (consumer of the eMRTD service, unbroken) |

Voice tests ran on host (numpy); eMRTD + NFC tests ran inside the `biometric-processor-biometric-api` image (needs `asn1crypto`). `ruff check` clean on all four files.

## Risks
- Voice change is a pure scaling correction; existing tests that used unit-norm fixtures stay green. Only effect on real traffic is genuine voiceprints with many enrollments now scoring higher (closer to true cosine) — i.e. fewer false rejects. Threshold untouched.
- eMRTD change only adds reject paths to a dormant eID flow (empty CSCA trust store already returns NO_TRUST_STORE in prod), so no behavior change for current callers; it tightens trust correctly when a store is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)