### PR TITLE
fix(puzzle): document pitch-sign convention + Phase-4 minors (numpy imports, fetch timing)

### DIFF
--- a/app/api/routes/enrollment.py
+++ b/app/api/routes/enrollment.py
@@ -3,6 +3,7 @@
 import logging
 from typing import List, Optional
 
+import numpy as np
 from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, Header, HTTPException, Request, UploadFile
 
 from app.api.routes import verification as verify_route
@@ -335,8 +336,6 @@ async def enroll_embedding(
         "enroll-embedding request (no image, liveness enforced upstream): "
         f"user_id={user_id}, tenant_id={tenant_id}"
     )
-
-    import numpy as np
 
     embedding = np.asarray(request.embedding, dtype=np.float32)
 

--- a/app/api/routes/verification.py
+++ b/app/api/routes/verification.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Any, Optional
 
+import numpy as np
 from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Request, UploadFile
 
 from app.api.schemas.verification import EmbeddingVerifyRequest, VerificationResponse
@@ -599,8 +600,6 @@ async def verify_embedding(
         "verify-embedding request (no image, liveness enforced upstream): "
         f"user_id={user_id}, tenant_id={tenant_id}"
     )
-
-    import numpy as np
 
     probe = np.asarray(request.embedding, dtype=np.float32)
 

--- a/app/application/services/challenge_metric_scorer.py
+++ b/app/application/services/challenge_metric_scorer.py
@@ -27,6 +27,14 @@ session-based detectors use:
     nod / shake_head                            oscillation_count ≥ 2
     light                                       brightness_delta  ≥ 0.05
 
+  HEAD-POSE SIGN CONVENTION (cross-repo, agreed 2026-06-12 — Phase-1B):
+    yaw   < 0 = head turned to the USER's LEFT  (turn_left);  > 0 = RIGHT (turn_right)
+    pitch < 0 = looking UP / chin up            (look_up);    > 0 = looking DOWN (look_down)
+  The web-app client (``HeadPoseEstimator`` + ``LookUpDetector``/``LookDownDetector``)
+  uses the SAME sign and submits the RAW ``headPose.pitch`` / ``yaw`` under the
+  ``pitch`` / ``yaw`` metric keys (no flip), so the gates below apply unchanged.
+  Mirror doc: web ``src/features/biometric-puzzles/puzzleServerAction.ts``.
+
   Hand (mirrors ``ActiveGestureLivenessManager`` thresholds):
     finger_count / math                         finger_count    == target (in params)
     wave                                         reversals       ≥ 2

--- a/app/application/use_cases/verify_face.py
+++ b/app/application/use_cases/verify_face.py
@@ -149,10 +149,14 @@ class VerifyFaceUseCase:
         # Steps 6-7: retrieve stored template, compute distance, resolve the
         # (possibly adaptive aged) threshold, and decide. Shared with the
         # client-side embedding route (/verify-embedding) via match_embedding.
+        # Pass `stage_ms` so the template-fetch duration is recorded back into the
+        # same dict and the verify log line regains its `fetch=Xms` segment (the
+        # extraction into match_embedding had dropped it).
         result = await self.match_embedding(
             user_id=user_id,
             embedding=new_embedding,
             tenant_id=tenant_id,
+            stage_ms=stage_ms,
         )
 
         total_ms = (time.perf_counter() - t_start) * 1000
@@ -171,6 +175,7 @@ class VerifyFaceUseCase:
         user_id: str,
         embedding,
         tenant_id: Optional[str] = None,
+        stage_ms: Optional[dict[str, float]] = None,
     ) -> VerificationResult:
         """Match an ALREADY-EXTRACTED embedding against the user's template.
 
@@ -191,6 +196,11 @@ class VerifyFaceUseCase:
             user_id: User identifier to verify against.
             embedding: Probe embedding (numpy array or sequence of floats).
             tenant_id: Optional tenant identifier for multi-tenancy.
+            stage_ms: Optional per-stage timing dict. When supplied (by
+                :meth:`execute`), the template-fetch duration is recorded under
+                the ``"fetch"`` key so the verify log line keeps its
+                ``fetch=Xms`` segment. Observability only — no behaviour change;
+                the ``/verify-embedding`` route omits it (it has no log line).
 
         Returns:
             VerificationResult with the verdict, distance, threshold and the
@@ -199,8 +209,12 @@ class VerifyFaceUseCase:
         Raises:
             EmbeddingNotFoundError: When no stored embedding exists for the user.
         """
-        # Retrieve stored embedding
+        # Retrieve stored embedding (timed back into stage_ms when provided, so
+        # the verify log line regains its `fetch=Xms` per-stage segment).
+        _t_fetch = time.perf_counter()
         stored_embedding = await self._repository.find_by_user_id(user_id, tenant_id)
+        if stage_ms is not None:
+            stage_ms["fetch"] = (time.perf_counter() - _t_fetch) * 1000
 
         if stored_embedding is None:
             logger.warning(f"No embedding found for user_id={user_id}")


### PR DESCRIPTION
## Phase-1B puzzle/embedding gap closures (bio side)

### B1 — pitch-sign convention (verification; no code change)
Confirmed bio's `look_up`/`look_down` pitch gates **already match** the web
client's head-pose sign, so the challenge does NOT mis-fire and no flip is
needed:
- bio `challenge_metric_scorer.py`: `look_up: pitch ≤ -10°`,
  `look_down: pitch ≥ +10°`.
- web `HeadPoseEstimator` + `LookUp`/`LookDownDetector`: **pitch < 0 = looking
  UP**, **pitch > 0 = looking DOWN**; submits the raw `headPose.pitch`.

Both sides agree: **looking UP = negative pitch, looking DOWN = positive pitch**.
Documented the agreed cross-repo convention in `challenge_metric_scorer.py`'s
module docstring (mirror lives in web `puzzleServerAction.ts`).

### B2 — Phase-4 minors
- **Module-level numpy import.** Moved the inline `import numpy as np` to the top
  of `verification.py` (`/verify-embedding`) and `enrollment.py`
  (`/enroll-embedding`). numpy is a hard dependency — the in-function imports
  were needless. (The numpy import inside the EAR-veto block is left in its
  optional `spoof_detector` try/except guard, intentionally.)
- **Restore `fetch=Xms` timing.** The `match_embedding` extraction moved the
  template fetch out of `execute` and dropped its per-stage timing, so the
  `face/verify` log line lost its `fetch=` segment. `match_embedding` now accepts
  an optional `stage_ms` dict and records the fetch duration into it when
  `execute` supplies one. **Behaviour-neutral, observability only** — the
  `/verify-embedding` route omits it (it has no log line).

### V&V
- `pytest tests/api/test_puzzle_session.py tests/api/test_puzzle_verify_challenge.py tests/unit/application/test_use_cases.py`
  → **76 passed**.
- `ruff check` on the four edited files → clean.
- Edited route + use-case + scorer modules import cleanly (numpy at module level).

Additive + correctness; the client-embedding / puzzle paths stay flag-gated.
Pairs with web-app#216.