### PR TITLE
fix(enroll): multi-image quality-floor alignment + per-frame skip (fix #7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,21 @@ the gated files run.
   Same `ENROLL_LIVENESS_ENABLED` flag (default `True`); when the use case is
   built without a checker (legacy/unit-test callers) the gate is skipped.
   CPU-only.
+- **Multi-image enroll quality-floor + per-frame skip (fix #7, 2026-06-03)**:
+  two related hardenings in `enroll_multi_image.py` / `config.py`. (1) The
+  per-frame quality floor `MULTI_IMAGE_MIN_QUALITY_PER_IMAGE` default dropped
+  **60.0 → 40.0** to match the single-image `QUALITY_THRESHOLD` (=40 in prod),
+  removing the asymmetry where a 40-59-scoring frame passed single `/enroll`
+  but was rejected per-frame on `/enroll/multi` (env-overridable). (2) A frame
+  that fails ONLY the per-frame **quality** gate (`PoorImageQualityError`, or
+  defensively `FaceNotDetectedError`) is now **skipped** — logged, not fused —
+  and the loop continues toward `MULTI_IMAGE_MIN_IMAGES`; one weak photo no
+  longer aborts the whole batch. If too many frames are skipped to reach the
+  minimum, `InsufficientImagesError` is raised (HTTP-mapped) so the user is
+  told to retry. **Security preserved**: liveness (`LivenessCheckFailedError`)
+  and anti-spoof (`SpoofDetectedError`) failures, ML timeouts, MultipleFaces,
+  and any unexpected error stay **FATAL** (abort fail-closed) — only
+  quality-class failures are skippable (see `_SKIPPABLE_FRAME_ERRORS`).
 - **Voice**: enroll, verify, search, delete — Resemblyzer 256-dim speaker embeddings, centroid-based
 - Routes: `voice.py`, repo: `pgvector_voice_repository.py`, embedder: `speaker_embedder.py`
 - **Voice verify centroid normalization (P1-10, 2026-06-02)**: the default enroll

--- a/app/application/use_cases/enroll_multi_image.py
+++ b/app/application/use_cases/enroll_multi_image.py
@@ -19,7 +19,10 @@ from app.domain.exceptions.enrollment_errors import (
     InvalidImageCountError,
     MLModelTimeoutError,
 )
-from app.domain.exceptions.face_errors import FaceNotDetectedError, PoorImageQualityError
+from app.domain.exceptions.face_errors import (
+    FaceNotDetectedError,
+    PoorImageQualityError,
+)
 from app.domain.exceptions.liveness_errors import LivenessCheckFailedError
 from app.domain.interfaces.embedding_extractor import IEmbeddingExtractor
 from app.domain.interfaces.embedding_repository import IEmbeddingRepository
@@ -28,6 +31,22 @@ from app.domain.interfaces.quality_assessor import IQualityAssessor
 from app.domain.services.embedding_fusion_service import EmbeddingFusionService
 
 logger = logging.getLogger(__name__)
+
+# Per-frame failures that are SAFE to skip-and-continue during multi-image
+# enrollment: they mean "this one frame isn't usable", NOT "this is an
+# attack". Skipping a poor-quality frame and continuing toward
+# MULTI_IMAGE_MIN_IMAGES mirrors how a human retake works and removes the
+# asymmetric rejection where one 40-59-scoring frame aborted the whole batch.
+# FaceNotDetected is normally absorbed earlier by the full-image fallback;
+# it is listed here only as a defensive belt-and-braces for any path that
+# re-raises it per-frame.
+#
+# SECURITY: liveness (LivenessCheckFailedError) and anti-spoof
+# (SpoofDetectedError) failures are DELIBERATELY excluded — a non-live /
+# spoofed frame MUST fail the whole enrollment fail-closed, never be
+# silently skipped. Model timeouts (MLModelTimeoutError), MultipleFaces and
+# any unexpected error also remain fatal.
+_SKIPPABLE_FRAME_ERRORS = (PoorImageQualityError, FaceNotDetectedError)
 
 
 class EnrollMultiImageUseCase:
@@ -111,11 +130,25 @@ class EnrollMultiImageUseCase:
 
         Raises:
             InvalidImageCountError: When number of images is not 2-5
-            FaceNotDetectedError: When no face is found in an image
-            MultipleFacesError: When multiple faces are found in an image
-            PoorImageQualityError: When image quality is below threshold
+            InsufficientImagesError: When too many frames were skipped on the
+                per-frame quality gate to reach ``MULTI_IMAGE_MIN_IMAGES``
+                usable frames (the user should retry with clearer photos).
+            LivenessCheckFailedError: When any frame fails the server-side
+                passive liveness check — FATAL, aborts the whole batch
+                (fail-closed; a non-live/spoofed frame is never skipped).
+            SpoofDetectedError: When anti-spoof flags a frame — FATAL (as above).
+            MultipleFacesError: When multiple faces are found in a frame — FATAL.
+            MLModelTimeoutError: When an ML model operation times out — FATAL.
             FusionError: When embedding fusion fails
             RepositoryError: When save to repository fails
+
+        Note:
+            A frame that fails ONLY the per-frame QUALITY gate
+            (``PoorImageQualityError`` / defensively ``FaceNotDetectedError``) is
+            SKIPPED — logged, not added to the fusion set — and the loop
+            continues toward ``MULTI_IMAGE_MIN_IMAGES``. One weak photo no longer
+            aborts an otherwise-good multi-image enrollment. Security-relevant
+            failures (liveness, anti-spoof) still abort fail-closed.
         """
         logger.info(
             f"Starting multi-image enrollment: user_id={user_id}, "
@@ -263,7 +296,32 @@ class EnrollMultiImageUseCase:
                 embeddings.append(embedding_vector)
                 quality_scores.append(quality.score)
 
+            except _SKIPPABLE_FRAME_ERRORS as e:
+                # SKIP-AND-CONTINUE: a frame that fails ONLY the per-frame quality
+                # gate (or, defensively, face-not-detected) is dropped from the
+                # fusion set and we move on to the next frame. We do NOT abort the
+                # whole batch — one weak photo out of several should not fail an
+                # otherwise-good enrollment. After the loop we check that enough
+                # good frames survived (>= min_images), raising InsufficientImages
+                # otherwise. Liveness/spoof/timeout/unexpected errors do NOT match
+                # this tuple and fall through to the fatal handler below.
+                error_code = getattr(e, "error_code", type(e).__name__)
+                logger.warning(
+                    "  Image %d SKIPPED (%s): %s — continuing toward %d good frame(s)",
+                    i,
+                    error_code,
+                    str(e),
+                    min_images,
+                )
+                # Note: deliberately do NOT mark_failed / clear_submissions here —
+                # the surviving good frames stay in the session for fusion.
+                continue
+
             except Exception as e:
+                # FATAL: liveness failure, anti-spoof / SpoofDetected, ML timeout,
+                # MultipleFaces, or any unexpected error aborts the entire batch
+                # fail-closed (security-preserving). This is the same behaviour as
+                # before for these error types.
                 logger.error(f"Failed to process image {i}: {str(e)}")
                 session.mark_failed()
 
@@ -284,11 +342,38 @@ class EnrollMultiImageUseCase:
                 if face_region is not None:
                     del face_region
 
-        # Step 4: Verify we have enough images
+        # Step 4: Verify enough GOOD frames survived the per-frame quality gate.
+        # Quality-failing frames were skipped (not added), so the submission count
+        # may be below len(image_paths). If too many were skipped to reach
+        # min_images, tell the caller to retry with better images.
+        accepted = session.get_submission_count()
+        skipped = len(image_paths) - accepted
+        if skipped:
+            logger.info(
+                "Multi-image enrollment: %d/%d frame(s) accepted, %d skipped on "
+                "quality (min required=%d)",
+                accepted,
+                len(image_paths),
+                skipped,
+                session.min_images,
+            )
         if not session.is_ready_for_fusion():
+            logger.warning(
+                "Multi-image enrollment for user_id=%s has only %d usable frame(s) "
+                "after skipping %d poor-quality frame(s); minimum is %d",
+                user_id,
+                accepted,
+                skipped,
+                session.min_images,
+            )
+            session.mark_failed()
+            # Release any partial state before bailing.
+            session.clear_submissions()
+            embeddings.clear()
+            quality_scores.clear()
             raise InsufficientImagesError(
                 session_id=session.session_id,
-                current=session.get_submission_count(),
+                current=accepted,
                 minimum=session.min_images,
             )
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -516,7 +516,16 @@ class Settings(BaseSettings):
         default="weighted_average"
     )
     MULTI_IMAGE_NORMALIZATION: Literal["l2", "none"] = Field(default="l2")
-    MULTI_IMAGE_MIN_QUALITY_PER_IMAGE: float = Field(default=60.0, ge=0.0, le=100.0)
+    # Per-frame quality floor for the multi-image enrollment path.
+    # Aligned (2026-06-03) with the single-image floor so the two enroll paths
+    # reject identically: the deployed single-image `/enroll` floor is
+    # ``QUALITY_THRESHOLD`` (=40 in prod `.env.prod`). Previously this defaulted
+    # to 60.0, so a frame scoring 40-59 passed single `/enroll` but was rejected
+    # per-frame on `/enroll/multi` — an asymmetric rejection. Frames below this
+    # floor are now SKIPPED (not added to the fusion set) and the enrollment
+    # continues toward MULTI_IMAGE_MIN_IMAGES; only liveness/anti-spoof failures
+    # are fatal. Env-overridable. See enroll_multi_image.py.
+    MULTI_IMAGE_MIN_QUALITY_PER_IMAGE: float = Field(default=40.0, ge=0.0, le=100.0)
 
     # Embedding Cache Settings
     EMBEDDING_CACHE_ENABLED: bool = Field(default=True, description="Enable LRU cache for embedding lookups")

--- a/tests/unit/application/use_cases/test_enroll_multi_image.py
+++ b/tests/unit/application/use_cases/test_enroll_multi_image.py
@@ -12,11 +12,13 @@ from app.domain.entities.quality_assessment import QualityAssessment
 from app.domain.services.embedding_fusion_service import EmbeddingFusionService
 from app.domain.exceptions.enrollment_errors import (
     InvalidImageCountError,
+    InsufficientImagesError,
     FusionError,
 )
 from app.domain.exceptions.face_errors import (
     FaceNotDetectedError,
     PoorImageQualityError,
+    SpoofDetectedError,
 )
 from app.domain.exceptions.liveness_errors import LivenessCheckFailedError
 
@@ -269,7 +271,7 @@ class TestEnrollMultiImageUseCase:
         mock_embedding_repository.save.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_enrollment_poor_quality_in_one_image(
+    async def test_enrollment_poor_quality_in_one_image_skips_and_succeeds(
         self,
         mock_face_detector,
         mock_embedding_extractor,
@@ -278,7 +280,16 @@ class TestEnrollMultiImageUseCase:
         mock_fusion_service,
         temp_image_files,
     ):
-        """Test that poor quality in one image fails enrollment."""
+        """One quality-failing frame is SKIPPED (not fatal), enrollment succeeds.
+
+        UPDATED (2026-06-03, fix #7): the multi-image path no longer aborts the
+        whole batch on a single quality-only failure. A frame scoring below
+        ``MULTI_IMAGE_MIN_QUALITY_PER_IMAGE`` is dropped from the fusion set and
+        the loop continues. With 3 frames and 1 below the floor, 2 good frames
+        survive (>= MULTI_IMAGE_MIN_IMAGES=2) so enrollment completes and the
+        fused template is persisted. (The old test asserted the opposite —
+        fail-the-batch — under the pre-fix fail-closed-on-quality policy.)
+        """
         use_case = EnrollMultiImageUseCase(
             detector=mock_face_detector,
             extractor=mock_embedding_extractor,
@@ -287,16 +298,16 @@ class TestEnrollMultiImageUseCase:
             fusion_service=mock_fusion_service,
         )
 
-        # Make second image have poor quality
+        # Make second image fall BELOW the per-frame quality floor (default 40.0).
         call_count = [0]
 
         async def assess_with_poor_quality(face_region):
             call_count[0] += 1
-            if call_count[0] == 2:  # Second image
+            if call_count[0] == 2:  # Second image — below the 40.0 floor.
                 return QualityAssessment(
-                    score=40.0,  # Below threshold
-                    blur_score=50.0,
-                    lighting_score=60.0,
+                    score=25.0,  # Below MULTI_IMAGE_MIN_QUALITY_PER_IMAGE (40.0)
+                    blur_score=10.0,
+                    lighting_score=30.0,
                     face_size=80,
                     is_acceptable=False,
                 )
@@ -315,11 +326,21 @@ class TestEnrollMultiImageUseCase:
                 0, 255, (200, 200, 3), dtype=np.uint8
             )
 
-            with pytest.raises(PoorImageQualityError):
-                await use_case.execute(
-                    user_id="test_user_123",
-                    image_paths=temp_image_files,
-                )
+            result = await use_case.execute(
+                user_id="test_user_123",
+                image_paths=temp_image_files,
+            )
+
+        # The bad frame was skipped; the 2 good frames produced the template.
+        assert result.user_id == "test_user_123"
+        # Quality was assessed on all 3, but only 2 embeddings were extracted/fused.
+        assert mock_quality_assessor.assess.call_count == 3
+        assert mock_embedding_extractor.extract.call_count == 2
+        # Exactly the 2 surviving quality scores were fused (85.0, 85.0).
+        fuse_call = mock_fusion_service.fuse_embeddings.call_args
+        assert len(fuse_call.kwargs["quality_scores"]) == 2
+        assert all(q == 85.0 for q in fuse_call.kwargs["quality_scores"])
+        mock_embedding_repository.save.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_enrollment_fusion_failure_raises_error(
@@ -713,3 +734,213 @@ class TestEnrollMultiImageLivenessGate:
         assert result.user_id == "bypass_user"
         liveness_use_case.execute.assert_not_called()
         mock_embedding_repository.save.assert_called_once()
+
+
+def _quality(score: float) -> QualityAssessment:
+    """Build a QualityAssessment at an arbitrary score for the skip/abort tests."""
+    return QualityAssessment(
+        score=score,
+        blur_score=150.0 if score >= 40.0 else 10.0,
+        lighting_score=120.0 if score >= 40.0 else 30.0,
+        face_size=100,
+        is_acceptable=score >= 40.0,
+    )
+
+
+class TestEnrollMultiImageQualitySkipVsSecurityAbort:
+    """Fix #7 — multi-image enrollment hardening.
+
+    A frame that fails ONLY the per-frame QUALITY gate is skipped (logged, not
+    fused) and the loop continues toward ``MULTI_IMAGE_MIN_IMAGES``; if too few
+    good frames survive, ``InsufficientImagesError`` is raised so the user is
+    asked to retry. CRITICALLY, liveness and anti-spoof failures are NOT
+    skippable — a non-live/spoofed frame still aborts the WHOLE enrollment
+    fail-closed. These tests assert that skip-vs-abort split.
+    """
+
+    @pytest.mark.asyncio
+    async def test_one_bad_quality_frame_skipped_batch_succeeds(
+        self,
+        mock_face_detector,
+        mock_embedding_extractor,
+        mock_quality_assessor,
+        mock_embedding_repository,
+        mock_fusion_service,
+        temp_image_files,
+    ):
+        """3 frames, 1 below the quality floor → skip it, fuse the other 2,
+        succeed (>= min_images=2)."""
+        scores = iter([85.0, 20.0, 90.0])  # frame 2 is below the 40.0 floor
+
+        async def assess(face_region):
+            return _quality(next(scores))
+
+        mock_quality_assessor.assess = AsyncMock(side_effect=assess)
+
+        use_case = EnrollMultiImageUseCase(
+            detector=mock_face_detector,
+            extractor=mock_embedding_extractor,
+            quality_assessor=mock_quality_assessor,
+            repository=mock_embedding_repository,
+            fusion_service=mock_fusion_service,
+        )
+
+        with patch("cv2.imread") as mock_imread:
+            mock_imread.return_value = np.random.randint(
+                0, 255, (200, 200, 3), dtype=np.uint8
+            )
+            result = await use_case.execute(
+                user_id="retake_user",
+                image_paths=temp_image_files,
+            )
+
+        assert result.user_id == "retake_user"
+        # All 3 assessed; only the 2 good frames extracted + fused.
+        assert mock_quality_assessor.assess.call_count == 3
+        assert mock_embedding_extractor.extract.call_count == 2
+        fuse_call = mock_fusion_service.fuse_embeddings.call_args
+        assert sorted(fuse_call.kwargs["quality_scores"]) == [85.0, 90.0]
+        mock_embedding_repository.save.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_too_many_bad_quality_frames_raises_insufficient(
+        self,
+        mock_face_detector,
+        mock_embedding_extractor,
+        mock_quality_assessor,
+        mock_embedding_repository,
+        mock_fusion_service,
+        temp_image_files,
+    ):
+        """3 frames, only 1 above the floor → 1 good frame < min_images(2) →
+        InsufficientImagesError (retry), NOTHING persisted."""
+        scores = iter([88.0, 15.0, 10.0])  # only frame 1 passes
+
+        async def assess(face_region):
+            return _quality(next(scores))
+
+        mock_quality_assessor.assess = AsyncMock(side_effect=assess)
+
+        use_case = EnrollMultiImageUseCase(
+            detector=mock_face_detector,
+            extractor=mock_embedding_extractor,
+            quality_assessor=mock_quality_assessor,
+            repository=mock_embedding_repository,
+            fusion_service=mock_fusion_service,
+        )
+
+        with patch("cv2.imread") as mock_imread:
+            mock_imread.return_value = np.random.randint(
+                0, 255, (200, 200, 3), dtype=np.uint8
+            )
+            with pytest.raises(InsufficientImagesError) as exc_info:
+                await use_case.execute(
+                    user_id="too_blurry",
+                    image_paths=temp_image_files,
+                )
+
+        # Only the one good frame was ever extracted; fusion + save never ran.
+        assert mock_embedding_extractor.extract.call_count == 1
+        mock_fusion_service.fuse_embeddings.assert_not_called()
+        mock_embedding_repository.save.assert_not_called()
+        assert exc_info.value.current_images == 1
+        assert exc_info.value.minimum_images == 2
+
+    @pytest.mark.asyncio
+    async def test_liveness_failing_frame_still_aborts_batch(
+        self,
+        mock_face_detector,
+        mock_embedding_extractor,
+        mock_quality_assessor,
+        mock_embedding_repository,
+        mock_fusion_service,
+        temp_image_files,
+    ):
+        """SECURITY: a liveness-failing frame is NOT skippable — it aborts the
+        whole enrollment fail-closed even though other frames are good quality."""
+        call_count = [0]
+
+        async def liveness_side_effect(image_path):
+            call_count[0] += 1
+            # Frame 2 is not live (photo/screen replay).
+            return _live_result(score=12.0, is_live=call_count[0] != 2)
+
+        liveness_use_case = Mock(spec=CheckLivenessUseCase)
+        liveness_use_case.execute = AsyncMock(side_effect=liveness_side_effect)
+
+        # Every frame is GOOD quality — so the ONLY reason to abort is liveness.
+        mock_quality_assessor.assess = AsyncMock(return_value=_quality(90.0))
+
+        use_case = EnrollMultiImageUseCase(
+            detector=mock_face_detector,
+            extractor=mock_embedding_extractor,
+            quality_assessor=mock_quality_assessor,
+            repository=mock_embedding_repository,
+            fusion_service=mock_fusion_service,
+            liveness_use_case=liveness_use_case,
+        )
+
+        with patch("cv2.imread") as mock_imread:
+            mock_imread.return_value = np.random.randint(
+                0, 255, (200, 200, 3), dtype=np.uint8
+            )
+            with pytest.raises(LivenessCheckFailedError):
+                await use_case.execute(
+                    user_id="replayer",
+                    image_paths=temp_image_files,
+                )
+
+        # Aborted on frame 2 — fail-closed, nothing fused/persisted.
+        assert liveness_use_case.execute.await_count == 2
+        mock_fusion_service.fuse_embeddings.assert_not_called()
+        mock_embedding_repository.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_spoof_detected_frame_still_aborts_batch(
+        self,
+        mock_face_detector,
+        mock_embedding_extractor,
+        mock_quality_assessor,
+        mock_embedding_repository,
+        mock_fusion_service,
+        temp_image_files,
+    ):
+        """SECURITY: a SpoofDetectedError on a frame is NOT skippable — it aborts
+        the whole enrollment fail-closed. (Anti-spoof can surface either via the
+        liveness use case's LivenessCheckFailedError or, if a detector/extractor
+        raises SpoofDetectedError directly, that too must be fatal.) Here we
+        raise SpoofDetectedError from the extractor on frame 2 to prove the
+        broad fatal handler — not the skippable tuple — catches it."""
+        call_count = [0]
+
+        async def extract_with_spoof(face_region):
+            call_count[0] += 1
+            if call_count[0] == 2:
+                raise SpoofDetectedError(antispoof_score=0.97)
+            return np.random.randn(128).astype(np.float32)
+
+        mock_embedding_extractor.extract = AsyncMock(side_effect=extract_with_spoof)
+        mock_quality_assessor.assess = AsyncMock(return_value=_quality(90.0))
+
+        use_case = EnrollMultiImageUseCase(
+            detector=mock_face_detector,
+            extractor=mock_embedding_extractor,
+            quality_assessor=mock_quality_assessor,
+            repository=mock_embedding_repository,
+            fusion_service=mock_fusion_service,
+        )
+
+        with patch("cv2.imread") as mock_imread:
+            mock_imread.return_value = np.random.randint(
+                0, 255, (200, 200, 3), dtype=np.uint8
+            )
+            with pytest.raises(SpoofDetectedError):
+                await use_case.execute(
+                    user_id="spoofer2",
+                    image_paths=temp_image_files,
+                )
+
+        # Aborted on frame 2 — fail-closed, nothing fused/persisted.
+        assert mock_embedding_extractor.extract.call_count == 2
+        mock_fusion_service.fuse_embeddings.assert_not_called()
+        mock_embedding_repository.save.assert_not_called()


### PR DESCRIPTION
## Summary

Hardens the multi-image face enrollment path (`/enroll/multi`) so a single
weak frame no longer aborts an otherwise-good batch, **while preserving the
fail-closed security guarantee for spoof / non-live frames**.

### 1. Align the per-frame quality floor with single-image enroll
`app/core/config.py`: `MULTI_IMAGE_MIN_QUALITY_PER_IMAGE` default **60.0 → 40.0**
to match the deployed single-image `QUALITY_THRESHOLD` (=40). Previously a frame
scoring 40–59 **passed** single `/enroll` but was **rejected** per-frame on
`/enroll/multi` — an asymmetric rejection. Still env-overridable; a comment
references the single-image floor and the rationale.

### 2. Skip-and-continue on quality-only failures; abort on security failures
`app/application/use_cases/enroll_multi_image.py`: a frame that fails **only**
the per-frame quality gate (`PoorImageQualityError`, or defensively
`FaceNotDetectedError`) is now **skipped** — logged, not added to the fusion
set — and the loop continues toward `MULTI_IMAGE_MIN_IMAGES`. After the loop, if
too few good frames survived, `InsufficientImagesError` (existing) is raised so
the user is told to retry.

### Security-preserving skip / abort distinction
A new module-level tuple `_SKIPPABLE_FRAME_ERRORS = (PoorImageQualityError,
FaceNotDetectedError)` makes the split explicit:

| Failure | Behaviour |
|---|---|
| Per-frame **quality** (`PoorImageQualityError`) | **Skip + continue** |
| Face-not-detected per-frame (`FaceNotDetectedError`, defensive) | **Skip + continue** |
| **Liveness** (`LivenessCheckFailedError`) | **FATAL — abort fail-closed** |
| **Anti-spoof** (`SpoofDetectedError`) | **FATAL — abort fail-closed** |
| ML timeout (`MLModelTimeoutError`), MultipleFaces, any unexpected error | **FATAL — abort** |

The skippable errors are caught in a dedicated `except _SKIPPABLE_FRAME_ERRORS`
branch placed **before** the broad `except Exception` (which is retained as the
fatal safety net — it still `mark_failed()` + `clear_submissions()` + re-raises).
A non-live / spoofed frame can therefore never be silently skipped.

## Tests
`tests/unit/application/use_cases/test_enroll_multi_image.py`:
- **Updated** the old "one poor frame fails the whole batch" test to the new
  skip-and-succeed semantics (a sub-floor frame is dropped, the 2 good frames
  are fused, enrollment succeeds).
- **New** `TestEnrollMultiImageQualitySkipVsSecurityAbort`:
  - one bad-quality frame skipped + batch succeeds (≥ min_images),
  - too many bad-quality frames → `InsufficientImagesError`, nothing persisted,
  - liveness-failing frame still aborts (`LivenessCheckFailedError`) — security,
  - spoof frame still aborts (`SpoofDetectedError`) — security.

### Test results (system Python, ML/detector/liveness mocked per existing patterns)
- `test_enroll_multi_image.py` → **20 passed**
- `tests/unit -k "enroll or multi or quality"` → **148 passed** (excluding 3
  pre-existing NFC/eMRTD collection errors caused by a missing optional
  `asn1crypto` dep on the bare host — present identically on unmodified `main`,
  unrelated to this change).
- `ruff check app/` with the CI ignore flags → **All checks passed**.

## Caveat
Targeted gate only. The full `pytest` suite + the env-gated full-stack
integration tests need the Docker ML stack (DeepFace/TF + DB/Redis) and were not
run here; the four ML-lifespan integration files SKIP on a bare host by design
(see `CLAUDE.md` Test/CI honesty). All targeted enrollment unit tests are green.

Docs: `CLAUDE.md` updated with a "Multi-image enroll quality-floor + per-frame
skip (fix #7)" bullet.

Do **not** merge — opened for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)