### PR TITLE
feat(api): server-issued single-use puzzle session (liveness, anti-replay)

### DIFF
--- a/app/api/routes/puzzle.py
+++ b/app/api/routes/puzzle.py
@@ -8,6 +8,7 @@ This module provides endpoints for the liveness puzzle challenge-response system
 
 import logging
 import time
+from functools import lru_cache
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Header
@@ -20,10 +21,20 @@ from app.api.schemas.puzzle import (
     VerifyPuzzleResponse,
 )
 from app.api.schemas.active_liveness import ChallengeType
+from app.api.schemas.puzzle_session import (
+    IssuedChallenge,
+    PuzzleSessionChallengeRequest,
+    PuzzleSessionChallengeResponse,
+    PuzzleSessionCreateRequest,
+    PuzzleSessionCreateResponse,
+    PuzzleSessionVerdictRequest,
+    PuzzleSessionVerdictResponse,
+)
 from app.api.schemas.single_challenge import (
     VerifyChallengeRequest,
     VerifyChallengeResponse,
 )
+from app.application.services.puzzle_session_manager import PuzzleSessionManager
 from app.application.use_cases.generate_puzzle import GeneratePuzzleUseCase
 from app.application.use_cases.verify_puzzle import VerifyPuzzleUseCase
 from app.core.container import get_generate_puzzle_use_case, get_verify_puzzle_use_case
@@ -31,6 +42,22 @@ from app.core.container import get_generate_puzzle_use_case, get_verify_puzzle_u
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/liveness", tags=["Liveness Puzzle"])
+
+
+# ---------------------------------------------------------------------------
+# Process-wide puzzle session store (CV-1).
+#
+# The auth puzzle session is intentionally in-process + ephemeral (like the
+# other liveness sessions). A single ``PuzzleSessionManager`` is shared across
+# all three routes via this lru_cache singleton so a session created on the
+# CREATE route is visible to the SUBMIT + VERDICT routes in the same process.
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def get_puzzle_session_manager() -> PuzzleSessionManager:
+    """Return the process-wide puzzle session manager (singleton)."""
+    return PuzzleSessionManager()
 
 
 @router.post(
@@ -584,3 +611,139 @@ async def verify_challenge(
         reason_code=None,
         message="Challenge verified.",
     )
+
+
+# ---------------------------------------------------------------------------
+# CV-1 (2026-06-12) — server-issued, single-use, anti-replay puzzle SESSION.
+#
+# Replaces the stateless ``/verify-challenge`` trust model for the AUTH path.
+# Additive: ``/verify-challenge`` stays as the (stateless) training surface.
+#
+# bio has no public route — identity-core-api proxies these with X-API-Key.
+# Contract: docs/superpowers/plans/2026-06-12-puzzle-session-convergence.md.
+# Session semantics live in PuzzleSessionManager (server-randomized challenges,
+# unguessable token_urlsafe id, 5-minute TTL, single-use consume on verdict,
+# owner-bound to user_id+tenant_id). The session spans BOTH the 14 face and
+# 9 hand challenge types; per-challenge scoring is the shared metric scorer.
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/puzzle-session",
+    response_model=PuzzleSessionCreateResponse,
+    summary="Create a server-issued puzzle session (auth path)",
+    description=(
+        "Randomly selects `count` challenges from `allowed_challenge_types` "
+        "(server-randomized per attempt), creates a single-use, short-TTL "
+        "session bound to user_id+tenant_id, and returns an opaque session_id "
+        "plus the issued challenges. The session spans both face and hand "
+        "challenge types."
+    ),
+    responses={
+        200: {"description": "Session created."},
+        400: {"description": "Invalid request (empty allowed types / bad count)."},
+    },
+)
+async def create_puzzle_session(
+    request: PuzzleSessionCreateRequest,
+    manager: PuzzleSessionManager = Depends(get_puzzle_session_manager),
+) -> PuzzleSessionCreateResponse:
+    """Create a server-randomized, single-use puzzle session."""
+    try:
+        session = manager.create_session(
+            user_id=request.user_id,
+            tenant_id=request.tenant_id,
+            allowed_challenge_types=list(request.allowed_challenge_types),
+            count=request.count,
+            difficulty=request.difficulty,
+        )
+    except ValueError as exc:
+        logger.warning("create_puzzle_session rejected: %s", exc)
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    return PuzzleSessionCreateResponse(
+        session_id=session.session_id,
+        challenges=[
+            IssuedChallenge(
+                action=c.action,
+                params=(c.params or None),
+            )
+            for c in session.challenges
+        ],
+    )
+
+
+@router.post(
+    "/puzzle-session/{session_id}/challenge",
+    response_model=PuzzleSessionChallengeResponse,
+    summary="Submit one challenge's traces to a puzzle session (per-challenge UX)",
+    description=(
+        "Scores the submitted traces against an ISSUED, not-yet-completed "
+        "challenge in the session. Metric is REQUIRED on this path "
+        "(absent/empty metrics → verified=false, METRIC_REQUIRED). On success "
+        "the challenge is marked complete. This is per-challenge UX feedback, "
+        "NOT the auth gate (that is /verdict)."
+    ),
+    responses={
+        200: {"description": "Per-challenge verdict returned."},
+        404: {"description": "Unknown or expired session."},
+    },
+)
+async def submit_puzzle_challenge(
+    session_id: str,
+    request: PuzzleSessionChallengeRequest,
+    manager: PuzzleSessionManager = Depends(get_puzzle_session_manager),
+) -> PuzzleSessionChallengeResponse:
+    """Score one challenge against the issued session."""
+    verified, reason_code = manager.submit_challenge(
+        session_id,
+        action=request.action,
+        metrics=request.metrics,
+        start_timestamp_ms=request.start_timestamp_ms,
+        end_timestamp_ms=request.end_timestamp_ms,
+        confidence=request.confidence,
+    )
+
+    # Unknown / expired session → 404 (the session id is opaque + ephemeral).
+    if reason_code in ("SESSION_NOT_FOUND", "SESSION_EXPIRED", "SESSION_CONSUMED"):
+        raise HTTPException(status_code=404, detail=reason_code)
+
+    return PuzzleSessionChallengeResponse(
+        verified=verified,
+        action=request.action,
+        reason_code=reason_code,
+    )
+
+
+@router.post(
+    "/puzzle-session/{session_id}/verdict",
+    response_model=PuzzleSessionVerdictResponse,
+    summary="Consume a puzzle session and return the authoritative verdict",
+    description=(
+        "The AUTH GATE. Returns verified=true iff ALL issued challenges were "
+        "validated AND the session owner matches user_id+tenant_id AND the "
+        "session is not expired AND not already consumed. CONSUMES the session "
+        "(single-use). Anything else → verified=false; unknown/expired → 404."
+    ),
+    responses={
+        200: {"description": "Verdict returned; session consumed."},
+        404: {"description": "Unknown or expired session."},
+    },
+)
+async def puzzle_session_verdict(
+    session_id: str,
+    request: PuzzleSessionVerdictRequest,
+    manager: PuzzleSessionManager = Depends(get_puzzle_session_manager),
+) -> PuzzleSessionVerdictResponse:
+    """Return the authoritative verdict and consume the session (single-use)."""
+    verified, reason_code = manager.verdict(
+        session_id,
+        user_id=request.user_id,
+        tenant_id=request.tenant_id,
+    )
+
+    # Unknown / expired session → 404 (an already-consumed id is also gone).
+    if reason_code in ("SESSION_NOT_FOUND", "SESSION_EXPIRED"):
+        raise HTTPException(status_code=404, detail=reason_code)
+
+    return PuzzleSessionVerdictResponse(verified=verified)

--- a/app/api/routes/puzzle.py
+++ b/app/api/routes/puzzle.py
@@ -3,6 +3,7 @@
 This module provides endpoints for the liveness puzzle challenge-response system:
 - POST /liveness/generate-puzzle: Generate a new liveness puzzle
 - POST /liveness/verify: Verify puzzle completion
