### PR TITLE
feat(api): /verify-embedding + /enroll-embedding for client-computed Facenet512 vectors

### DIFF
--- a/app/api/routes/enrollment.py
+++ b/app/api/routes/enrollment.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, Header, HTTPException, Request, UploadFile
 
 from app.api.routes import verification as verify_route
-from app.api.schemas.enrollment import EnrollmentResponse
+from app.api.schemas.enrollment import EmbeddingEnrollRequest, EnrollmentResponse
 from app.api.schemas.multi_image_enrollment import MultiImageEnrollmentResponse
 from app.application.use_cases.check_liveness import CheckLivenessUseCase
 from app.application.use_cases.delete_enrollment import DeleteEnrollmentUseCase
@@ -287,6 +287,79 @@ def _pick_single_client_embedding(
     except Exception:
         return None
     return None
+
+
+@router.post("/enroll-embedding", response_model=EnrollmentResponse, status_code=200)
+async def enroll_embedding(
+    request: EmbeddingEnrollRequest,
+    use_case: EnrollFaceUseCase = Depends(get_enroll_face_use_case),
+) -> EnrollmentResponse:
+    """Enroll a user from a PRECOMPUTED face embedding (client-side embedding).
+
+    The client computed the Facenet512 embedding locally — no image leaves the
+    device — and submits the raw, L2-normalized 512-vector. This endpoint stores
+    it as the user's template via the SAME dual-column Fernet path that the image
+    ``/enroll`` path uses after it computes the embedding (``store_embedding`` on
+    the enroll use case). It SKIPS face detection, quality assessment and the
+    server-side Facenet512 forward pass, because the client already produced the
+    embedding. The embedding is persisted exactly as supplied (no
+    re-normalization); the cosine match path normalizes consistently at verify
+    time, so verify parity with the image path is preserved.
+
+    SECURITY — NO LIVENESS HERE: this path receives no image, so NO liveness /
+    anti-spoof check is (or can be) performed before persisting. The Identity
+    Core layer (sub-projects B/C) MUST pair it with a liveness factor (puzzle /
+    passive) before trusting the enrollment, exactly as ``/verify-embedding``
+    requires one at verify time.
+
+    Args:
+        request: tenant_id, user_id and the 512-d embedding (length-validated to
+            exactly 512 by the schema → HTTP 422 otherwise).
+        use_case: Injected enrollment use case (reused for its storage logic).
+
+    Returns:
+        EnrollmentResponse describing the stored template.
+
+    Raises:
+        HTTPException 400: Invalid user_id / tenant_id.
+        HTTPException 500: Storage failure (RepositoryError → global handler).
+    """
+    try:
+        user_id = validate_user_id(request.user_id)
+        tenant_id = validate_tenant_id(request.tenant_id)
+    except ValidationError as e:
+        logger.warning(f"Input validation failed: {str(e)}")
+        raise HTTPException(status_code=400, detail=f"Invalid input: {str(e)}")
+
+    logger.info(
+        "enroll-embedding request (no image, liveness enforced upstream): "
+        f"user_id={user_id}, tenant_id={tenant_id}"
+    )
+
+    import numpy as np
+
+    embedding = np.asarray(request.embedding, dtype=np.float32)
+
+    # Reuse the EXACT dual-column Fernet storage tail of EnrollFaceUseCase. There
+    # is no server-side image to assess, so the sample is stored at the
+    # precomputed-embedding quality score (the client gated capture quality
+    # before computing the embedding).
+    result = await use_case.store_embedding(
+        user_id=user_id,
+        embedding=embedding,
+        quality_score=EnrollFaceUseCase.PRECOMPUTED_EMBEDDING_QUALITY_SCORE,
+        tenant_id=tenant_id,
+        optimize=False,
+    )
+
+    return EnrollmentResponse(
+        success=True,
+        user_id=result.user_id,
+        quality_score=result.quality_score,
+        message="Face enrolled successfully (precomputed embedding)",
+        embedding_dimension=result.get_embedding_dimension(),
+        liveness_score=None,
+    )
 
 
 @router.post("/enroll/multi", response_model=MultiImageEnrollmentResponse, status_code=200)

--- a/app/api/routes/verification.py
+++ b/app/api/routes/verification.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Request, UploadFile
 
-from app.api.schemas.verification import VerificationResponse
+from app.api.schemas.verification import EmbeddingVerifyRequest, VerificationResponse
 from app.application.services.device_spoof_risk_evaluator import (
     DeviceSpoofRiskEvaluator,
 )
@@ -523,6 +523,84 @@ async def verify_face(
         # Cleanup temporary file
         if image_path:
             await storage.cleanup(image_path)
+
+
+@router.post("/verify-embedding", response_model=VerificationResponse, status_code=200)
+async def verify_embedding(
+    request: EmbeddingVerifyRequest,
+    use_case: VerifyFaceUseCase = Depends(get_verify_face_use_case),
+) -> VerificationResponse:
+    """Verify a user from a PRECOMPUTED face embedding (client-side embedding).
+
+    The client (browser/device) computed the Facenet512 embedding locally — no
+    image leaves the device — and submits the raw, L2-normalized 512-vector.
+    This endpoint runs ONLY the pgvector match + threshold/decision logic
+    against the user's stored template via the SAME ``match_embedding`` code
+    that the image ``/verify`` path runs after it extracts the embedding. It
+    SKIPS face detection, quality assessment, liveness and the server-side
+    Facenet512 forward pass, because the client already produced the embedding.
+
+    SECURITY — NO LIVENESS HERE: this path receives no image, so NO liveness /
+    anti-spoof check is (or can be) performed. It therefore REQUIRES a paired
+    liveness factor (puzzle / passive) enforced at the Identity Core layer
+    (sub-projects B/C) before the result is trusted as a login factor. On its
+    own a matched embedding only proves "this vector matches the template", not
+    "a live person produced it now".
+
+    Normalization: the embedding is passed through to the similarity calculator
+    unchanged. The cosine calculator L2-normalizes both operands internally, so
+    a client-sent already-normalized vector and the stored template are compared
+    consistently without double-normalizing here.
+
+    Args:
+        request: tenant_id, user_id and the 512-d embedding (length-validated to
+            exactly 512 by the schema → HTTP 422 otherwise).
+        use_case: Injected verification use case (reused for its match logic).
+
+    Returns:
+        VerificationResponse with the same shape the image path returns. The
+        anti-spoof attachment fields are always None on this path (no image).
+
+    Raises:
+        HTTPException 400: Invalid user_id / tenant_id.
+        HTTPException 404: User not enrolled (EmbeddingNotFoundError).
+    """
+    # Validate identifiers for parity with the image path (the schema already
+    # guarantees the embedding length).
+    try:
+        user_id = validate_user_id(request.user_id)
+        tenant_id = validate_tenant_id(request.tenant_id)
+    except ValidationError as e:
+        logger.warning(f"Input validation failed: {str(e)}")
+        raise HTTPException(status_code=400, detail=f"Invalid input: {str(e)}")
+
+    logger.info(
+        "verify-embedding request (no image, liveness enforced upstream): "
+        f"user_id={user_id}, tenant_id={tenant_id}"
+    )
+
+    import numpy as np
+
+    probe = np.asarray(request.embedding, dtype=np.float32)
+
+    # Reuse the EXACT match + adaptive-threshold + decision logic from
+    # VerifyFaceUseCase. EmbeddingNotFoundError propagates to the global handler
+    # as HTTP 404, identical to the image path.
+    result = await use_case.match_embedding(
+        user_id=user_id,
+        embedding=probe,
+        tenant_id=tenant_id,
+    )
+
+    message = "Face verified successfully" if result.verified else "Face does not match"
+
+    return VerificationResponse(
+        verified=result.verified,
+        confidence=result.confidence,
+        distance=result.distance,
+        threshold=result.threshold,
+        message=message,
+    )
 
 
 def _pick_single_client_embedding(

--- a/app/api/schemas/enrollment.py
+++ b/app/api/schemas/enrollment.py
@@ -20,7 +20,10 @@ class EmbeddingEnrollRequest(BaseModel):
     liveness factor before trusting the enrollment.
     """
 
-    tenant_id: str = Field(..., description="Tenant identifier for multi-tenancy")
+    tenant_id: Optional[str] = Field(
+        default=None,
+        description="Optional tenant identifier for multi-tenancy",
+    )
     user_id: str = Field(..., description="User identifier to enroll")
     embedding: List[float] = Field(
         ...,

--- a/app/api/schemas/enrollment.py
+++ b/app/api/schemas/enrollment.py
@@ -1,8 +1,45 @@
 """Enrollment API schemas."""
 
-from typing import Optional
+from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+from app.api.schemas.verification import EMBEDDING_DIMENSION
+
+
+class EmbeddingEnrollRequest(BaseModel):
+    """Request body for ``POST /enroll-embedding`` (client-side embedding).
+
+    The client computed the Facenet512 embedding locally (no image leaves the
+    device) and submits the raw 512-vector to be stored as the user's template
+    via the SAME dual-column Fernet path that the image ``/enroll`` path uses
+    after it computes the embedding.
+
+    SECURITY: this path has NO image, so liveness / anti-spoof is NOT performed
+    here. The Identity Core layer (sub-projects B/C) must pair it with a
+    liveness factor before trusting the enrollment.
+    """
+
+    tenant_id: str = Field(..., description="Tenant identifier for multi-tenancy")
+    user_id: str = Field(..., description="User identifier to enroll")
+    embedding: List[float] = Field(
+        ...,
+        description=(
+            f"Precomputed {EMBEDDING_DIMENSION}-d Facenet512 embedding, "
+            "L2-normalized by the client. Must be exactly "
+            f"{EMBEDDING_DIMENSION} floats."
+        ),
+    )
+
+    @field_validator("embedding")
+    @classmethod
+    def _validate_embedding_length(cls, value: List[float]) -> List[float]:
+        if len(value) != EMBEDDING_DIMENSION:
+            raise ValueError(
+                f"embedding must have exactly {EMBEDDING_DIMENSION} elements, "
+                f"got {len(value)}"
+            )
+        return value
 
 
 class EnrollmentResponse(BaseModel):

--- a/app/api/schemas/verification.py
+++ b/app/api/schemas/verification.py
@@ -1,14 +1,56 @@
 """Verification API schemas."""
 
-from typing import Any, Optional
+from typing import Any, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+# Facenet512 embedding dimensionality. The precomputed-embedding routes accept
+# ONLY a full-length vector — a wrong length is a hard 422, never a silent
+# truncate/pad.
+EMBEDDING_DIMENSION = 512
 
 
 class VerificationRequest(BaseModel):
     """Face verification request (not used with multipart/form-data, kept for reference)."""
 
     user_id: str = Field(..., description="User identifier to verify against")
+
+
+class EmbeddingVerifyRequest(BaseModel):
+    """Request body for ``POST /verify-embedding`` (client-side embedding).
+
+    The client (browser/device) has ALREADY computed the Facenet512 embedding
+    locally — no image leaves the device — and submits the raw 512-vector. The
+    route runs ONLY the pgvector match + threshold/decision logic against the
+    user's stored template; it SKIPS detection, quality, liveness and the
+    server-side Facenet512 forward pass.
+
+    SECURITY: because there is NO image, this path performs NO liveness /
+    anti-spoof. It MUST be paired with a liveness factor (puzzle / passive)
+    enforced at the Identity Core layer (sub-projects B/C) before it is trusted
+    as a login factor.
+    """
+
+    tenant_id: str = Field(..., description="Tenant identifier for multi-tenancy")
+    user_id: str = Field(..., description="User identifier to verify against")
+    embedding: List[float] = Field(
+        ...,
+        description=(
+            f"Precomputed {EMBEDDING_DIMENSION}-d Facenet512 embedding, "
+            "L2-normalized by the client. Must be exactly "
+            f"{EMBEDDING_DIMENSION} floats."
+        ),
+    )
+
+    @field_validator("embedding")
+    @classmethod
+    def _validate_embedding_length(cls, value: List[float]) -> List[float]:
+        if len(value) != EMBEDDING_DIMENSION:
+            raise ValueError(
+                f"embedding must have exactly {EMBEDDING_DIMENSION} elements, "
+                f"got {len(value)}"
+            )
+        return value
 
 
 class VerificationResponse(BaseModel):

--- a/app/api/schemas/verification.py
+++ b/app/api/schemas/verification.py
@@ -31,7 +31,10 @@ class EmbeddingVerifyRequest(BaseModel):
     as a login factor.
     """
 
-    tenant_id: str = Field(..., description="Tenant identifier for multi-tenancy")
+    tenant_id: Optional[str] = Field(
+        default=None,
+        description="Optional tenant identifier for multi-tenancy",
+    )
     user_id: str = Field(..., description="User identifier to verify against")
     embedding: List[float] = Field(
         ...,

--- a/app/application/use_cases/enroll_face.py
+++ b/app/application/use_cases/enroll_face.py
@@ -30,6 +30,13 @@ class EnrollFaceUseCase:
     Dependencies are injected for testability (Dependency Inversion Principle).
     """
 
+    # Quality score assigned to a CLIENT-PRECOMPUTED embedding (the
+    # /enroll-embedding path), where there is no server-side image to assess.
+    # The client already gated capture quality before computing the embedding,
+    # so a precomputed template is treated as a full-confidence sample. Stored
+    # like any other enrollment via the same dual-column Fernet path.
+    PRECOMPUTED_EMBEDDING_QUALITY_SCORE = 100.0
+
     def __init__(
         self,
         detector: IFaceDetector,
@@ -125,27 +132,16 @@ class EnrollFaceUseCase:
             logger.debug("Step 4/4: Extracting embedding...")
             embedding_vector = await self._extractor.extract(face_region)
 
-            # Step 6: Save to repository
-            await self._repository.save(
+            # Steps 6-7: persist via the dual-column Fernet path + build the
+            # result entity. Shared with the client-side embedding route
+            # (/enroll-embedding) via store_embedding so the crypto-at-rest
+            # storage is written in exactly one place.
+            face_embedding = await self.store_embedding(
                 user_id=user_id,
                 embedding=embedding_vector,
                 quality_score=quality.score,
                 tenant_id=tenant_id,
-                fuse_with_existing=optimize,
-            )
-
-            # Step 7: Create and return result entity
-            face_embedding = FaceEmbedding.create_new(
-                user_id=user_id,
-                vector=embedding_vector,
-                quality_score=quality.score,
-                tenant_id=tenant_id,
-            )
-
-            logger.info(
-                f"Enrollment completed successfully for user_id={user_id}, "
-                f"quality={quality.score:.1f}, "
-                f"embedding_dim={len(embedding_vector)}"
+                optimize=optimize,
             )
 
             return face_embedding
@@ -158,3 +154,62 @@ class EnrollFaceUseCase:
                 del image
             if face_region is not None:
                 del face_region
+
+    async def store_embedding(
+        self,
+        user_id: str,
+        embedding,
+        quality_score: float,
+        tenant_id: Optional[str] = None,
+        optimize: bool = False,
+    ) -> FaceEmbedding:
+        """Persist an ALREADY-EXTRACTED embedding as the user's template.
+
+        This is the storage tail of :meth:`execute` — the dual-column Fernet
+        write (``repository.save``) plus building the returned
+        :class:`FaceEmbedding` entity — factored out so the
+        precomputed-embedding route (``/enroll-embedding``) can store a
+        client-computed vector through the EXACT same crypto-at-rest path
+        without re-detecting / re-embedding. ``execute`` calls this with the
+        freshly-extracted embedding and the assessed quality, so its behaviour
+        is unchanged.
+
+        The Fernet encryption + plaintext-vs-ciphertext dual-column handling
+        lives entirely inside ``repository.save``; this method never touches the
+        crypto directly.
+
+        Args:
+            user_id: Unique identifier for the user.
+            embedding: Embedding vector to persist.
+            quality_score: Quality score (0-100) associated with this sample.
+            tenant_id: Optional tenant identifier for multi-tenancy.
+            optimize: Forwarded as ``fuse_with_existing`` (re-enroll & optimize).
+
+        Returns:
+            FaceEmbedding entity describing the stored template.
+
+        Raises:
+            RepositoryError: When the save operation fails.
+        """
+        await self._repository.save(
+            user_id=user_id,
+            embedding=embedding,
+            quality_score=quality_score,
+            tenant_id=tenant_id,
+            fuse_with_existing=optimize,
+        )
+
+        face_embedding = FaceEmbedding.create_new(
+            user_id=user_id,
+            vector=embedding,
+            quality_score=quality_score,
+            tenant_id=tenant_id,
+        )
+
+        logger.info(
+            f"Enrollment completed successfully for user_id={user_id}, "
+            f"quality={quality_score:.1f}, "
+            f"embedding_dim={len(embedding)}"
+        )
+
+        return face_embedding

--- a/app/application/use_cases/verify_face.py
+++ b/app/application/use_cases/verify_face.py
@@ -146,21 +146,70 @@ class VerifyFaceUseCase:
         new_embedding = await self._extractor.extract(face_region)
         stage_ms["embed"] = (time.perf_counter() - t0) * 1000
 
-        # Step 6: Retrieve stored embedding
-        logger.debug("Step 5/6: Retrieving stored embedding...")
-        t0 = time.perf_counter()
+        # Steps 6-7: retrieve stored template, compute distance, resolve the
+        # (possibly adaptive aged) threshold, and decide. Shared with the
+        # client-side embedding route (/verify-embedding) via match_embedding.
+        result = await self.match_embedding(
+            user_id=user_id,
+            embedding=new_embedding,
+            tenant_id=tenant_id,
+        )
+
+        total_ms = (time.perf_counter() - t_start) * 1000
+        timing_summary = " ".join(f"{k}={v:.0f}ms" for k, v in stage_ms.items())
+        logger.info(
+            f"face/verify: {timing_summary} total={total_ms:.0f}ms "
+            f"user_id={user_id} verified={result.verified} "
+            f"distance={result.distance:.4f} confidence={result.confidence:.4f} "
+            f"threshold={result.threshold}"
+        )
+
+        return result
+
+    async def match_embedding(
+        self,
+        user_id: str,
+        embedding,
+        tenant_id: Optional[str] = None,
+    ) -> VerificationResult:
+        """Match an ALREADY-EXTRACTED embedding against the user's template.
+
+        This is the pgvector match + threshold/decision logic that
+        :meth:`execute` runs after it computes the embedding from an image,
+        factored out so the precomputed-embedding route (``/verify-embedding``)
+        can reuse the EXACT same matching, adaptive-aged-threshold and
+        confidence logic without re-detecting / re-embedding. ``execute`` calls
+        this with the freshly-extracted embedding, so its behaviour is
+        unchanged.
+
+        The ``embedding`` is compared via the injected similarity calculator,
+        which L2-normalizes both operands internally — a client-supplied
+        already-normalized vector and the stored template are therefore compared
+        consistently whether or not either is pre-normalized.
+
+        Args:
+            user_id: User identifier to verify against.
+            embedding: Probe embedding (numpy array or sequence of floats).
+            tenant_id: Optional tenant identifier for multi-tenancy.
+
+        Returns:
+            VerificationResult with the verdict, distance, threshold and the
+            threshold-anchored confidence.
+
+        Raises:
+            EmbeddingNotFoundError: When no stored embedding exists for the user.
+        """
+        # Retrieve stored embedding
         stored_embedding = await self._repository.find_by_user_id(user_id, tenant_id)
-        stage_ms["fetch"] = (time.perf_counter() - t0) * 1000
 
         if stored_embedding is None:
             logger.warning(f"No embedding found for user_id={user_id}")
             raise EmbeddingNotFoundError(user_id)
 
-        # Step 7: Calculate similarity
-        logger.debug("Step 6/6: Calculating similarity...")
-        distance = self._similarity_calculator.calculate(new_embedding, stored_embedding)
+        # Calculate similarity
+        distance = self._similarity_calculator.calculate(embedding, stored_embedding)
 
-        # Step 7: Determine threshold — use adaptive (lenient) threshold for aged embeddings
+        # Determine threshold — use adaptive (lenient) threshold for aged embeddings
         threshold = self._similarity_calculator.get_threshold()
         try:
             if hasattr(self._repository, "find_created_at"):
@@ -184,15 +233,6 @@ class VerifyFaceUseCase:
         # boundary reads ~50% and an identical match ~100% instead of the
         # misleading naive ``1 - distance``. Decision logic is unchanged.
         confidence = self._similarity_calculator.get_confidence(distance, threshold)
-
-        total_ms = (time.perf_counter() - t_start) * 1000
-        timing_summary = " ".join(f"{k}={v:.0f}ms" for k, v in stage_ms.items())
-        logger.info(
-            f"face/verify: {timing_summary} total={total_ms:.0f}ms "
-            f"user_id={user_id} verified={verified} "
-            f"distance={distance:.4f} confidence={confidence:.4f} "
-            f"threshold={threshold}"
-        )
 
         return VerificationResult(
             verified=verified,

--- a/scripts/export_facenet512_onnx.py
+++ b/scripts/export_facenet512_onnx.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Export + quantize DeepFace Facenet512 to ONNX from our pinned weights.
+
+This produces the *shippable client model* for the browser-side face-embedding
+path (compute the 512-d Facenet512 embedding in the browser via
+onnxruntime-web, upload only the vector). It is built from the SAME
+SHA-pinned weights the server already runs
+(``~/.deepface/weights/facenet512_weights.h5``) so the exported model matches
+the production DeepFace Facenet512 exactly -- no unlicensed third-party ONNX.
+
+Pipeline:
+  1. Build the DeepFace Facenet512 Keras model (loads the pinned .h5).
+  2. Export -> ONNX via tf2onnx (opset 17, input (1,160,160,3) float32 NHWC).
+  3. INT8-quantize via onnxruntime.quantization.quantize_dynamic (QInt8)
+     -> the shippable ~24 MB model.
+  4. Parity-check the quantized model vs DeepFace.represent(Facenet512) on the
+     sample faces -- cosine should stay >= ~0.99. If INT8 parity regresses
+     below --min-cos, fall back to FP16 (~47 MB) automatically.
+  5. Print the shipped model's sha256 + byte size.
+
+The model lands OUTSIDE git (default /tmp/fnet_out); the repo gitignores
+``*.onnx``. Only this script is version-controlled -- the model is a
+reproducible build artifact.
+
+Model preprocessing contract the browser must reproduce (see the spike report
+``docs/THESIS_AUDIT_2026-06-11/16_facenet_browser_spike.md``):
+  input (1,160,160,3) float32, BGR, [0,1], aspect-preserving resize +
+  centre black-pad to 160x160, normalization="base" (identity);
+  output 512-d, L2-normalize before upload.
+
+Usage:
+  python scripts/export_facenet512_onnx.py                 # INT8, parity on samples
+  python scripts/export_facenet512_onnx.py --out /models   # custom out dir
+  python scripts/export_facenet512_onnx.py --format fp16    # force FP16
+  python scripts/export_facenet512_onnx.py --no-parity      # skip parity (no faces)
+
+Requires: deepface, tensorflow(-cpu), tf2onnx, onnx, onnxruntime
+(see requirements-known-good-2026-05-29.lock). The feasibility spike used the
+isolated venv at /tmp/fnet_spike/venv which has all of these.
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import hashlib
+import os
+import sys
+import time
+
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "3")
+os.environ.setdefault("CUDA_VISIBLE_DEVICES", "-1")
+
+DEFAULT_FACES_GLOB = "/tmp/fnet_spike/faces/*.jpg"
+MIN_PARITY_COS = 0.98  # below this for INT8 -> auto-fallback to FP16
+
+
+def sha256_of(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def build_keras_model():
+    """Build the DeepFace Facenet512 Keras model (loads pinned weights)."""
+    from deepface.modules import modeling
+
+    client = modeling.build_model(
+        task="facial_recognition", model_name="Facenet512"
+    )
+    return client.model  # underlying tf.keras Model
+
+
+def export_fp32_onnx(keras_model, out_path: str) -> None:
+    """Export the Keras model to FP32 ONNX (opset 17, fixed batch=1 input)."""
+    import tensorflow as tf
+    import tf2onnx
+
+    spec = (tf.TensorSpec((1, 160, 160, 3), tf.float32, name="input"),)
+    tf2onnx.convert.from_keras(
+        keras_model, input_signature=spec, opset=17, output_path=out_path
+    )
+
+
+def quantize_int8(fp32_path: str, int8_path: str) -> None:
+    """Dynamic INT8 (QInt8) quantization via onnxruntime.quantization."""
+    from onnxruntime.quantization import QuantType, quantize_dynamic
+
+    quantize_dynamic(
+        model_input=fp32_path,
+        model_output=int8_path,
+        weight_type=QuantType.QInt8,
+    )
+
+
+def quantize_fp16(fp32_path: str, fp16_path: str) -> None:
+    """FP16 conversion. Prefer onnxconverter-common; fall back to onnxruntime
+    float16 transformer if unavailable."""
+    import onnx
+
+    model = onnx.load(fp32_path)
+    try:
+        from onnxconverter_common import float16
+
+        model_fp16 = float16.convert_float_to_float16(
+            model, keep_io_types=True
+        )
+    except ImportError:
+        from onnxruntime.transformers.float16 import convert_float_to_float16
+
+        model_fp16 = convert_float_to_float16(model, keep_io_types=True)
+    onnx.save(model_fp16, fp16_path)
+
+
+# ---------------------------------------------------------------- parity check
+def _load_faces(faces_glob: str):
+    import cv2
+
+    faces = {}
+    for f in sorted(glob.glob(faces_glob)):
+        img = cv2.imread(f)
+        if img is not None:
+            faces[os.path.basename(f).rsplit(".", 1)[0]] = img
+    return faces
+
+
+def parity_check(onnx_path: str, faces_glob: str) -> dict:
+    """Compare the ONNX model's embeddings vs DeepFace Facenet512 on sample
+    faces. Mirrors the production path: detector_backend='skip',
+    aspect-preserving resize + centre-pad to 160x160, [0,1], normalization=
+    'base' -- and feeds the model BGR (the colour order DeepFace's
+    represent() hands to Facenet512; see spike report sec.1). Returns
+    {name: cosine}.
+
+    NOTE: colour order is load-bearing. cv2.imread gives BGR and that is what
+    the model expects; converting to RGB here collapses parity to ~0.86-0.95
+    (this exact bug was in the spike's first harness). Do NOT add a
+    BGR->RGB conversion.
+    """
+    import numpy as np
+    import onnxruntime as ort
+    from deepface import DeepFace
+    from deepface.modules import preprocessing
+
+    faces = _load_faces(faces_glob)
+    if not faces:
+        print(f"[parity] no faces matched {faces_glob}; skipping parity")
+        return {}
+
+    sess = ort.InferenceSession(
+        onnx_path, providers=["CPUExecutionProvider"]
+    )
+    inp_name = sess.get_inputs()[0].name
+
+    def onnx_embed(face_bgr):
+        # feed BGR directly (production colour order), aspect-preserving
+        # resize + centre-pad to 160x160, [0,1], base-norm (identity).
+        x = preprocessing.resize_image(face_bgr, (160, 160))
+        x = preprocessing.normalize_input(x, normalization="base")
+        out = sess.run(None, {inp_name: x.astype(np.float32)})[0][0]
+        n = np.linalg.norm(out)
+        return out / n if n else out
+
+    def deepface_embed(face_bgr):
+        objs = DeepFace.represent(
+            img_path=face_bgr,
+            model_name="Facenet512",
+            detector_backend="skip",
+            enforce_detection=False,
+            align=True,
+            normalization="base",
+        )
+        e = np.array(objs[0]["embedding"], dtype=np.float32)
+        n = np.linalg.norm(e)
+        return e / n if n else e
+
+    parity = {}
+    for name, img in faces.items():
+        d = deepface_embed(img)
+        o = onnx_embed(img)
+        parity[name] = round(
+            float(np.dot(d, o) / (np.linalg.norm(d) * np.linalg.norm(o))), 5
+        )
+        print(f"[parity] {name}: cos(deepface, onnx) = {parity[name]}")
+    if parity:
+        vals = list(parity.values())
+        print(
+            f"[parity] MEAN={round(sum(vals) / len(vals), 5)} "
+            f"MIN={round(min(vals), 5)}"
+        )
+    return parity
+
+
+def report(label: str, path: str) -> None:
+    size = os.path.getsize(path)
+    print(f"\n=== SHIPPABLE MODEL ({label}) ===")
+    print(f"path   : {path}")
+    print(f"bytes  : {size} ({size / 1e6:.2f} MB)")
+    print(f"sha256 : {sha256_of(path)}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--out", default="/tmp/fnet_out",
+        help="output dir for the .onnx artifacts (default /tmp/fnet_out)",
+    )
+    ap.add_argument(
+        "--format", choices=["int8", "fp16", "fp32"], default="int8",
+        help="quantization format for the shipped model (default int8; "
+             "auto-falls back to fp16 if int8 parity < --min-cos)",
+    )
+    ap.add_argument(
+        "--faces", default=DEFAULT_FACES_GLOB,
+        help=f"glob of sample face jpgs for parity (default {DEFAULT_FACES_GLOB})",
+    )
+    ap.add_argument(
+        "--no-parity", action="store_true",
+        help="skip the DeepFace parity check (e.g. no sample faces available)",
+    )
+    ap.add_argument(
+        "--min-cos", type=float, default=MIN_PARITY_COS,
+        help=f"min acceptable INT8 parity cosine before FP16 fallback "
+             f"(default {MIN_PARITY_COS})",
+    )
+    args = ap.parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+    fp32_path = os.path.join(args.out, "facenet512.onnx")
+    int8_path = os.path.join(args.out, "facenet512_int8.onnx")
+    fp16_path = os.path.join(args.out, "facenet512_fp16.onnx")
+
+    # 1. build + 2. FP32 export (always needed as the quantization source) -----
+    t0 = time.time()
+    keras_model = build_keras_model()
+    print(
+        f"[build] Facenet512 Keras model: params={keras_model.count_params():,} "
+        f"input={keras_model.inputs[0].shape} ({time.time() - t0:.1f}s)"
+    )
+
+    t0 = time.time()
+    export_fp32_onnx(keras_model, fp32_path)
+    print(
+        f"[onnx] FP32 export OK opset17 -> {fp32_path} "
+        f"({os.path.getsize(fp32_path) / 1e6:.1f} MB, {time.time() - t0:.1f}s)"
+    )
+
+    # 3. quantize to the requested shippable format ---------------------------
+    if args.format == "fp32":
+        shipped_path, shipped_label = fp32_path, "FP32"
+    elif args.format == "fp16":
+        quantize_fp16(fp32_path, fp16_path)
+        shipped_path, shipped_label = fp16_path, "FP16"
+        print(f"[onnx] FP16 -> {fp16_path}")
+    else:  # int8
+        quantize_int8(fp32_path, int8_path)
+        shipped_path, shipped_label = int8_path, "INT8"
+        print(f"[onnx] INT8 (QInt8 dynamic) -> {int8_path}")
+
+    # 4. parity check (+ auto FP16 fallback if INT8 regresses) ----------------
+    if not args.no_parity:
+        parity = parity_check(shipped_path, args.faces)
+        if (
+            args.format == "int8"
+            and parity
+            and min(parity.values()) < args.min_cos
+        ):
+            print(
+                f"[parity] INT8 MIN={min(parity.values())} < {args.min_cos} "
+                f"-> falling back to FP16"
+            )
+            quantize_fp16(fp32_path, fp16_path)
+            shipped_path, shipped_label = fp16_path, "FP16 (INT8-fallback)"
+            print(f"[onnx] FP16 -> {fp16_path}")
+            parity_check(shipped_path, args.faces)
+
+    # 5. final report ---------------------------------------------------------
+    report(shipped_label, shipped_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/api/test_verify_embedding.py
+++ b/tests/api/test_verify_embedding.py
@@ -255,3 +255,63 @@ def test_enroll_embedding_wrong_length_is_rejected():
             user_id="user-1",
             embedding=_unit_vector(seed=1, dim=256),
         )
+
+
+# ---------------------------------------------------------------------------
+# tenant_id parity tests — tenant_id must be Optional (mirror legacy /verify)
+# ---------------------------------------------------------------------------
+
+
+def test_verify_embedding_tenant_id_optional_none():
+    """tenant_id may be omitted entirely — defaults to None without 422."""
+    req = EmbeddingVerifyRequest(user_id="user-1", embedding=_unit_vector(seed=1))
+    assert req.tenant_id is None
+
+
+def test_verify_embedding_tenant_id_optional_explicit_none():
+    """tenant_id=None is accepted explicitly."""
+    req = EmbeddingVerifyRequest(
+        tenant_id=None, user_id="user-1", embedding=_unit_vector(seed=1)
+    )
+    assert req.tenant_id is None
+
+
+def test_enroll_embedding_tenant_id_optional_none():
+    """EmbeddingEnrollRequest tenant_id may be omitted — defaults to None."""
+    req = EmbeddingEnrollRequest(user_id="user-1", embedding=_unit_vector(seed=1))
+    assert req.tenant_id is None
+
+
+@pytest.mark.asyncio
+async def test_verify_embedding_null_tenant_id_accepted():
+    """A None tenant_id on the request is forwarded to the use case (same as legacy /verify)."""
+    repo = _FakeEmbeddingRepository()
+    vec = _unit_vector(seed=5)
+    repo._store["user-5"] = np.asarray(vec, dtype=np.float32)
+
+    request = EmbeddingVerifyRequest(user_id="user-5", embedding=vec)
+    assert request.tenant_id is None
+
+    response = await verification_route.verify_embedding(
+        request=request,
+        use_case=_make_verify_use_case(repo),
+    )
+    assert response.verified is True
+
+
+@pytest.mark.asyncio
+async def test_enroll_embedding_null_tenant_id_accepted():
+    """Null tenant_id on enroll is forwarded to repository.save correctly."""
+    repo = _FakeEmbeddingRepository()
+    vec = _unit_vector(seed=6)
+
+    request = EmbeddingEnrollRequest(user_id="user-6", embedding=vec)
+    assert request.tenant_id is None
+
+    response = await enrollment_route.enroll_embedding(
+        request=request,
+        use_case=_make_enroll_use_case(repo),
+    )
+
+    assert response.success is True
+    assert repo.save_calls[0]["tenant_id"] is None

--- a/tests/api/test_verify_embedding.py
+++ b/tests/api/test_verify_embedding.py
@@ -1,0 +1,257 @@
+"""Tests for the precomputed-embedding routes (client-side embedding, Phase 4).
+
+These cover the two additive routes that let a caller submit a PRECOMPUTED
+512-d Facenet512 embedding instead of a face image:
+
+    * ``POST /verify-embedding`` (Task 4.1) — runs ONLY the pgvector match +
+      threshold/decision logic; it SKIPS detection, quality, liveness and
+      Facenet512 because the client already computed the embedding.
+    * ``POST /enroll-embedding`` (Task 4.2) — stores the client vector as the
+      user's template via the EXISTING dual-column Fernet path.
+
+The route handler coroutines are exercised directly (rather than through a full
+TestClient) — the same pattern ``tests/unit/api/test_voice_routes.py`` uses to
+avoid the asyncio loop-poisoning the integration TestClient-in-test-body suffers
+from. The shared match/store code is reused from the verify/enroll use cases, so
+these tests also prove that extracted code behaves correctly end-to-end.
+"""
+
+import numpy as np
+import pytest
+from pydantic import ValidationError as PydanticValidationError
+
+from app.api.routes import verification as verification_route
+from app.api.routes import enrollment as enrollment_route
+from app.api.schemas.verification import EmbeddingVerifyRequest
+from app.api.schemas.enrollment import EmbeddingEnrollRequest
+from app.application.use_cases.verify_face import VerifyFaceUseCase
+from app.application.use_cases.enroll_face import EnrollFaceUseCase
+from app.infrastructure.ml.similarity.cosine_similarity import CosineSimilarityCalculator
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _unit_vector(seed: int, dim: int = 512) -> list[float]:
+    """A deterministic, L2-normalized 512-vector — the client contract sends an
+    already-normalized embedding."""
+    rng = np.random.default_rng(seed)
+    v = rng.standard_normal(dim).astype(np.float32)
+    v = v / np.linalg.norm(v)
+    return v.tolist()
+
+
+class _FakeEmbeddingRepository:
+    """In-memory stand-in for the pgvector repository.
+
+    Stores the LAST embedding per (user_id) and serves it back from
+    ``find_by_user_id`` — enough to prove the enroll→verify round-trip without a
+    live PostgreSQL. The real ``save`` does the Fernet dual-column write; the
+    route under test calls ``save`` exactly as the image path does, so this fake
+    proves the WIRING (shared store/match code) rather than the crypto, which is
+    unit-tested separately against the real repository.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[str, np.ndarray] = {}
+        self.save_calls: list[dict] = []
+
+    async def save(
+        self,
+        user_id: str,
+        embedding: np.ndarray,
+        quality_score: float,
+        tenant_id=None,
+        fuse_with_existing: bool = False,
+    ) -> None:
+        self.save_calls.append(
+            {
+                "user_id": user_id,
+                "quality_score": quality_score,
+                "tenant_id": tenant_id,
+                "fuse_with_existing": fuse_with_existing,
+                "dim": len(embedding),
+            }
+        )
+        self._store[user_id] = np.asarray(embedding, dtype=np.float32)
+
+    async def find_by_user_id(self, user_id: str, tenant_id=None):
+        return self._store.get(user_id)
+
+
+def _make_verify_use_case(repository) -> VerifyFaceUseCase:
+    """A VerifyFaceUseCase with a REAL cosine calculator + the supplied repo.
+
+    Detector / extractor / quality_assessor are irrelevant to the embedding
+    match path (which skips them), so they are passed as None.
+    """
+    return VerifyFaceUseCase(
+        detector=None,
+        extractor=None,
+        similarity_calculator=CosineSimilarityCalculator(threshold=0.4),
+        repository=repository,
+        quality_assessor=None,
+    )
+
+
+def _make_enroll_use_case(repository) -> EnrollFaceUseCase:
+    return EnrollFaceUseCase(
+        detector=None,
+        extractor=None,
+        quality_assessor=None,
+        repository=repository,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 4.1 — POST /verify-embedding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_verify_embedding_matches_stored_template():
+    """Stored matching template + matching vector -> verified:true, distance<0.4."""
+    repo = _FakeEmbeddingRepository()
+    vec = _unit_vector(seed=1)
+    repo._store["user-1"] = np.asarray(vec, dtype=np.float32)
+
+    request = EmbeddingVerifyRequest(tenant_id="t1", user_id="user-1", embedding=vec)
+    response = await verification_route.verify_embedding(
+        request=request,
+        use_case=_make_verify_use_case(repo),
+    )
+
+    assert response.verified is True
+    assert response.distance < 0.4
+
+
+@pytest.mark.asyncio
+async def test_verify_embedding_rejects_non_matching_vector():
+    """A different vector -> verified:false."""
+    repo = _FakeEmbeddingRepository()
+    repo._store["user-1"] = np.asarray(_unit_vector(seed=1), dtype=np.float32)
+
+    request = EmbeddingVerifyRequest(
+        tenant_id="t1", user_id="user-1", embedding=_unit_vector(seed=999)
+    )
+    response = await verification_route.verify_embedding(
+        request=request,
+        use_case=_make_verify_use_case(repo),
+    )
+
+    assert response.verified is False
+
+
+@pytest.mark.asyncio
+async def test_verify_embedding_unknown_user_is_not_found():
+    """No stored template -> EmbeddingNotFoundError (mapped to HTTP 404)."""
+    from app.domain.exceptions.verification_errors import EmbeddingNotFoundError
+
+    repo = _FakeEmbeddingRepository()
+    request = EmbeddingVerifyRequest(
+        tenant_id="t1", user_id="nobody", embedding=_unit_vector(seed=1)
+    )
+
+    with pytest.raises(EmbeddingNotFoundError):
+        await verification_route.verify_embedding(
+            request=request,
+            use_case=_make_verify_use_case(repo),
+        )
+
+
+def test_verify_embedding_wrong_length_is_rejected():
+    """Wrong length (256 floats) -> schema validation error (HTTP 422)."""
+    with pytest.raises(PydanticValidationError):
+        EmbeddingVerifyRequest(
+            tenant_id="t1",
+            user_id="user-1",
+            embedding=_unit_vector(seed=1, dim=256),
+        )
+
+
+def test_verify_embedding_correct_length_is_accepted():
+    """A 512-vector validates cleanly."""
+    req = EmbeddingVerifyRequest(
+        tenant_id="t1", user_id="user-1", embedding=_unit_vector(seed=1)
+    )
+    assert len(req.embedding) == 512
+
+
+# ---------------------------------------------------------------------------
+# Task 4.2 — POST /enroll-embedding + round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enroll_embedding_stores_template_via_repository_save():
+    """The client vector is stored through the same repository.save path."""
+    repo = _FakeEmbeddingRepository()
+    vec = _unit_vector(seed=7)
+
+    request = EmbeddingEnrollRequest(tenant_id="t1", user_id="user-7", embedding=vec)
+    response = await enrollment_route.enroll_embedding(
+        request=request,
+        use_case=_make_enroll_use_case(repo),
+    )
+
+    assert response.success is True
+    assert response.user_id == "user-7"
+    assert response.embedding_dimension == 512
+    assert len(repo.save_calls) == 1
+    assert repo.save_calls[0]["user_id"] == "user-7"
+    assert repo.save_calls[0]["tenant_id"] == "t1"
+    assert repo.save_calls[0]["dim"] == 512
+
+
+@pytest.mark.asyncio
+async def test_enroll_then_verify_roundtrip_same_vector_matches():
+    """enroll a vector, then /verify-embedding with the SAME vector -> verified, distance~0."""
+    repo = _FakeEmbeddingRepository()
+    vec = _unit_vector(seed=42)
+
+    await enrollment_route.enroll_embedding(
+        request=EmbeddingEnrollRequest(tenant_id="t1", user_id="rt", embedding=vec),
+        use_case=_make_enroll_use_case(repo),
+    )
+
+    response = await verification_route.verify_embedding(
+        request=EmbeddingVerifyRequest(tenant_id="t1", user_id="rt", embedding=vec),
+        use_case=_make_verify_use_case(repo),
+    )
+
+    assert response.verified is True
+    assert response.distance == pytest.approx(0.0, abs=1e-5)
+
+
+@pytest.mark.asyncio
+async def test_enroll_then_verify_roundtrip_different_vector_rejected():
+    """enroll one vector, verify a DIFFERENT vector -> verified:false."""
+    repo = _FakeEmbeddingRepository()
+
+    await enrollment_route.enroll_embedding(
+        request=EmbeddingEnrollRequest(
+            tenant_id="t1", user_id="rt2", embedding=_unit_vector(seed=42)
+        ),
+        use_case=_make_enroll_use_case(repo),
+    )
+
+    response = await verification_route.verify_embedding(
+        request=EmbeddingVerifyRequest(
+            tenant_id="t1", user_id="rt2", embedding=_unit_vector(seed=12345)
+        ),
+        use_case=_make_verify_use_case(repo),
+    )
+
+    assert response.verified is False
+
+
+def test_enroll_embedding_wrong_length_is_rejected():
+    """Wrong length on enroll -> schema validation error (HTTP 422)."""
+    with pytest.raises(PydanticValidationError):
+        EmbeddingEnrollRequest(
+            tenant_id="t1",
+            user_id="user-1",
+            embedding=_unit_vector(seed=1, dim=256),
+        )


### PR DESCRIPTION
Additive internal endpoints that accept a precomputed 512-d L2-normalized vector and run only the pgvector match / template store (no MTCNN/quality/liveness/Facenet512); reuse the existing match + Fernet storage; NO liveness on this path — requires a paired liveness factor at Identity Core; default behavior unchanged.

- `POST /verify-embedding`: accepts a client-computed Facenet512 512-vector, runs only the pgvector match + adaptive-aged-threshold + confidence logic via the extracted `VerifyFaceUseCase.match_embedding` method; no image/liveness/anti-spoof
- `POST /enroll-embedding`: stores a client-computed vector as the user template via the existing Fernet dual-column path (`EnrollFaceUseCase.store_embedding`); no image/liveness
- `tenant_id` is Optional on both schemas, matching the legacy `/verify` and `/enroll` routes (Form(None)) — a null tenant is forwarded identically
- Includes ONNX export script for shipping Facenet512 weights to the browser
- No existing route changed; existing tests unaffected