### PR TITLE
chore(gitignore): ignore prod-secret backups (.env*.bak*) + .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,6 +227,11 @@ render-cli.zip
 # Demo local data
 face_landmarker.task
 *.tflite
+
+# Local prod-secret backups (e.g. .env.prod.bak-YYYYMMDD) — NEVER commit
+.env*.bak*
+# Claude Code local scratch (worktrees, agent state)
+.claude/
 analysis_*.json
 recording_*.mp4
 screenshot_*.jpg


### PR DESCRIPTION
A local prod-secrets backup `.env.prod.bak-20260530` (POSTGRES_PASSWORD, API_KEY_SECRET, JWT_SECRET, …) was untracked but **not gitignored** — a stray `git add .` could commit/leak it. Adds `.env*.bak*` and `.claude/` to `.gitignore`. No file deleted; nothing else changes. Found via `scripts/drift-check.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)