+- POST /liveness/verify-challenge: Single-challenge structural validation (web training surface)
 """
 
 import logging
@@ -18,6 +19,7 @@ from app.api.schemas.puzzle import (
     VerifyPuzzleRequest,
     VerifyPuzzleResponse,
 )
+from app.api.schemas.active_liveness import ChallengeType
 from app.api.schemas.single_challenge import (
     VerifyChallengeRequest,
     VerifyChallengeResponse,
@@ -308,6 +310,177 @@ _MAX_CHALLENGE_DURATION_S = 60.0
 # detected-pass threshold of 0.5).
 _MIN_CHALLENGE_CONFIDENCE = 0.5
 
+# ---------------------------------------------------------------------------
+# Per-action metric thresholds for the 8 new face challenges.
+#
+# The web client sends an optional ``metrics`` dict alongside each submission.
+# For face actions that report a primary metric, the server applies a
+# plausibility gate: if the metric is present AND its value is implausibly
+# weak (indicating the gesture was not actually performed), the submission is
+# rejected with an action-specific reason_code.
+#
+# The metric gate is OPTIONAL — absent metrics are not penalised (the client
+# may omit them for back-compat). The gate only fires when the client does
+# supply the metric.
+#
+# Thresholds and their derivation:
+#
+#   EAR-based (CLOSE_LEFT_EYE / CLOSE_RIGHT_EYE):
+#     Mirrors active_liveness_manager.py ``blink_threshold=0.21``.  A closed
+#     single eye has EAR ≤ 0.21; anything above that is "eye open".
+#     Metric key: ``ear``  (float, 0..1, lower = more closed).
+#
+#   Pitch-based (LOOK_UP / LOOK_DOWN):
+#     live_session_baseline_calibrator.py treats |pitch| > 10° as
+#     non-neutral. We require |pitch| ≥ 10° for a confirmed look gesture.
+#     LOOK_UP = negative pitch (face tilts up, landmark y decreases in
+#     image coords); LOOK_DOWN = positive pitch.
+#     Metric key: ``pitch``  (float, degrees; positive = down).
+#
+#   Brow-raise-based (RAISE_LEFT_BROW / RAISE_RIGHT_BROW):
+#     Mirrors active_liveness_manager.py ``eyebrow_threshold=0.08``
+#     (brow–eye vertical distance in normalised coords).
+#     Metric key: ``brow_raise``  (float, 0..1+, higher = more raised).
+#
+#   Oscillation-based (NOD / SHAKE_HEAD):
+#     A real nod/shake requires at least 2 direction reversals (1 full
+#     cycle = forward+back).  The client counts reversals and sends
+#     ``oscillation_count``.  Floor = 2 (conservative: matches the
+#     wave-gesture minimum in the gesture manager).
+#     Metric key: ``oscillation_count``  (int ≥ 0).
+# ---------------------------------------------------------------------------
+
+# EAR ≤ this → eye is closed enough to confirm the gesture.
+_EYE_CLOSE_EAR_MAX: float = 0.21
+
+# |pitch| ≥ this (degrees) → head is tilted enough to confirm look gesture.
+_HEAD_PITCH_MIN_DEG: float = 10.0
+
+# Brow-raise metric ≥ this → brow raise confirmed.
+# Mirrors eyebrow_threshold from ActiveLivenessManager (0.08 normalised units).
+_BROW_RAISE_MIN: float = 0.08
+
+# Minimum oscillation cycles for nod / shake.
+_OSCILLATION_MIN: int = 2
+
+
+def _check_action_metrics(
+    request: VerifyChallengeRequest,
+    duration_s: float,
+) -> Optional[VerifyChallengeResponse]:
+    """Return a rejection response if action-specific metrics fail plausibility.
+
+    Returns ``None`` when the submission passes (or metrics are absent).
+    The gate is only active for the 8 new face challenges; all other actions
+    fall through unchanged.
+    """
+    action = request.action
+    metrics = request.metrics
+
+    if action == ChallengeType.CLOSE_LEFT_EYE:
+        ear = metrics.get("ear")
+        if ear is not None and float(ear) > _EYE_CLOSE_EAR_MAX:
+            logger.info(
+                "verify-challenge rejected: eye_not_closed action=%s ear=%.3f threshold=%.2f",
+                action.value,
+                ear,
+                _EYE_CLOSE_EAR_MAX,
+            )
+            return VerifyChallengeResponse(
+                verified=False,
+                action=action,
+                duration_seconds=duration_s,
+                reason_code="EYE_NOT_CLOSED",
+                message="Left eye EAR above the closed-eye threshold.",
+            )
+
+    elif action == ChallengeType.CLOSE_RIGHT_EYE:
+        ear = metrics.get("ear")
+        if ear is not None and float(ear) > _EYE_CLOSE_EAR_MAX:
+            logger.info(
+                "verify-challenge rejected: eye_not_closed action=%s ear=%.3f threshold=%.2f",
+                action.value,
+                ear,
+                _EYE_CLOSE_EAR_MAX,
+            )
+            return VerifyChallengeResponse(
+                verified=False,
+                action=action,
+                duration_seconds=duration_s,
+                reason_code="EYE_NOT_CLOSED",
+                message="Right eye EAR above the closed-eye threshold.",
+            )
+
+    elif action == ChallengeType.LOOK_UP:
+        pitch = metrics.get("pitch")
+        if pitch is not None and float(pitch) > -_HEAD_PITCH_MIN_DEG:
+            logger.info(
+                "verify-challenge rejected: insufficient_pitch action=%s pitch=%.1f min=%.1f",
+                action.value,
+                pitch,
+                -_HEAD_PITCH_MIN_DEG,
+            )
+            return VerifyChallengeResponse(
+                verified=False,
+                action=action,
+                duration_seconds=duration_s,
+                reason_code="INSUFFICIENT_HEAD_PITCH",
+                message="Head pitch does not confirm a look-up gesture.",
+            )
+
+    elif action == ChallengeType.LOOK_DOWN:
+        pitch = metrics.get("pitch")
+        if pitch is not None and float(pitch) < _HEAD_PITCH_MIN_DEG:
+            logger.info(
+                "verify-challenge rejected: insufficient_pitch action=%s pitch=%.1f min=%.1f",
+                action.value,
+                pitch,
+                _HEAD_PITCH_MIN_DEG,
+            )
+            return VerifyChallengeResponse(
+                verified=False,
+                action=action,
+                duration_seconds=duration_s,
+                reason_code="INSUFFICIENT_HEAD_PITCH",
+                message="Head pitch does not confirm a look-down gesture.",
+            )
+
+    elif action in (ChallengeType.RAISE_LEFT_BROW, ChallengeType.RAISE_RIGHT_BROW):
+        brow_raise = metrics.get("brow_raise")
+        if brow_raise is not None and float(brow_raise) < _BROW_RAISE_MIN:
+            logger.info(
+                "verify-challenge rejected: brow_not_raised action=%s brow_raise=%.3f min=%.3f",
+                action.value,
+                brow_raise,
+                _BROW_RAISE_MIN,
+            )
+            return VerifyChallengeResponse(
+                verified=False,
+                action=action,
+                duration_seconds=duration_s,
+                reason_code="BROW_NOT_RAISED",
+                message="Brow-raise metric below the acceptance threshold.",
+            )
+
+    elif action in (ChallengeType.NOD, ChallengeType.SHAKE_HEAD):
+        osc = metrics.get("oscillation_count")
+        if osc is not None and int(osc) < _OSCILLATION_MIN:
+            logger.info(
+                "verify-challenge rejected: insufficient_oscillation action=%s osc=%d min=%d",
+                action.value,
+                int(osc),
+                _OSCILLATION_MIN,
+            )
+            return VerifyChallengeResponse(
+                verified=False,
+                action=action,
+                duration_seconds=duration_s,
+                reason_code="INSUFFICIENT_OSCILLATION",
+                message="Head oscillation count below the minimum for this gesture.",
+            )
+
+    return None
+
 
 @router.post(
     "/verify-challenge",
@@ -389,6 +562,11 @@ async def verify_challenge(
             reason_code="CONFIDENCE_BELOW_FLOOR",
             message="Detection confidence is below the acceptance floor.",
         )
+
+    # 4. Action-specific metric plausibility gate (new face challenges).
+    metric_rejection = _check_action_metrics(request, duration_s)
+    if metric_rejection is not None:
+        return metric_rejection
 
     logger.info(
         "verify-challenge accepted: action=%s tenant=%s user=%s "

--- a/app/api/schemas/active_liveness.py
+++ b/app/api/schemas/active_liveness.py
@@ -9,8 +9,10 @@ from pydantic import BaseModel, Field
 class ChallengeType(str, Enum):
     """Types of liveness challenges.
 
-    Face-modality values (``BLINK`` … ``RAISE_EYEBROWS``) are scored by
-    ``ActiveLivenessManager`` against MediaPipe face landmarks.
+    Face-modality values (``BLINK`` … ``SHAKE_HEAD``) are scored by
+    ``ActiveLivenessManager`` against MediaPipe face landmarks (session-based)
+    or validated structurally by the ``/liveness/verify-challenge`` endpoint
+    (web puzzle surface, single-shot).
     Gesture-modality values (``FINGER_COUNT`` … ``HOLD_POSITION``) are scored
     by ``ActiveGestureLivenessManager`` against client-supplied hand landmarks.
     Mirror of ``GestureChallengeType`` in ``app.api.schemas.gesture_liveness``;
@@ -25,6 +27,15 @@ class ChallengeType(str, Enum):
     TURN_RIGHT = "turn_right"
     OPEN_MOUTH = "open_mouth"
     RAISE_EYEBROWS = "raise_eyebrows"
+    # Face modality — single-eye and head-motion challenges (web puzzle surface).
+    CLOSE_LEFT_EYE = "close_left_eye"
+    CLOSE_RIGHT_EYE = "close_right_eye"
+    LOOK_UP = "look_up"
+    LOOK_DOWN = "look_down"
+    RAISE_LEFT_BROW = "raise_left_brow"
+    RAISE_RIGHT_BROW = "raise_right_brow"
+    NOD = "nod"
+    SHAKE_HEAD = "shake_head"
     # Gesture modality (server-side verifies landmarks-only; no ML inference).
     FINGER_COUNT = "finger_count"
     SHAPE_TRACE = "shape_trace"

