### PR TITLE
Reproducible face-recognition benchmark harness + RESULTS template

### DIFF
--- a/tests/benchmarks/RESULTS.md
+++ b/tests/benchmarks/RESULTS.md
@@ -1,55 +1,53 @@
-# Face-Recognition Benchmark — methodology & results
+# Face-Recognition Benchmark — methodology & results (template)
 
 Reproducible 1:1 verification accuracy for the **production face model**
 (FaceNet-512 via DeepFace, cosine distance, accept threshold 0.45 — the same model
-and operating point used by `/verify`). This file exists so every face-accuracy
-number on the poster / in the defense is backed by a **committed, re-runnable
-script + a raw per-pair CSV**, not a slide.
+and operating point used by `/verify`). This file + harness exist so that the
+face-accuracy numbers used on the poster / in the defense can be **re-derived from a
+committed script and raw CSV**, instead of living only on a slide.
 
 Harness: [`face_recognition_accuracy.py`](./face_recognition_accuracy.py).
 
-## Reported results
+> **Status: results NOT yet committed.** The table below is a template. Fill it in
+> **only** from a CSV produced by the harness on this machine — do not transcribe
+> numbers from slides. Until the CSVs land, this repo makes **no** verified
+> face-accuracy claim.
 
-> **Provenance:** produced by **Ayşenur Arıcı's** offline evaluation of FaceNet-512
-> on the standard public verification protocols below. These are *model-accuracy*
-> benchmarks (offline, on the public datasets) — **not** end-to-end production-API
-> latency, which is tracked separately. The raw per-pair CSVs are **pending commit**
-> (see "To finish" below); until they land, treat the table as *reported, not yet
-> independently re-derived in this repo*.
+## Results (fill from your run)
 
-| Dataset    | Pairs  | AUC    | EER    | FAR @ 0.45 | TAR    |
-|------------|-------:|:------:|:------:|:----------:|:------:|
-| LFW        | 5,600  | 0.9943 | 1.93 % | 0.27 %     | 95.6 % |
-| CFP-FP     | 1,378  | 0.9845 | —      | —          | —      |
-| AgeDB-30   | —      | 0.9475 | —      | —          | —      |
-| **Total**  | 12,062 |        |        |            |        |
+| Dataset    | Pairs | AUC | EER | FAR @ 0.45 | TAR | CSV |
+|------------|------:|:---:|:---:|:----------:|:---:|-----|
+| LFW        |       |     |     |            |     | `lfw_results.csv` |
+| CFP-FP     |       |     |     |            |     | `cfp_fp_results.csv` |
+| AgeDB-30   |       |     |     |            |     | `agedb30_results.csv` |
 
-Scale: 1,342 enrolled images across 100 identities; 12,062 verification pairs over
-the three protocols. Model: **FaceNet-512** (512-D), cosine distance, threshold 0.45.
+Model: FaceNet-512 (512-D), cosine distance, threshold 0.45.
 
-Cross-check (independent corroboration of provenance): AgeDB-30 ≈ 0.9475 was already
-recorded in `archive/2026-04-pre-roadmap-2028/BIOMETRIC_PIPELINE_AUDIT_2026-04-28.md`,
-and the methodology is documented in `docs/01-getting-started/METRICS_COLLECTION_GUIDE.md`.
+**Targets to confirm** (these are the values currently *claimed on the poster* — re-run
+to verify and replace the table above with your measured figures): LFW ≈ 0.9943 AUC /
+EER 1.93 % / FAR 0.27 % / TAR 95.6 %; CFP-FP ≈ 0.9845 AUC; AgeDB-30 ≈ 0.9475 AUC; over
+≈12,062 pairs (≈1,342 images / 100 identities). A prior internal note also recorded
+AgeDB-30 ≈ 0.9475 (`archive/2026-04-pre-roadmap-2028/BIOMETRIC_PIPELINE_AUDIT_2026-04-28.md`);
+methodology in `docs/01-getting-started/METRICS_COLLECTION_GUIDE.md`.
 
 ## Reproduce
 
 ```bash
-# LFW (convert the official pairs.txt to "imgA imgB label" lines first)
+# Convert the official LFW pairs.txt to "imgA imgB label" lines first, then:
 python tests/benchmarks/face_recognition_accuracy.py \
     --pairs lfw_pairs.txt --images ~/datasets/lfw \
     --model Facenet512 --threshold 0.45 --out lfw_results.csv
-# repeat with --pairs cfp_fp_pairs.txt / agedb30_pairs.txt
+# repeat for CFP-FP and AgeDB-30
 ```
 
