### PR TITLE
fix(face): add libgles2 + libegl1 so MediaPipe FaceLandmarker loads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxrender-dev \
     libgomp1 \
     libgl1 \
+    libgles2 \
+    libegl1 \
     curl \
     ffmpeg \
     gcc \


### PR DESCRIPTION
Prod bio container had `libgl1` but not `libGLESv2.so.2`/`libEGL.so.1` that MediaPipe FaceLandmarker dlopen()s → every `/verify` logged `OSError: libGLESv2.so.2: cannot open shared object file` → `Failed to create FaceLandmarker` → no landmarks → liveness score stuck ~58 < 70 → **face verification rejected for all clients**, with ~27s detection on the fallback path. Added both libs to the runtime apt layer (reproducible — deps lock-pinned). **Deployed + verified on prod: container healthy, `ldconfig` shows libGLESv2.so.2 present.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)