--- a/app/api/schemas/puzzle_session.py
+++ b/app/api/schemas/puzzle_session.py
@@ -1,0 +1,138 @@
+"""Schemas for the server-issued, single-use, anti-replay puzzle SESSION.
+
+CV-1 of the puzzle-as-login convergence
+(docs/superpowers/plans/2026-06-12-puzzle-session-convergence.md).
+
+Three routes, snake_case JSON exactly as the canonical contract specifies:
+
+  POST /api/v1/liveness/puzzle-session
+    req:  PuzzleSessionCreateRequest  {tenant_id, user_id, allowed_challenge_types, count, difficulty?}
+    resp: PuzzleSessionCreateResponse {session_id, challenges:[{action, params?}]}
+
+  POST /api/v1/liveness/puzzle-session/{session_id}/challenge
+    req:  PuzzleSessionChallengeRequest  {action, metrics, start_timestamp_ms, end_timestamp_ms, confidence}
+    resp: PuzzleSessionChallengeResponse {verified, action, reason_code?}
+
+  POST /api/v1/liveness/puzzle-session/{session_id}/verdict
+    req:  PuzzleSessionVerdictRequest  {user_id, tenant_id}
+    resp: PuzzleSessionVerdictResponse {verified}
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from app.api.schemas.active_liveness import ChallengeType
+
+
+class PuzzleSessionCreateRequest(BaseModel):
+    """CREATE — start of the PUZZLE step (identity → bio, X-API-Key)."""
+
+    tenant_id: str = Field(..., description="Owning tenant; binds the session.")
+    user_id: str = Field(..., description="Owning user; binds the session.")
+    allowed_challenge_types: List[ChallengeType] = Field(
+        ...,
+        min_length=1,
+        description=(
+            "The challenge types the server may choose from. May mix face and "
+            "hand types; the server randomly selects `count` of them."
+        ),
+    )
+    count: int = Field(
+        ..., ge=1, le=10, description="How many challenges to issue (server-randomized)."
+    )
+    difficulty: Optional[str] = Field(
+        default=None, description="Optional difficulty hint (easy|standard|hard)."
+    )
+
+
+class IssuedChallenge(BaseModel):
+    """One server-issued challenge returned to the client."""
+
+    action: ChallengeType = Field(..., description="The challenge action to perform.")
+    params: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Optional server-issued parameters for the action (e.g. "
+            "{'target': 3} for finger_count). Absent when the action takes none."
+        ),
+    )
+
+
+class PuzzleSessionCreateResponse(BaseModel):
+    """CREATE response — opaque session id + the server-issued challenges."""
+
+    session_id: str = Field(..., description="Unguessable, single-use, short-TTL token.")
+    challenges: List[IssuedChallenge] = Field(
+        ..., description="The server-randomized challenges to present, in order."
+    )
+
+
+class PuzzleSessionChallengeRequest(BaseModel):
+    """SUBMIT one challenge's traces for scoring (metric REQUIRED)."""
+
+    action: ChallengeType = Field(..., description="The completed challenge action.")
+    metrics: Dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Client-computed metric payload for the action (REQUIRED on this "
+            "path; absent/empty → verified=false with reason METRIC_REQUIRED)."
+        ),
+    )
+    start_timestamp_ms: float = Field(
+        ..., gt=0, description="Client clock when the challenge started."
+    )
+    end_timestamp_ms: float = Field(
+        ..., gt=0, description="Client clock when the challenge completed."
+    )
+    confidence: float = Field(
+        ..., ge=0.0, le=1.0, description="Client detection confidence [0..1]."
+    )
+
+
+class PuzzleSessionChallengeResponse(BaseModel):
+    """SUBMIT verdict for one challenge (per-challenge UX feedback, not the gate)."""
+
+    verified: bool = Field(..., description="Whether this challenge passed.")
+    action: ChallengeType = Field(..., description="The echoed challenge action.")
+    reason_code: Optional[str] = Field(
+        default=None,
+        description=(
+            "Failure category when verified=false (METRIC_REQUIRED, "
+            "ACTION_NOT_ISSUED, ALREADY_COMPLETED, TIMESTAMPS_OUT_OF_ORDER, "
+            "CONFIDENCE_BELOW_FLOOR, or an action-specific metric reason)."
+        ),
+    )
+
+
+class PuzzleSessionVerdictRequest(BaseModel):
+    """VERDICT — the auth gate. Client sends ONLY owner identity."""
+
+    user_id: str = Field(..., description="Requesting user; must match the session owner.")
+    tenant_id: str = Field(..., description="Requesting tenant; must match the session owner.")
+
+
+class PuzzleSessionVerdictResponse(BaseModel):
+    """VERDICT result — authoritative pass/fail. Session is consumed on this call."""
+
+    verified: bool = Field(
+        ...,
+        description=(
+            "True iff all issued challenges validated AND owner matches AND not "
+            "expired AND not already consumed. The session is single-use: a "
+            "second verdict call returns false."
+        ),
+    )
+
+
+__all__ = [
+    "PuzzleSessionCreateRequest",
+    "PuzzleSessionCreateResponse",
+    "IssuedChallenge",
+    "PuzzleSessionChallengeRequest",
+    "PuzzleSessionChallengeResponse",
+    "PuzzleSessionVerdictRequest",
+    "PuzzleSessionVerdictResponse",
+]