-The script embeds each image with DeepFace (FaceNet-512, MTCNN detector), computes
-cosine distance per pair, then reports **AUC** (`roc_auc_score`), **EER**, and
-**TAR/FAR** at the threshold, and writes a per-pair CSV.
+The script embeds each image (DeepFace, FaceNet-512, MTCNN), computes cosine distance
+per pair, and reports **AUC** (`roc_auc_score`), **EER**, and **TAR/FAR** at the
+threshold, writing a per-pair CSV.
 
-## To finish (turns "reported" into "reproducible")
+## To finish (turns this template into evidence)
 
-1. Commit Ayşenur's eval artifact (notebook or script) that produced the table.
-2. Commit the raw per-pair CSVs here: `lfw_results.csv`, `cfp_fp_results.csv`,
-   `agedb30_results.csv` (the script's `--out`).
-3. Fill the empty CFP-FP / AgeDB-30 cells from those CSVs.
+1. Run the harness on LFW / CFP-FP / AgeDB-30 (or commit the eval notebook that produced the numbers).
+2. Commit the raw per-pair CSVs next to this file.
+3. Fill the results table from those CSVs.
 
-Once (1)–(3) land, the poster's "99.43 % AUC" has a one-click source for the jury.
+Once (1)–(3) land, the poster's face-accuracy numbers have a one-click, defensible source.

--- a/tests/benchmarks/RESULTS.md
+++ b/tests/benchmarks/RESULTS.md
@@ -1,0 +1,55 @@
+# Face-Recognition Benchmark — methodology & results
+
+Reproducible 1:1 verification accuracy for the **production face model**
+(FaceNet-512 via DeepFace, cosine distance, accept threshold 0.45 — the same model
+and operating point used by `/verify`). This file exists so every face-accuracy
+number on the poster / in the defense is backed by a **committed, re-runnable
+script + a raw per-pair CSV**, not a slide.
+
+Harness: [`face_recognition_accuracy.py`](./face_recognition_accuracy.py).
+
+## Reported results
+
+> **Provenance:** produced by **Ayşenur Arıcı's** offline evaluation of FaceNet-512
+> on the standard public verification protocols below. These are *model-accuracy*
+> benchmarks (offline, on the public datasets) — **not** end-to-end production-API
+> latency, which is tracked separately. The raw per-pair CSVs are **pending commit**
+> (see "To finish" below); until they land, treat the table as *reported, not yet
+> independently re-derived in this repo*.
+
+| Dataset    | Pairs  | AUC    | EER    | FAR @ 0.45 | TAR    |
+|------------|-------:|:------:|:------:|:----------:|:------:|
+| LFW        | 5,600  | 0.9943 | 1.93 % | 0.27 %     | 95.6 % |
+| CFP-FP     | 1,378  | 0.9845 | —      | —          | —      |
+| AgeDB-30   | —      | 0.9475 | —      | —          | —      |
+| **Total**  | 12,062 |        |        |            |        |
+
+Scale: 1,342 enrolled images across 100 identities; 12,062 verification pairs over
+the three protocols. Model: **FaceNet-512** (512-D), cosine distance, threshold 0.45.
+
+Cross-check (independent corroboration of provenance): AgeDB-30 ≈ 0.9475 was already
+recorded in `archive/2026-04-pre-roadmap-2028/BIOMETRIC_PIPELINE_AUDIT_2026-04-28.md`,
+and the methodology is documented in `docs/01-getting-started/METRICS_COLLECTION_GUIDE.md`.
+
+## Reproduce
+
+```bash
+# LFW (convert the official pairs.txt to "imgA imgB label" lines first)
+python tests/benchmarks/face_recognition_accuracy.py \
+    --pairs lfw_pairs.txt --images ~/datasets/lfw \
+    --model Facenet512 --threshold 0.45 --out lfw_results.csv
+# repeat with --pairs cfp_fp_pairs.txt / agedb30_pairs.txt
+```
+
+The script embeds each image with DeepFace (FaceNet-512, MTCNN detector), computes
+cosine distance per pair, then reports **AUC** (`roc_auc_score`), **EER**, and
+**TAR/FAR** at the threshold, and writes a per-pair CSV.
+
+## To finish (turns "reported" into "reproducible")
+
+1. Commit Ayşenur's eval artifact (notebook or script) that produced the table.
+2. Commit the raw per-pair CSVs here: `lfw_results.csv`, `cfp_fp_results.csv`,
+   `agedb30_results.csv` (the script's `--out`).
+3. Fill the empty CFP-FP / AgeDB-30 cells from those CSVs.
+
+Once (1)–(3) land, the poster's "99.43 % AUC" has a one-click source for the jury.

--- a/tests/benchmarks/face_recognition_accuracy.py
+++ b/tests/benchmarks/face_recognition_accuracy.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Face-recognition verification benchmark harness (LFW / AgeDB-30 / CFP-FP).
+
+Reproducible 1:1 verification eval for the production face model (FaceNet-512 via
+DeepFace), so the accuracy numbers reported on the poster / in the defense are
+backed by a committed, re-runnable script + a raw per-pair CSV.
+
+It does NOT run in CI (no datasets in-repo, not a ``test_*`` file). It is a CLI
+tool the team runs locally against a standard verification protocol, then commits
+the resulting CSV next to ``RESULTS.md``.
+
+Pairs file format (one pair per line, whitespace-separated)::
+
+    <img_path_a> <img_path_b> <label>     # label = 1 genuine / 0 impostor
+
+(LFW's ``pairs.txt`` can be converted to this form; ``--images`` is prepended.)
+
+Example::
+
+    python tests/benchmarks/face_recognition_accuracy.py \
+        --pairs lfw_pairs.txt --images ~/datasets/lfw \
+        --model Facenet512 --threshold 0.45 --out lfw_results.csv
+
+Outputs AUC, EER, and FAR/TAR at the chosen cosine threshold, plus a per-pair CSV.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+def cosine_distance(a: np.ndarray, b: np.ndarray) -> float:
+    a = a / (np.linalg.norm(a) + 1e-10)
+    b = b / (np.linalg.norm(b) + 1e-10)
+    return float(1.0 - np.dot(a, b))
+
+
+def embed(img_path: str, model: str) -> np.ndarray:
+    # Imported lazily so --help works without the heavy ML stack installed.
+    from deepface import DeepFace
+
+    reps = DeepFace.represent(
+        img_path=img_path, model_name=model,
+        detector_backend="mtcnn", enforce_detection=False,
+    )
+    return np.asarray(reps[0]["embedding"], dtype=np.float32)
+
+
+def equal_error_rate(labels: np.ndarray, scores: np.ndarray) -> tuple[float, float]:
+    """EER + the threshold where FAR == FRR. ``scores`` = genuine-similarity (higher = more same)."""
+    from sklearn.metrics import roc_curve
+
+    fpr, tpr, thr = roc_curve(labels, scores)
+    fnr = 1 - tpr
+    i = int(np.nanargmin(np.abs(fnr - fpr)))
+    return float((fpr[i] + fnr[i]) / 2), float(thr[i])
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--pairs", required=True, help="pairs file: 'imgA imgB label' per line")
+    ap.add_argument("--images", default="", help="root dir prepended to relative image paths")
+    ap.add_argument("--model", default="Facenet512", help="DeepFace model (prod = Facenet512)")
+    ap.add_argument("--threshold", type=float, default=0.45, help="cosine-distance accept threshold")
+    ap.add_argument("--out", default="face_recognition_results.csv", help="per-pair CSV output")
+    args = ap.parse_args(argv)
+
+    root = Path(args.images)
+    rows, labels, dists = [], [], []
+    cache: dict[str, np.ndarray] = {}
+
+    for ln in Path(args.pairs).read_text().splitlines():
+        ln = ln.strip()
+        if not ln or ln.startswith("#"):
+            continue
+        a, b, label = ln.split()
+        pa, pb = str(root / a), str(root / b)
+        try:
+            ea = cache.setdefault(pa, embed(pa, args.model))
+            eb = cache.setdefault(pb, embed(pb, args.model))
+        except Exception as exc:  # noqa: BLE001 — a missing/undetectable face shouldn't abort the run
+            print(f"skip {a} {b}: {exc}", file=sys.stderr)
+            continue
+        d = cosine_distance(ea, eb)
+        labels.append(int(label)); dists.append(d)
+        rows.append({"img_a": a, "img_b": b, "label": int(label),
+                     "cosine_distance": round(d, 6), "accept": int(d <= args.threshold)})
+
+    if not labels:
+        print("no usable pairs", file=sys.stderr)
+        return 2
+
+    from sklearn.metrics import roc_auc_score
+
+    labels_np = np.asarray(labels)
+    sim = 1.0 - np.asarray(dists)                       # similarity: higher = same person
+    auc = float(roc_auc_score(labels_np, sim))
+    eer, eer_thr = equal_error_rate(labels_np, sim)
+    accept = np.asarray(dists) <= args.threshold
+    genuine, impostor = labels_np == 1, labels_np == 0
+    tar = float(accept[genuine].mean()) if genuine.any() else float("nan")   # true accept
+    far = float(accept[impostor].mean()) if impostor.any() else float("nan")  # false accept
+
+    with open(args.out, "w", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=["img_a", "img_b", "label", "cosine_distance", "accept"])
+        w.writeheader(); w.writerows(rows)
+
+    print(f"model={args.model}  pairs={len(labels)}  (genuine={int(genuine.sum())} impostor={int(impostor.sum())})")
+    print(f"AUC={auc:.4f}  EER={eer*100:.2f}%  (EER cos-sim thr={eer_thr:.3f})")
+    print(f"@cosine<= {args.threshold}:  TAR={tar*100:.2f}%  FAR={far*100:.2f}%")
+    print(f"per-pair CSV -> {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Gives the face-recognition accuracy claims a committed, re-runnable home so they can be reproduced rather than living only on a slide.

- `tests/benchmarks/face_recognition_accuracy.py` — embeds image pairs via DeepFace (FaceNet-512, MTCNN), cosine distance, reports AUC / EER / TAR / FAR + per-pair CSV. Not collected by pytest (no `test_` prefix; no in-repo datasets).
- `tests/benchmarks/RESULTS.md` — **template**: methodology + reproduce steps. The results table is intentionally **empty** — it must be filled from a CSV produced by the harness, not transcribed from slides. The poster-claimed figures are listed only as *targets to confirm*. This repo asserts no verified accuracy number until the CSVs are committed.

**Left open for the teammate to complete:** run the harness on LFW / CFP-FP / AgeDB-30 (or commit the eval notebook), commit the raw CSVs, fill the table. Then the poster numbers have a one-click source for the jury.

🤖 Generated with [Claude Code](https://claude.com/claude-code)