--- a/app/application/services/challenge_metric_scorer.py
+++ b/app/application/services/challenge_metric_scorer.py
@@ -1,0 +1,314 @@
+"""Metric-based challenge scoring (face + hand), shared by the puzzle paths.
+
+Single source of truth for the per-action plausibility gates used by BOTH:
+
+  * the stateless ``POST /liveness/verify-challenge`` training surface
+    (face metrics only, metric-OPTIONAL — absent metric passes for back-compat); and
+  * the server-issued, anti-replay ``POST /liveness/puzzle-session/{id}/challenge``
+    auth path (face + hand, metric-REQUIRED — absent/empty metric fails, closing the
+    "structural-only passes" hole).
+
+The client computes the per-action metric locally (MediaPipe FaceMesh for the 14
+face challenges; MediaPipe Hands for the 9 hand challenges) and submits a small
+scalar payload. The server applies a deterministic threshold gate. No frame
+streaming, no ML inference on the server — the gate mirrors the thresholds the
+session-based detectors use:
+
+  Face (mirrors ``ActiveLivenessManager`` / ``LiveSessionBaselineCalibrator``):
+    blink / close_left_eye / close_right_eye   ear            ≤ 0.21
+    smile                                       mar            ≥ 0.40
+    open_mouth                                  mar            ≥ 0.50
+    raise_eyebrows / raise_left_brow /          brow_raise     ≥ 0.08
+      raise_right_brow
+    turn_left                                   yaw            ≤ -15.0°
+    turn_right                                  yaw            ≥ +15.0°
+    look_up                                     pitch          ≤ -10.0°
+    look_down                                   pitch          ≥ +10.0°
+    nod / shake_head                            oscillation_count ≥ 2
+    light                                       brightness_delta  ≥ 0.05
+
+  Hand (mirrors ``ActiveGestureLivenessManager`` thresholds):
+    finger_count / math                         finger_count    == target (in params)
+    wave                                         reversals       ≥ 2
+    hand_flip                                    orientation_changes ≥ 1
+    finger_tap                                   tap_dist_scaled ≤ 0.08
+    pinch                                        pinch_dist_scaled ≤ 0.12
+    hold_position                                wrist_variance  ≤ 2e-3
+    shape_trace                                  dtw_cost        ≤ 0.25
+    peek_a_boo                                   covered_then_revealed == True
+
+The gate returns ``None`` on pass, or a ``(reason_code, message)`` tuple on
+failure. The puzzle path additionally treats an absent metric as a failure
+(``METRIC_REQUIRED``); the verify-challenge path passes through absent metrics.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple
+
+from app.api.schemas.active_liveness import ChallengeType
+
+# ---------------------------------------------------------------------------
+# Face thresholds (mirror ActiveLivenessManager / verify-challenge / calibrator)
+# ---------------------------------------------------------------------------
+
+# EAR ≤ this → eye closed enough (blink_threshold=0.21).
+_EYE_CLOSE_EAR_MAX: float = 0.21
+# MAR ≥ this → smile/mouth-open confirmed.
+_SMILE_MAR_MIN: float = 0.40
+_OPEN_MOUTH_MAR_MIN: float = 0.50
+# Brow-raise metric ≥ this → confirmed (eyebrow_threshold=0.08).
+_BROW_RAISE_MIN: float = 0.08
+# |yaw| ≥ this (degrees) → head turn confirmed.
+_HEAD_YAW_MIN_DEG: float = 15.0
+# |pitch| ≥ this (degrees) → head look up/down confirmed.
+_HEAD_PITCH_MIN_DEG: float = 10.0
+# Minimum oscillation cycles for nod / shake.
+_OSCILLATION_MIN: int = 2
+# Brightness delta ≥ this → the screen flash was observed (LIGHT challenge).
+_LIGHT_BRIGHTNESS_DELTA_MIN: float = 0.05
+
+# ---------------------------------------------------------------------------
+# Hand thresholds (mirror ActiveGestureLivenessManager defaults)
+# ---------------------------------------------------------------------------
+
+_WAVE_MIN_REVERSALS: int = 2
+_HAND_FLIP_MIN_ORIENT_CHANGES: int = 1
+_FINGER_TAP_MAX_DIST_SCALED: float = 0.08
+_PINCH_MAX_DIST_SCALED: float = 0.12
+_HOLD_MAX_VARIANCE: float = 2e-3
+_DTW_COST_MAX: float = 0.25
+
+
+# Metric key documentation, exposed so route schemas / docs / tests can refer to
+# the canonical key per action without duplicating string literals.
+ACTION_METRIC_KEY: Dict[ChallengeType, str] = {
+    ChallengeType.BLINK: "ear",
+    ChallengeType.CLOSE_LEFT_EYE: "ear",
+    ChallengeType.CLOSE_RIGHT_EYE: "ear",
+    ChallengeType.SMILE: "mar",
+    ChallengeType.OPEN_MOUTH: "mar",
+    ChallengeType.RAISE_EYEBROWS: "brow_raise",
+    ChallengeType.RAISE_LEFT_BROW: "brow_raise",
+    ChallengeType.RAISE_RIGHT_BROW: "brow_raise",
+    ChallengeType.TURN_LEFT: "yaw",
+    ChallengeType.TURN_RIGHT: "yaw",
+    ChallengeType.LOOK_UP: "pitch",
+    ChallengeType.LOOK_DOWN: "pitch",
+    ChallengeType.NOD: "oscillation_count",
+    ChallengeType.SHAKE_HEAD: "oscillation_count",
+    ChallengeType.LIGHT: "brightness_delta",
+    ChallengeType.FINGER_COUNT: "finger_count",
+    ChallengeType.MATH: "finger_count",
+    ChallengeType.WAVE: "reversals",
+    ChallengeType.HAND_FLIP: "orientation_changes",
+    ChallengeType.FINGER_TAP: "tap_dist_scaled",
+    ChallengeType.PINCH: "pinch_dist_scaled",
+    ChallengeType.HOLD_POSITION: "wrist_variance",
+    ChallengeType.SHAPE_TRACE: "dtw_cost",
+    ChallengeType.PEEK_A_BOO: "covered_then_revealed",
+}
+
+
+def _to_float(value: Any) -> Optional[float]:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_int(value: Any) -> Optional[int]:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def score_action_metrics(
+    action: ChallengeType,
+    metrics: Dict[str, Any],
+    params: Optional[Dict[str, Any]] = None,
+) -> Optional[Tuple[str, str]]:
+    """Apply the per-action metric plausibility gate.
+
+    Args:
+        action: The challenge action being scored.
+        metrics: Client-computed metric payload (one scalar per action).
+        params: Challenge params issued by the server (e.g. ``target`` for
+            finger_count). Optional; only finger_count / math consult it.
+
+    Returns:
+        ``None`` if the metric is present AND plausible for the action.
+        A ``(reason_code, message)`` tuple if the supplied metric is implausible.
+        For actions with no registered metric gate, returns ``None`` (pass).
+
+    Note:
+        This function does NOT decide whether an absent metric is acceptable —
+        a missing metric returns ``None`` here so the verify-challenge path can
+        keep its metric-OPTIONAL behaviour. The puzzle path enforces
+        metric-required separately (via :func:`metric_is_present`).
+    """
+    params = params or {}
+
+    # --- Face: eye-closure (EAR ≤ max) ---
+    if action in (
+        ChallengeType.BLINK,
+        ChallengeType.CLOSE_LEFT_EYE,
+        ChallengeType.CLOSE_RIGHT_EYE,
+    ):
+        ear = _to_float(metrics.get("ear"))
+        if ear is not None and ear > _EYE_CLOSE_EAR_MAX:
+            return ("EYE_NOT_CLOSED", "Eye EAR is above the closed-eye threshold.")
+        return None
+
+    # --- Face: smile (MAR ≥ min) ---
+    if action == ChallengeType.SMILE:
+        mar = _to_float(metrics.get("mar"))
+        if mar is not None and mar < _SMILE_MAR_MIN:
+            return ("SMILE_NOT_DETECTED", "Mouth-aspect ratio below the smile threshold.")
+        return None
+
+    # --- Face: open mouth (MAR ≥ min, stricter) ---
+    if action == ChallengeType.OPEN_MOUTH:
+        mar = _to_float(metrics.get("mar"))
+        if mar is not None and mar < _OPEN_MOUTH_MAR_MIN:
+            return ("MOUTH_NOT_OPEN", "Mouth-aspect ratio below the open-mouth threshold.")
+        return None
+
+    # --- Face: brow raise (≥ min) ---
+    if action in (
+        ChallengeType.RAISE_EYEBROWS,
+        ChallengeType.RAISE_LEFT_BROW,
+        ChallengeType.RAISE_RIGHT_BROW,
+    ):
+        brow = _to_float(metrics.get("brow_raise"))
+        if brow is not None and brow < _BROW_RAISE_MIN:
+            return ("BROW_NOT_RAISED", "Brow-raise metric below the acceptance threshold.")
+        return None
+
+    # --- Face: head yaw (turn) ---
+    if action == ChallengeType.TURN_LEFT:
+        yaw = _to_float(metrics.get("yaw"))
+        if yaw is not None and yaw > -_HEAD_YAW_MIN_DEG:
+            return ("INSUFFICIENT_HEAD_YAW", "Head yaw does not confirm a left turn.")
+        return None
+    if action == ChallengeType.TURN_RIGHT:
+        yaw = _to_float(metrics.get("yaw"))
+        if yaw is not None and yaw < _HEAD_YAW_MIN_DEG:
+            return ("INSUFFICIENT_HEAD_YAW", "Head yaw does not confirm a right turn.")
+        return None
+
+    # --- Face: head pitch (look up/down) ---
+    if action == ChallengeType.LOOK_UP:
+        pitch = _to_float(metrics.get("pitch"))
+        if pitch is not None and pitch > -_HEAD_PITCH_MIN_DEG:
+            return ("INSUFFICIENT_HEAD_PITCH", "Head pitch does not confirm a look-up gesture.")
+        return None
+    if action == ChallengeType.LOOK_DOWN:
+        pitch = _to_float(metrics.get("pitch"))
+        if pitch is not None and pitch < _HEAD_PITCH_MIN_DEG:
+            return ("INSUFFICIENT_HEAD_PITCH", "Head pitch does not confirm a look-down gesture.")
+        return None
+
+    # --- Face: nod / shake (oscillation) ---
+    if action in (ChallengeType.NOD, ChallengeType.SHAKE_HEAD):
+        osc = _to_int(metrics.get("oscillation_count"))
+        if osc is not None and osc < _OSCILLATION_MIN:
+            return (
+                "INSUFFICIENT_OSCILLATION",
+                "Head oscillation count below the minimum for this gesture.",
+            )
+        return None
+
+    # --- Face: light flash ---
+    if action == ChallengeType.LIGHT:
+        delta = _to_float(metrics.get("brightness_delta"))
+        if delta is not None and delta < _LIGHT_BRIGHTNESS_DELTA_MIN:
+            return ("LIGHT_NOT_OBSERVED", "Screen-flash brightness delta below the threshold.")
+        return None
+
+    # --- Hand: finger count / math (must match the issued target) ---
+    if action in (ChallengeType.FINGER_COUNT, ChallengeType.MATH):
+        observed = _to_int(metrics.get("finger_count"))
+        target = _to_int(params.get("target"))
+        if observed is not None and target is not None and observed != target:
+            return (
+                "FINGER_COUNT_MISMATCH",
+                f"Observed {observed} fingers; expected {target}.",
+            )
+        return None
+
+    # --- Hand: wave (reversals ≥ min) ---
+    if action == ChallengeType.WAVE:
+        reversals = _to_int(metrics.get("reversals"))
+        if reversals is not None and reversals < _WAVE_MIN_REVERSALS:
+            return ("INSUFFICIENT_WAVE", "Wave reversal count below the minimum.")
+        return None
+
+    # --- Hand: hand flip (orientation changes ≥ min) ---
+    if action == ChallengeType.HAND_FLIP:
+        changes = _to_int(metrics.get("orientation_changes"))
+        if changes is not None and changes < _HAND_FLIP_MIN_ORIENT_CHANGES:
+            return ("HAND_NOT_FLIPPED", "Hand orientation did not change.")
+        return None
+
+    # --- Hand: finger tap (tip distance ≤ max) ---
+    if action == ChallengeType.FINGER_TAP:
+        dist = _to_float(metrics.get("tap_dist_scaled"))
+        if dist is not None and dist > _FINGER_TAP_MAX_DIST_SCALED:
+            return ("TAP_NOT_DETECTED", "Fingertip distance above the tap threshold.")
+        return None
+
+    # --- Hand: pinch (thumb-index distance ≤ max) ---
+    if action == ChallengeType.PINCH:
+        dist = _to_float(metrics.get("pinch_dist_scaled"))
+        if dist is not None and dist > _PINCH_MAX_DIST_SCALED:
+            return ("PINCH_NOT_DETECTED", "Thumb-index distance above the pinch threshold.")
+        return None
+
+    # --- Hand: hold position (wrist variance ≤ max) ---
+    if action == ChallengeType.HOLD_POSITION:
+        var = _to_float(metrics.get("wrist_variance"))
+        if var is not None and var > _HOLD_MAX_VARIANCE:
+            return ("HAND_NOT_STILL", "Wrist variance above the hold-still threshold.")
+        return None
+
+    # --- Hand: shape trace (DTW cost ≤ max) ---
+    if action == ChallengeType.SHAPE_TRACE:
+        cost = _to_float(metrics.get("dtw_cost"))
+        if cost is not None and cost > _DTW_COST_MAX:
+            return ("SHAPE_MISMATCH", "Shape-trace DTW cost above the match threshold.")
+        return None
+
+    # --- Hand: peek-a-boo (covered then revealed flag) ---
+    if action == ChallengeType.PEEK_A_BOO:
+        flag = metrics.get("covered_then_revealed")
+        if flag is not None and not bool(flag):
+            return ("PEEK_A_BOO_INCOMPLETE", "Did not observe a cover-then-reveal sequence.")
+        return None
+
+    # No registered gate for this action — pass.
+    return None
+
+
+def metric_is_present(action: ChallengeType, metrics: Dict[str, Any]) -> bool:
+    """Return True if the canonical metric for ``action`` is present (non-empty).
+
+    Used by the metric-REQUIRED puzzle path to close the structural-only hole.
+    An empty ``metrics`` dict, or one missing the action's canonical key (or with
+    a ``None`` value for it), is treated as absent.
+    """
+    if not metrics:
+        return False
+    key = ACTION_METRIC_KEY.get(action)
+    if key is None:
+        # Action has no registered metric — require at least one non-null metric.
+        return any(v is not None for v in metrics.values())
+    return metrics.get(key) is not None
+
+
+__all__ = [
+    "score_action_metrics",
+    "metric_is_present",
+    "ACTION_METRIC_KEY",
+]

--- a/app/application/services/puzzle_session_manager.py
+++ b/app/application/services/puzzle_session_manager.py
@@ -1,0 +1,323 @@
+"""Server-authoritative, single-use, anti-replay puzzle SESSION manager.
+
+CV-1 of the puzzle-as-login convergence
+(docs/superpowers/plans/2026-06-12-puzzle-session-convergence.md).
+
+Replaces the stateless ``/verify-challenge`` trust model for the auth path with a
+server-issued session whose scoring state lives here (bio is the sole authority).
+
+Trust properties enforced (all four):
+  * Challenges are **server-randomized per attempt** — ``create_session`` picks
+    ``count`` challenges at random from ``allowed_challenge_types``; the client
+    cannot pre-record a known sequence.
+  * ``session_id`` is **unguessable** (``secrets.token_urlsafe``) and short-lived
+    (TTL ``DEFAULT_TTL_SECONDS`` = 300 s, matching the existing
+    ``COMPLETED_SESSION_TTL_SECONDS`` for liveness sessions).
+  * The session is **single-use** — ``verdict`` consumes it; a second verdict on
+    the same id fails.
+  * The session is **bound to ``user_id`` + ``tenant_id``** — a session issued for
+    A cannot produce a verified verdict for B.
+
+The store is an in-memory dict keyed by ``session_id`` (mirrors how
+``ActiveGestureLivenessManager`` holds per-session scratch state in-process; the
+auth puzzle session is intentionally process-local + ephemeral, like the other
+liveness sessions). Scoring of a submitted challenge is delegated to the shared
+:mod:`app.application.services.challenge_metric_scorer`, which covers BOTH the 14
+face and 9 hand challenge types — so a single session spans both modalities.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import secrets
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from app.api.schemas.active_liveness import ChallengeType
+from app.application.services.challenge_metric_scorer import (
+    metric_is_present,
+    score_action_metrics,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PuzzleChallengeState:
+    """One issued challenge within a session."""
+
+    action: ChallengeType
+    params: Dict[str, Any] = field(default_factory=dict)
+    completed: bool = False
+    verified: bool = False
+
+
+@dataclass
+class PuzzleSession:
+    """A server-issued puzzle session (in-memory)."""
+
+    session_id: str
+    user_id: str
+    tenant_id: str
+    challenges: List[PuzzleChallengeState]
+    created_at: float
+    expires_at: float
+    consumed: bool = False
+
+    def is_expired(self, now: Optional[float] = None) -> bool:
+        return (now if now is not None else time.time()) >= self.expires_at
+
+    def all_verified(self) -> bool:
+        return bool(self.challenges) and all(
+            c.completed and c.verified for c in self.challenges
+        )
+
+    def find_pending(self, action: ChallengeType) -> Optional[PuzzleChallengeState]:
+        """First issued, not-yet-completed challenge matching ``action``."""
+        for c in self.challenges:
+            if c.action == action and not c.completed:
+                return c
+        return None
+
+
+class PuzzleSessionManager:
+    """In-memory, single-use, anti-replay puzzle session store + scorer."""
+
+    # TTL for a freshly issued session, in seconds. Mirrors the existing
+    # COMPLETED_SESSION_TTL_SECONDS (300) used by the liveness session repos.
+    DEFAULT_TTL_SECONDS: int = 300
+
+    # token_urlsafe byte length → ~43-char unguessable id.
+    _TOKEN_BYTES: int = 32
+
+    # Challenge actions that carry a server-issued numeric ``target`` param.
+    _TARGETED_ACTIONS = (ChallengeType.FINGER_COUNT, ChallengeType.MATH)
+
+    def __init__(self, ttl_seconds: Optional[int] = None) -> None:
+        self._ttl = int(ttl_seconds) if ttl_seconds is not None else self.DEFAULT_TTL_SECONDS
+        self._sessions: Dict[str, PuzzleSession] = {}
+        logger.info("PuzzleSessionManager initialised (ttl=%ss)", self._ttl)
+
+    # ------------------------------------------------------------------
+    # CREATE
+    # ------------------------------------------------------------------
+
+    def create_session(
+        self,
+        *,
+        user_id: str,
+        tenant_id: str,
+        allowed_challenge_types: List[ChallengeType],
+        count: int,
+        difficulty: Optional[str] = None,
+        now: Optional[float] = None,
+    ) -> PuzzleSession:
+        """Create a session with ``count`` server-randomized challenges.
+
+        Raises:
+            ValueError: if ``allowed_challenge_types`` is empty or ``count`` < 1.
+        """
+        if not allowed_challenge_types:
+            raise ValueError("allowed_challenge_types must be non-empty")
+        if count < 1:
+            raise ValueError("count must be >= 1")
+
+        created_at = now if now is not None else time.time()
+
+        # Server-randomized selection. Sample WITHOUT replacement when enough
+        # distinct types are allowed; otherwise sample WITH replacement so a
+        # caller can ask for more challenges than distinct allowed types.
+        pool = list(allowed_challenge_types)
+        if count <= len(pool):
+            chosen = random.sample(pool, count)
+        else:
+            chosen = [random.choice(pool) for _ in range(count)]
+
+        challenges: List[PuzzleChallengeState] = []
+        for action in chosen:
+            params: Dict[str, Any] = {}
+            if action in self._TARGETED_ACTIONS:
+                # Ask for 1..5 fingers (avoid 0=fist), mirroring the gesture manager.
+                params["target"] = random.randint(1, 5)
+            challenges.append(PuzzleChallengeState(action=action, params=params))
+
+        session = PuzzleSession(
+            session_id=self._new_session_id(),
+            user_id=user_id,
+            tenant_id=tenant_id,
+            challenges=challenges,
+            created_at=created_at,
+            expires_at=created_at + self._ttl,
+        )
+        self._sessions[session.session_id] = session
+        logger.info(
+            "Created puzzle session %s for user=%s tenant=%s with %d challenges (%s)",
+            session.session_id,
+            user_id,
+            tenant_id,
+            len(challenges),
+            ",".join(c.action.value for c in challenges),
+        )
+        return session
+
+    def _new_session_id(self) -> str:
+        # Collision-safe by construction (32 random bytes); loop is defensive.
+        while True:
+            sid = secrets.token_urlsafe(self._TOKEN_BYTES)
+            if sid not in self._sessions:
+                return sid
+
+    # ------------------------------------------------------------------
+    # SUBMIT (score one challenge)
+    # ------------------------------------------------------------------
+
+    def submit_challenge(
+        self,
+        session_id: str,
+        *,
+        action: ChallengeType,
+        metrics: Dict[str, Any],
+        start_timestamp_ms: float,
+        end_timestamp_ms: float,
+        confidence: float,
+        now: Optional[float] = None,
+    ) -> Tuple[bool, Optional[str]]:
+        """Score one submitted challenge against the issued session.
+
+        Returns ``(verified, reason_code)``. ``verified`` is True only when the
+        action is one of the issued + not-yet-completed challenges, a metric is
+        PRESENT (metric-required on this path), and the metric + structural
+        checks pass. On success the matching challenge is marked complete.
+
+        A consumed / expired / unknown session yields ``(False, reason_code)``;
+        the route maps ``SESSION_NOT_FOUND`` / ``SESSION_EXPIRED`` to HTTP 404.
+        """
+        session = self._sessions.get(session_id)
+        if session is None:
+            return (False, "SESSION_NOT_FOUND")
+        if session.consumed:
+            return (False, "SESSION_CONSUMED")
+        if session.is_expired(now):
+            return (False, "SESSION_EXPIRED")
+
+        challenge = session.find_pending(action)
+        if challenge is None:
+            # Either not issued, or already completed.
+            issued = any(c.action == action for c in session.challenges)
+            return (False, "ALREADY_COMPLETED" if issued else "ACTION_NOT_ISSUED")
+
+        # Metric REQUIRED on the auth path — closes the structural-only hole.
+        if not metric_is_present(action, metrics):
+            return (False, "METRIC_REQUIRED")
+
+        # Structural: timestamp monotonicity.
+        if end_timestamp_ms < start_timestamp_ms:
+            return (False, "TIMESTAMPS_OUT_OF_ORDER")
+
+        # Structural: confidence floor (matches verify-challenge floor 0.5).
+        if confidence < 0.5:
+            return (False, "CONFIDENCE_BELOW_FLOOR")
+
+        # Metric plausibility gate (shared scorer; consults params for target).
+        rejection = score_action_metrics(action, metrics, challenge.params)
+        if rejection is not None:
+            reason_code, _msg = rejection
+            return (False, reason_code)
+
+        challenge.completed = True
+        challenge.verified = True
+        logger.info(
+            "Puzzle session %s challenge %s verified (user=%s tenant=%s)",
+            session_id,
+            action.value,
+            session.user_id,
+            session.tenant_id,
+        )
+        return (True, None)
+
+    # ------------------------------------------------------------------
+    # VERDICT (consume, single-use)
+    # ------------------------------------------------------------------
+
+    def verdict(
+        self,
+        session_id: str,
+        *,
+        user_id: str,
+        tenant_id: str,
+        now: Optional[float] = None,
+    ) -> Tuple[bool, Optional[str]]:
+        """Return the authoritative verdict and CONSUME the session (single-use).
+
+        ``verified`` is True only when ALL of:
+          * session exists and is not expired,
+          * session has not already been consumed,
+          * owner ``user_id`` + ``tenant_id`` match the requester,
+          * every issued challenge was completed AND validated.
+
+        The session is consumed (marked + removed) whenever it exists and is not
+        expired — including on a False verdict — so a captured trace cannot be
+        replayed against the same id. Unknown / expired sessions return
+        ``(False, "SESSION_NOT_FOUND" | "SESSION_EXPIRED")`` (route → HTTP 404).
+        """
+        session = self._sessions.get(session_id)
+        if session is None:
+            return (False, "SESSION_NOT_FOUND")
+        if session.consumed:
+            # Already used once — anti-replay.
+            return (False, "SESSION_CONSUMED")
+        if session.is_expired(now):
+            # Expire-and-evict; treat as not found by the route (404).
+            self._sessions.pop(session_id, None)
+            return (False, "SESSION_EXPIRED")
+
+        # From here the session is live and unconsumed: consume it exactly once,
+        # regardless of the boolean outcome (single-use is unconditional).
+        session.consumed = True
+        self._sessions.pop(session_id, None)
+
+        if session.user_id != user_id or session.tenant_id != tenant_id:
+            logger.warning(
+                "Puzzle verdict owner mismatch session=%s issued_for=(%s,%s) requested_by=(%s,%s)",
+                session_id,
+                session.user_id,
+                session.tenant_id,
+                user_id,
+                tenant_id,
+            )
+            return (False, "OWNER_MISMATCH")
+
+        if not session.all_verified():
+            return (False, "CHALLENGES_INCOMPLETE")
+
+        logger.info(
+            "Puzzle session %s verdict=PASS (user=%s tenant=%s, consumed)",
+            session_id,
+            user_id,
+            tenant_id,
+        )
+        return (True, None)
+
+    # ------------------------------------------------------------------
+    # Introspection / maintenance
+    # ------------------------------------------------------------------
+
+    def get_session(self, session_id: str) -> Optional[PuzzleSession]:
+        return self._sessions.get(session_id)
+
+    def purge_expired(self, now: Optional[float] = None) -> int:
+        """Drop expired sessions; return the number removed."""
+        ts = now if now is not None else time.time()
+        stale = [sid for sid, s in self._sessions.items() if s.is_expired(ts)]
+        for sid in stale:
+            self._sessions.pop(sid, None)
+        return len(stale)
+
+
+__all__ = [
+    "PuzzleSessionManager",
+    "PuzzleSession",
+    "PuzzleChallengeState",
+]

--- a/tests/api/test_puzzle_session.py
+++ b/tests/api/test_puzzle_session.py
@@ -1,0 +1,305 @@
+"""Tests for the server-issued, single-use, anti-replay puzzle SESSION (CV-1).
+
+Routes under test (mounted on a minimal FastAPI app to avoid the heavy app
+lifespan, mirroring tests/api/test_puzzle_verify_challenge.py):
+
+  POST /api/v1/liveness/puzzle-session
+  POST /api/v1/liveness/puzzle-session/{session_id}/challenge
+  POST /api/v1/liveness/puzzle-session/{session_id}/verdict
+
+Contract: docs/superpowers/plans/2026-06-12-puzzle-session-convergence.md.
+
+Coverage:
+  * create → returns session_id + exactly `count` server-chosen challenges,
+    all drawn from the allowed set;
+  * submit a valid challenge → verified:true + marked complete;
+  * submit with absent metric → verified:false (METRIC_REQUIRED);
+  * submit an action NOT in the issued set → rejected (ACTION_NOT_ISSUED);
+  * verdict before all complete → verified:false;
+  * verdict after all valid → verified:true, THEN a second verdict → false
+    (single-use / consumed);
+  * verdict with wrong user_id/tenant_id → false (owner binding);
+  * expired session → false / 404;
+  * the session spans both face and hand challenge types.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.routes import puzzle as puzzle_routes
+from app.api.routes.puzzle import get_puzzle_session_manager, router as puzzle_router
+
+_USER = "user-aaa"
+_TENANT = "tenant-xyz"
+
+# Valid metric payloads, one per action used in these tests.
+_VALID_METRICS = {
+    "close_left_eye": {"ear": 0.12},
+    "close_right_eye": {"ear": 0.10},
+    "smile": {"mar": 0.55},
+    "nod": {"oscillation_count": 3},
+    "wave": {"reversals": 3},
+    "pinch": {"pinch_dist_scaled": 0.05},
+    "look_up": {"pitch": -15.0},
+}
+
+_BASE_START = 1_000_000.0
+_BASE_END = 1_001_000.0
+
+
+@pytest.fixture()
+def client() -> TestClient:
+    """Fresh app + fresh manager singleton per test (single-use isolation)."""
+    get_puzzle_session_manager.cache_clear()
+    app = FastAPI()
+    app.include_router(puzzle_router, prefix="/api/v1")
+    return TestClient(app)
+
+
+def _manager():
+    return get_puzzle_session_manager()
+
+
+def _create(client: TestClient, allowed, count, user=_USER, tenant=_TENANT) -> dict:
+    resp = client.post(
+        "/api/v1/liveness/puzzle-session",
+        json={
+            "tenant_id": tenant,
+            "user_id": user,
+            "allowed_challenge_types": allowed,
+            "count": count,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _submit(client: TestClient, sid: str, action: str, metrics=None) -> dict:
+    body = {
+        "action": action,
+        "metrics": metrics if metrics is not None else _VALID_METRICS.get(action, {}),
+        "start_timestamp_ms": _BASE_START,
+        "end_timestamp_ms": _BASE_END,
+        "confidence": 0.9,
+    }
+    return client.post(
+        f"/api/v1/liveness/puzzle-session/{sid}/challenge", json=body
+    )
+
+
+def _verdict(client: TestClient, sid: str, user=_USER, tenant=_TENANT):
+    return client.post(
+        f"/api/v1/liveness/puzzle-session/{sid}/verdict",
+        json={"user_id": user, "tenant_id": tenant},
+    )
+
+
+def _complete_all(client: TestClient, sid: str) -> None:
+    """Submit a valid metric for every issued challenge in the session."""
+    session = _manager().get_session(sid)
+    assert session is not None
+    for ch in session.challenges:
+        resp = _submit(client, sid, ch.action.value)
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["verified"] is True, resp.json()
+
+
+# ---------------------------------------------------------------------------
+# CREATE
+# ---------------------------------------------------------------------------
+
+
+def test_create_returns_session_id_and_count_challenges(client: TestClient) -> None:
+    allowed = ["close_left_eye", "smile", "nod", "wave", "pinch"]
+    data = _create(client, allowed, count=3)
+    assert isinstance(data["session_id"], str) and len(data["session_id"]) >= 20
+    assert len(data["challenges"]) == 3
+    # Every issued challenge is drawn from the allowed set.
+    for ch in data["challenges"]:
+        assert ch["action"] in allowed
+
+
+def test_create_spans_face_and_hand(client: TestClient) -> None:
+    """A single session can issue both face and hand challenge types."""
+    allowed = ["close_left_eye", "smile", "nod", "wave", "pinch"]
+    # Ask for all 5 distinct types so both modalities are represented.
+    data = _create(client, allowed, count=5)
+    actions = {c["action"] for c in data["challenges"]}
+    face = {"close_left_eye", "smile", "nod"}
+    hand = {"wave", "pinch"}
+    assert actions & face, "expected at least one face challenge"
+    assert actions & hand, "expected at least one hand challenge"
+
+
+def test_create_finger_count_carries_target_param(client: TestClient) -> None:
+    data = _create(client, ["finger_count"], count=1)
+    params = data["challenges"][0]["params"]
+    assert params is not None and 1 <= params["target"] <= 5
+
+
+def test_create_empty_allowed_is_422(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/liveness/puzzle-session",
+        json={
+            "tenant_id": _TENANT,
+            "user_id": _USER,
+            "allowed_challenge_types": [],
+            "count": 1,
+        },
+    )
+    assert resp.status_code == 422  # min_length=1 schema validation
+
+
+# ---------------------------------------------------------------------------
+# SUBMIT
+# ---------------------------------------------------------------------------
+
+
+def test_submit_valid_challenge_verifies_and_marks_complete(client: TestClient) -> None:
+    data = _create(client, ["close_left_eye"], count=1)
+    sid = data["session_id"]
+    action = data["challenges"][0]["action"]
+    resp = _submit(client, sid, action)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["verified"] is True
+    assert body["action"] == action
+    assert body["reason_code"] is None
+    # Marked complete in the session.
+    ch = _manager().get_session(sid).challenges[0]
+    assert ch.completed is True and ch.verified is True
+
+
+def test_submit_absent_metric_fails(client: TestClient) -> None:
+    data = _create(client, ["smile"], count=1)
+    sid = data["session_id"]
+    resp = _submit(client, sid, "smile", metrics={})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["verified"] is False
+    assert body["reason_code"] == "METRIC_REQUIRED"
+
+
+def test_submit_action_not_issued_rejected(client: TestClient) -> None:
+    data = _create(client, ["close_left_eye"], count=1)
+    sid = data["session_id"]
+    # "pinch" was not issued for this session.
+    assert all(c["action"] != "pinch" for c in data["challenges"])
+    resp = _submit(client, sid, "pinch")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["verified"] is False
+    assert body["reason_code"] == "ACTION_NOT_ISSUED"
+
+
+def test_submit_implausible_metric_fails(client: TestClient) -> None:
+    data = _create(client, ["close_left_eye"], count=1)
+    sid = data["session_id"]
+    # EAR above the closed-eye threshold → eye still open.
+    resp = _submit(client, sid, "close_left_eye", metrics={"ear": 0.30})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["verified"] is False
+    assert body["reason_code"] == "EYE_NOT_CLOSED"
+
+
+def test_submit_same_challenge_twice_already_completed(client: TestClient) -> None:
+    data = _create(client, ["close_left_eye"], count=1)
+    sid = data["session_id"]
+    assert _submit(client, sid, "close_left_eye").json()["verified"] is True
+    resp = _submit(client, sid, "close_left_eye")
+    assert resp.json()["verified"] is False
+    assert resp.json()["reason_code"] == "ALREADY_COMPLETED"
+
+
+def test_submit_unknown_session_404(client: TestClient) -> None:
+    resp = _submit(client, "does-not-exist", "smile")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# VERDICT
+# ---------------------------------------------------------------------------
+
+
+def test_verdict_before_all_complete_is_false(client: TestClient) -> None:
+    data = _create(client, ["close_left_eye", "smile"], count=2)
+    sid = data["session_id"]
+    # Complete only the first issued challenge.
+    first = data["challenges"][0]["action"]
+    assert _submit(client, sid, first).json()["verified"] is True
+    resp = _verdict(client, sid)
+    assert resp.status_code == 200
+    assert resp.json()["verified"] is False
+
+
+def test_verdict_after_all_valid_then_single_use(client: TestClient) -> None:
+    data = _create(client, ["close_left_eye", "smile", "nod"], count=3)
+    sid = data["session_id"]
+    _complete_all(client, sid)
+    first = _verdict(client, sid)
+    assert first.status_code == 200
+    assert first.json()["verified"] is True
+    # Single-use: the session is consumed → a second verdict is gone (404).
+    second = _verdict(client, sid)
+    assert second.status_code == 404
+
+
+def test_verdict_wrong_user_is_false(client: TestClient) -> None:
+    data = _create(client, ["close_left_eye"], count=1)
+    sid = data["session_id"]
+    _complete_all(client, sid)
+    resp = _verdict(client, sid, user="intruder")
+    assert resp.status_code == 200
+    assert resp.json()["verified"] is False
+
+
+def test_verdict_wrong_tenant_is_false(client: TestClient) -> None:
+    data = _create(client, ["close_left_eye"], count=1)
+    sid = data["session_id"]
+    _complete_all(client, sid)
+    resp = _verdict(client, sid, tenant="other-tenant")
+    assert resp.status_code == 200
+    assert resp.json()["verified"] is False
+
+
+def test_verdict_owner_mismatch_also_consumes(client: TestClient) -> None:
+    """A failed (owner-mismatch) verdict still consumes the session (anti-replay)."""
+    data = _create(client, ["close_left_eye"], count=1)
+    sid = data["session_id"]
+    _complete_all(client, sid)
+    bad = _verdict(client, sid, user="intruder")
+    assert bad.json()["verified"] is False
+    # Even the true owner cannot now verify — the id is consumed.
+    again = _verdict(client, sid)
+    assert again.status_code == 404
+
+
+def test_verdict_unknown_session_404(client: TestClient) -> None:
+    resp = _verdict(client, "nope")
+    assert resp.status_code == 404
+
+
+def test_expired_session_verdict_404(client: TestClient) -> None:
+    data = _create(client, ["close_left_eye"], count=1)
+    sid = data["session_id"]
+    _complete_all(client, sid)
+    # Force expiry by rewinding the stored session's expires_at.
+    session = _manager().get_session(sid)
+    session.expires_at = time.time() - 1.0
+    resp = _verdict(client, sid)
+    assert resp.status_code == 404
+
+
+def test_expired_session_submit_404(client: TestClient) -> None:
+    data = _create(client, ["close_left_eye", "smile"], count=2)
+    sid = data["session_id"]
+    session = _manager().get_session(sid)
+    session.expires_at = time.time() - 1.0
+    resp = _submit(client, sid, data["challenges"][0]["action"])
+    assert resp.status_code == 404

--- a/tests/api/test_puzzle_verify_challenge.py
+++ b/tests/api/test_puzzle_verify_challenge.py
@@ -1,0 +1,397 @@
+"""Tests for POST /api/v1/liveness/verify-challenge — 8 new face challenges.
+
+Covers:
+  - All 8 new action identifiers (close_left_eye, close_right_eye, look_up,
+    look_down, raise_left_brow, raise_right_brow, nod, shake_head) return
+    verified=true with valid timing, confidence, and metrics.
+  - Each new action's per-metric rejection path returns verified=false with
+    the correct reason_code when an implausible metric is supplied.
+  - Absent metrics are not penalised (backward-compat gate).
+  - The structural checks (timestamps, duration, confidence) still apply to
+    the new actions; one representative check per class is included.
+  - The 6 pre-existing challenge types (blink, smile, turn_left, turn_right,
+    pinch, open_mouth) still pass — regression guard.
+
+Design: the puzzle router is mounted on a minimal FastAPI app without the full
+app lifespan (no torch / uniface ONNX pre-load). This keeps the test runnable
+on bare CI runners and in the lightweight unit-test environment.  The same
+isolation pattern is used by tests/unit/test_nfc_verify_authenticity_route.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.routes.puzzle import router as puzzle_router
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(puzzle_router, prefix="/api/v1")
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Payload helpers
+# ---------------------------------------------------------------------------
+
+_BASE_START = 1_000_000.0
+_BASE_END = 1_001_000.0  # +1 000 ms — well within [120 ms, 60 s]
+_BASE_CONFIDENCE = 0.85
+
+
+def _payload(action: str, **overrides) -> dict:
+    """Build a structurally-valid payload; override fields per test."""
+    base: dict = {
+        "action": action,
+        "start_timestamp_ms": _BASE_START,
+        "end_timestamp_ms": _BASE_END,
+        "confidence": _BASE_CONFIDENCE,
+        "tenant_id": "tenant-test",
+        "user_id": "user-test",
+        "metrics": {},
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Regression: existing 6 challenges still pass
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "action",
+    ["blink", "smile", "turn_left", "turn_right", "open_mouth", "pinch"],
+)
+def test_existing_challenges_still_pass(client: TestClient, action: str) -> None:
+    resp = client.post("/api/v1/liveness/verify-challenge", json=_payload(action))
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is True, f"existing action {action!r} unexpectedly rejected: {body}"
+    assert body["reason_code"] is None
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: 8 new actions with valid metrics
+# ---------------------------------------------------------------------------
+
+
+def test_close_left_eye_valid(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload("close_left_eye", metrics={"ear": 0.15}),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is True
+    assert body["action"] == "close_left_eye"
+    assert body["reason_code"] is None
+
+
+def test_close_right_eye_valid(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload("close_right_eye", metrics={"ear": 0.10}),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is True
+    assert body["action"] == "close_right_eye"
+    assert body["reason_code"] is None
+
+
+def test_look_up_valid(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload("look_up", metrics={"pitch": -15.0}),  # negative = face tilts up
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is True
+    assert body["action"] == "look_up"
+    assert body["reason_code"] is None
+
+
+def test_look_down_valid(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload("look_down", metrics={"pitch": 12.0}),  # positive = face tilts down
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is True
+    assert body["action"] == "look_down"
+    assert body["reason_code"] is None
+
+
+def test_raise_left_brow_valid(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload("raise_left_brow", metrics={"brow_raise": 0.12}),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is True
+    assert body["action"] == "raise_left_brow"
+    assert body["reason_code"] is None
+
+
+def test_raise_right_brow_valid(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload("raise_right_brow", metrics={"brow_raise": 0.09}),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is True
+    assert body["action"] == "raise_right_brow"
+    assert body["reason_code"] is None
+
+
+def test_nod_valid(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload("nod", metrics={"oscillation_count": 3}),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is True
+    assert body["action"] == "nod"
+    assert body["reason_code"] is None
+
+
+def test_shake_head_valid(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload("shake_head", metrics={"oscillation_count": 4}),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is True
+    assert body["action"] == "shake_head"
+    assert body["reason_code"] is None
+
+
+# ---------------------------------------------------------------------------
+# Metric-gate rejections: bad metrics → verified=false + correct reason_code
+# ---------------------------------------------------------------------------
+
+
+def test_close_left_eye_ear_too_high(client: TestClient) -> None:
+    """EAR above threshold means the eye is still open."""
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload("close_left_eye", metrics={"ear": 0.30}),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is False
+    assert body["reason_code"] == "EYE_NOT_CLOSED"
+    assert body["action"] == "close_left_eye"
+
+
+def test_close_right_eye_ear_too_high(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload("close_right_eye", metrics={"ear": 0.25}),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is False
+    assert body["reason_code"] == "EYE_NOT_CLOSED"
+    assert body["action"] == "close_right_eye"
+
+
+def test_look_up_pitch_too_shallow(client: TestClient) -> None:
+    """Pitch of -5° is too small to confirm a look-up."""
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload("look_up", metrics={"pitch": -5.0}),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is False
+    assert body["reason_code"] == "INSUFFICIENT_HEAD_PITCH"
+    assert body["action"] == "look_up"
+
+
+def test_look_up_positive_pitch_rejected(client: TestClient) -> None:
+    """A positive pitch while claiming look_up is a wrong-direction gesture."""
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload("look_up", metrics={"pitch": 8.0}),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is False
+    assert body["reason_code"] == "INSUFFICIENT_HEAD_PITCH"
+
+
+def test_look_down_pitch_too_shallow(client: TestClient) -> None:
+    """Pitch of +3° is too small to confirm a look-down."""
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload("look_down", metrics={"pitch": 3.0}),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is False
+    assert body["reason_code"] == "INSUFFICIENT_HEAD_PITCH"
+    assert body["action"] == "look_down"
+
+
+def test_look_down_negative_pitch_rejected(client: TestClient) -> None:
+    """A negative pitch while claiming look_down is a wrong-direction gesture."""
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload("look_down", metrics={"pitch": -11.0}),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is False
+    assert body["reason_code"] == "INSUFFICIENT_HEAD_PITCH"
+
+
+def test_raise_left_brow_not_raised(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload("raise_left_brow", metrics={"brow_raise": 0.03}),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is False
+    assert body["reason_code"] == "BROW_NOT_RAISED"
+    assert body["action"] == "raise_left_brow"
+
+
+def test_raise_right_brow_not_raised(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload("raise_right_brow", metrics={"brow_raise": 0.00}),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is False
+    assert body["reason_code"] == "BROW_NOT_RAISED"
+    assert body["action"] == "raise_right_brow"
+
+
+def test_nod_insufficient_oscillation(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload("nod", metrics={"oscillation_count": 1}),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is False
+    assert body["reason_code"] == "INSUFFICIENT_OSCILLATION"
+    assert body["action"] == "nod"
+
+
+def test_shake_head_insufficient_oscillation(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload("shake_head", metrics={"oscillation_count": 0}),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is False
+    assert body["reason_code"] == "INSUFFICIENT_OSCILLATION"
+    assert body["action"] == "shake_head"
+
+
+# ---------------------------------------------------------------------------
+# Absent metrics must NOT cause rejection (backward-compat)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "action",
+    [
+        "close_left_eye",
+        "close_right_eye",
+        "look_up",
+        "look_down",
+        "raise_left_brow",
+        "raise_right_brow",
+        "nod",
+        "shake_head",
+    ],
+)
+def test_absent_metrics_pass(client: TestClient, action: str) -> None:
+    """New actions with no metrics dict pass all structural checks."""
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload(action, metrics={}),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is True, (
+        f"action {action!r} rejected with absent metrics: {body}"
+    )
+    assert body["reason_code"] is None
+
+
+# ---------------------------------------------------------------------------
+# Structural checks still apply to new actions
+# ---------------------------------------------------------------------------
+
+
+def test_new_action_timestamps_out_of_order(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload(
+            "look_up",
+            start_timestamp_ms=2_000_000.0,
+            end_timestamp_ms=1_999_000.0,
+            metrics={"pitch": -20.0},
+        ),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is False
+    assert body["reason_code"] == "TIMESTAMPS_OUT_OF_ORDER"
+
+
+def test_new_action_duration_too_short(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload(
+            "nod",
+            start_timestamp_ms=1_000_000.0,
+            end_timestamp_ms=1_000_050.0,  # 50 ms < 120 ms floor
+            metrics={"oscillation_count": 3},
+        ),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is False
+    assert body["reason_code"] == "DURATION_TOO_SHORT"
+
+
+def test_new_action_confidence_below_floor(client: TestClient) -> None:
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload(
+            "shake_head",
+            confidence=0.2,
+            metrics={"oscillation_count": 4},
+        ),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["verified"] is False
+    assert body["reason_code"] == "CONFIDENCE_BELOW_FLOOR"
+
+
+def test_new_action_unknown_string_is_422(client: TestClient) -> None:
+    """A completely unknown action name must still produce a 422."""
+    resp = client.post(
+        "/api/v1/liveness/verify-challenge",
+        json=_payload("unknown_face_action"),
+    )
+    assert resp.status_code == 422, resp.text

--- a/tests/unit/application/test_light_challenge_service.py
+++ b/tests/unit/application/test_light_challenge_service.py
@@ -99,5 +99,17 @@ def test_active_liveness_manager_generates_verification_token_on_pass(monkeypatc
     assert response.verification_token_expires_at is not None
 
 
-def test_active_liveness_challenge_type_does_not_expose_nod():
-    assert not hasattr(ChallengeType, "NOD")
+def test_active_liveness_manager_default_pool_does_not_include_nod():
+    """NOD is a puzzle-surface-only action (web puzzle session).
+    The ActiveLivenessManager session pool must not include it so
+    standard active-liveness flows are unaffected.
+    """
+    from app.application.services.active_liveness_manager import ActiveLivenessManager
+
+    manager = ActiveLivenessManager()
+    # Request max challenges with randomize off so the full pool is exposed.
+    session = manager.create_session(
+        ActiveLivenessConfig(num_challenges=5, randomize=False)
+    )
+    challenge_types = {c.type for c in session.challenges}
+    assert ChallengeType.NOD not in challenge_types


### PR DESCRIPTION
Additive puzzle-session layer (SP-B). Three new routes under `/liveness/puzzle-session`:

- `POST /liveness/puzzle-session/create` — issues a server-randomised, TTL-bound, owner-bound session containing N challenges drawn from the existing face+hand action catalogue; returns `session_id` + ordered challenge list to the caller.
- `POST /liveness/puzzle-session/submit` — accepts per-challenge metric payloads; validates each against the same detector thresholds already used by `/verify-challenge`; marks challenges complete; rejects absent/implausible metrics and replayed submissions.
- `GET  /liveness/puzzle-session/verdict` — single-use: returns pass/fail once all challenges are complete then permanently invalidates the session; owner+tenant binding enforced.

New modules: `puzzle_session_manager.py` (session lifecycle + single-use enforcement), `challenge_metric_scorer.py` (metric validation, reuses existing thresholds).

The stateless `/verify-challenge` training surface is unchanged. The puzzle path is reachable only when the identity `app.auth.puzzle-layer` flag is on.