### PR TITLE
feat(bio): voice/face enrollment-existence probes (login triage F2/F7/F9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,8 +209,18 @@ the gated files run.
   and anti-spoof (`SpoofDetectedError`) failures, ML timeouts, MultipleFaces,
   and any unexpected error stay **FATAL** (abort fail-closed) — only
   quality-class failures are skippable (see `_SKIPPABLE_FRAME_ERRORS`).
-- **Voice**: enroll, verify, search, delete — Resemblyzer 256-dim speaker embeddings, centroid-based
+- **Voice**: enroll, verify, search, delete, **exists** — Resemblyzer 256-dim speaker embeddings, centroid-based
 - Routes: `voice.py`, repo: `pgvector_voice_repository.py`, embedder: `speaker_embedder.py`
+- **Enrollment-existence probes (login triage F2/F7/F9, 2026-06-12):**
+  `GET /voice/{user_id}/exists` and `GET /face/{user_id}/exists` return
+  `{user_id, exists}` via a cheap `SELECT EXISTS(...)` against
+  `voice_enrollments` / `face_embeddings` (`repo.exists`) — NO inference, NO
+  vector decrypt. Face accepts an optional `?tenant_id=` (verify-path parity);
+  voice is user-scoped only (matches `/voice/verify`). identity-core-api's
+  `EnrollmentHealthService` calls these so FACE/VOICE are only reported enrolled
+  for users who genuinely have a template, instead of the prior "trust if the
+  service is reachable" fake that routed un-enrolled users into a voice step that
+  could never pass. Same `X-API-Key` auth as every other `/api/*` route.
 - **Voice verify centroid normalization (P1-10, 2026-06-02)**: the default enroll
   path stores the centroid as `AVG(embedding)::vector` (the mean of unit-norm
   embeddings has norm < 1 and shrinks as enrollments accumulate). `/voice/verify`

--- a/app/api/routes/verification.py
+++ b/app/api/routes/verification.py
@@ -4,9 +4,13 @@ import logging
 from typing import Any, Optional
 
 import numpy as np
-from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Request, UploadFile
+from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, Query, Request, UploadFile
 
-from app.api.schemas.verification import EmbeddingVerifyRequest, VerificationResponse
+from app.api.schemas.verification import (
+    EmbeddingVerifyRequest,
+    EnrollmentExistsResponse,
+    VerificationResponse,
+)
 from app.application.services.device_spoof_risk_evaluator import (
     DeviceSpoofRiskEvaluator,
 )
@@ -15,6 +19,7 @@ from app.application.use_cases.verify_face import VerifyFaceUseCase
 from app.core.container import (
     get_check_liveness_use_case,
     get_client_embedding_observation_repository,
+    get_embedding_repository,
     get_file_storage,
     get_verify_face_use_case,
 )
@@ -621,6 +626,51 @@ async def verify_embedding(
         threshold=result.threshold,
         message=message,
     )
+
+
+@router.get("/face/{user_id}/exists", response_model=EnrollmentExistsResponse)
+async def face_exists(
+    user_id: str,
+    tenant_id: Optional[str] = Query(
+        default=None,
+        description="Optional tenant scope (mirrors the face verify path).",
+    ),
+) -> EnrollmentExistsResponse:
+    """Return whether the user has a live face enrollment.
+
+    CHEAP existence probe — a single ``SELECT EXISTS(...)`` against
+    ``face_embeddings``. It NEVER runs detection/quality/liveness/embedding
+    inference and never decrypts a stored vector. ``tenant_id`` is optional and
+    mirrors the verify-path scoping; when omitted the probe is by ``user_id``
+    only.
+
+    Consumed by identity-core-api's ``EnrollmentHealthService`` so FACE is only
+    reported enrolled for users who genuinely have a template — replacing the
+    prior "trust if the service is reachable" fake (login triage F2/F7/F9).
+    """
+    try:
+        user_id = validate_user_id(user_id)
+        scoped_tenant = validate_tenant_id(tenant_id) if tenant_id else None
+    except ValidationError as e:
+        logger.warning(f"Input validation failed: {str(e)}")
+        raise HTTPException(status_code=400, detail=f"Invalid input: {str(e)}")
+
+    try:
+        repo = get_embedding_repository()
+        present = await repo.exists(user_id, scoped_tenant)
+        logger.info(
+            f"Face enrollment existence probe: user_id={user_id}, "
+            f"tenant_id={scoped_tenant}, exists={present}"
+        )
+        return EnrollmentExistsResponse(user_id=user_id, exists=present)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Face existence check failed: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail="Face enrollment existence check failed. Please try again.",
+        )
 
 
 def _pick_single_client_embedding(

--- a/app/api/routes/voice.py
+++ b/app/api/routes/voice.py
@@ -359,6 +359,51 @@ async def search_voice(request: VoiceSearchRequest):
         raise HTTPException(status_code=500, detail="Voice search failed. Please try again.")
 
 
+# -- GET /voice/{user_id}/exists ----------------------------------------------
+
+
+class ExistsResponse(BaseModel):
+    """Lightweight enrollment-existence probe response.
+
+    Returned by ``GET /voice/{user_id}/exists`` (and the symmetric face route).
+    Used by identity-core-api's ``EnrollmentHealthService`` to learn whether a
+    user REALLY has a voiceprint, instead of FAKING VOICE/FACE as always-enrolled
+    (which routed un-enrolled users into a voice step that could never pass —
+    login triage F2/F7).
+    """
+
+    user_id: str
+    exists: bool
+
+
+@router.get("/voice/{user_id}/exists", response_model=ExistsResponse)
+async def voice_exists(user_id: str) -> ExistsResponse:
+    """Return whether the user has a live (non-deleted) voice enrollment.
+
+    CHEAP existence probe — it never runs inference or decrypts a vector; it
+    issues a single ``SELECT EXISTS(...)`` against ``voice_enrollments``. Scoped
+    by ``user_id`` only, matching the ``/voice/verify`` path (voice verify is not
+    tenant-scoped). Any enrollment row (CENTROID or INDIVIDUAL) counts.
+    """
+    try:
+        user_id = validate_user_id(user_id)
+        repo = get_voice_repository()
+        present = await repo.exists(user_id)
+        logger.info(f"Voice enrollment existence probe: user_id={user_id}, exists={present}")
+        return ExistsResponse(user_id=user_id, exists=present)
+    except ValueError as e:
+        logger.warning(f"Voice existence validation error: {e}")
+        raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Voice existence check failed: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail="Voice enrollment existence check failed. Please try again.",
+        )
+
+
 # -- DELETE /voice/{user_id} ---------------------------------------------------
 
 

--- a/app/api/schemas/verification.py
+++ b/app/api/schemas/verification.py
@@ -56,6 +56,21 @@ class EmbeddingVerifyRequest(BaseModel):
         return value
 
 
+class EnrollmentExistsResponse(BaseModel):
+    """Lightweight enrollment-existence probe response.
+
+    Returned by ``GET /face/{user_id}/exists``. Consumed by identity-core-api's
+    ``EnrollmentHealthService`` so it can learn whether a user REALLY has a face
+    template instead of FAKING FACE/VOICE as always-enrolled (which routed
+    un-enrolled users into a biometric step that could never pass — login triage
+    F2/F7/F9). The probe is a cheap ``SELECT EXISTS(...)`` — it never runs
+    inference or decrypts a vector.
+    """
+
+    user_id: str = Field(..., description="User identifier that was probed")
+    exists: bool = Field(..., description="Whether a live face enrollment exists")
+
+
 class VerificationResponse(BaseModel):
     """Face verification response."""
 

--- a/app/infrastructure/persistence/repositories/pgvector_voice_repository.py
+++ b/app/infrastructure/persistence/repositories/pgvector_voice_repository.py
@@ -340,6 +340,41 @@ class PgVectorVoiceRepository:
         )
         return np.array(row["embedding"], dtype=np.float32)
 
+    async def exists(self, user_id: str) -> bool:
+        """Return whether the user has a live (non-deleted) voiceprint.
+
+        This is the authoritative "is there really a voice enrollment?" probe
+        against the embedding store, used by identity-core-api's
+        ``EnrollmentHealthService`` so that VOICE is only offered/auto-picked
+        for users who actually enrolled (previously identity FAKED VOICE/FACE
+        as always-enrolled, routing un-enrolled users into a voice step that
+        could never pass — login triage F2/F7).
+
+        It is a CHEAP existence check (``SELECT EXISTS(...)``) — it never runs
+        inference or decrypts a vector. Matches the verify path's scoping (by
+        ``user_id`` only; voice verify is not tenant-scoped). Any
+        ``enrollment_type`` row (CENTROID or INDIVIDUAL) counts, so the probe
+        returns True between the first individual enrollment and the centroid
+        being written.
+        """
+        try:
+            pool = await self._ensure_pool()
+            async with pool.acquire() as conn:
+                result = await conn.fetchval(
+                    """
+                    SELECT EXISTS(
+                        SELECT 1 FROM voice_enrollments
+                        WHERE user_id = $1::varchar
+                          AND deleted_at IS NULL
+                    )
+                    """,
+                    user_id,
+                )
+            return bool(result)
+        except Exception as e:
+            logger.error(f"Failed to check voice enrollment existence: {e}", exc_info=True)
+            raise RepositoryError(operation="exists", reason=str(e))
+
     async def delete_by_user_id(self, user_id: str) -> bool:
         """Soft-delete all voice enrollments for a user.
 

--- a/tests/unit/api/test_face_exists_route.py
+++ b/tests/unit/api/test_face_exists_route.py
@@ -1,0 +1,133 @@
+"""Unit tests for the face enrollment-existence probe (login triage F2/F7/F9).
+
+``GET /face/{user_id}/exists`` is the cheap, authoritative probe that
+identity-core-api's ``EnrollmentHealthService`` now calls to learn whether a
+user REALLY has a face template — replacing the prior "trust if the biometric
+service is reachable" fake that reported FACE/VOICE as always-enrolled.
+
+These tests drive the route handler coroutine directly (rather than through a
+full TestClient) to avoid the asyncio loop-poisoning that the
+TestClient-in-test-body pattern suffers from (same approach as
+``test_voice_routes.py``). The embedding repository is patched per-test, so no
+DB / ML stack is required.
+"""
+
+import sys
+import types
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+
+def _import_verification_routes():
+    """Import app.api.routes.verification without leaking a container stub.
+
+    In the Docker/CI image the real container imports cleanly, so the plain
+    import succeeds. In a lean environment lacking the heavy ML stack, install a
+    minimal container stub just long enough to satisfy verification.py's
+    ``from app.core.container import``, then restore sys.modules so other test
+    modules see the real container (mirrors the voice-route test helper).
+    """
+    try:
+        from app.api.routes import verification as _verification
+        return _verification
+    except Exception:
+        pass
+
+    _had_container = "app.core.container" in sys.modules
+    _saved_container = sys.modules.get("app.core.container")
+    _stub_container = types.ModuleType("app.core.container")
+    for _name in (
+        "get_check_liveness_use_case",
+        "get_client_embedding_observation_repository",
+        "get_embedding_repository",
+        "get_file_storage",
+        "get_verify_face_use_case",
+    ):
+        setattr(_stub_container, _name, lambda *a, **k: None)
+    sys.modules["app.core.container"] = _stub_container
+    try:
+        from app.api.routes import verification as _verification
+        return _verification
+    finally:
+        if _had_container:
+            sys.modules["app.core.container"] = _saved_container
+        else:
+            sys.modules.pop("app.core.container", None)
+
+
+verification_routes = _import_verification_routes()
+
+
+@pytest.mark.asyncio
+async def test_face_exists_true_when_enrollment_present():
+    """exists=True for an enrolled user; repo.exists is consulted with the user_id."""
+    repo = Mock()
+    repo.exists = AsyncMock(return_value=True)
+
+    with patch.object(verification_routes, "get_embedding_repository", return_value=repo):
+        res = await verification_routes.face_exists(
+            "11111111-1111-1111-1111-111111111111", tenant_id=None
+        )
+
+    repo.exists.assert_awaited_once_with("11111111-1111-1111-1111-111111111111", None)
+    assert res.exists is True
+    assert res.user_id == "11111111-1111-1111-1111-111111111111"
+
+
+@pytest.mark.asyncio
+async def test_face_exists_false_when_not_enrolled():
+    """A definitive exists=False is returned for an un-enrolled user (no masking)."""
+    repo = Mock()
+    repo.exists = AsyncMock(return_value=False)
+
+    with patch.object(verification_routes, "get_embedding_repository", return_value=repo):
+        res = await verification_routes.face_exists(
+            "22222222-2222-2222-2222-222222222222", tenant_id=None
+        )
+
+    assert res.exists is False
+    assert res.user_id == "22222222-2222-2222-2222-222222222222"
+
+
+@pytest.mark.asyncio
+async def test_face_exists_forwards_tenant_scope():
+    """A supplied tenant_id is forwarded to repo.exists (verify-path parity)."""
+    repo = Mock()
+    repo.exists = AsyncMock(return_value=True)
+
+    with patch.object(verification_routes, "get_embedding_repository", return_value=repo):
+        await verification_routes.face_exists(
+            "33333333-3333-3333-3333-333333333333", tenant_id="tenant-x"
+        )
+
+    repo.exists.assert_awaited_once_with(
+        "33333333-3333-3333-3333-333333333333", "tenant-x"
+    )
+
+
+@pytest.mark.asyncio
+async def test_face_exists_invalid_user_id_returns_400():
+    """A malformed user_id is a clean 400, not a 500."""
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        await verification_routes.face_exists("not a uuid !!", tenant_id=None)
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_face_exists_never_runs_inference():
+    """The probe is a pure store lookup — it must not invoke the verify use case."""
+    repo = Mock()
+    repo.exists = AsyncMock(return_value=True)
+    verify_uc = Mock()
+    verify_uc.match_embedding = AsyncMock(side_effect=AssertionError("must not match"))
+
+    with patch.object(verification_routes, "get_embedding_repository", return_value=repo), \
+         patch.object(verification_routes, "get_verify_face_use_case", return_value=verify_uc):
+        await verification_routes.face_exists(
+            "44444444-4444-4444-4444-444444444444", tenant_id=None
+        )
+
+    verify_uc.match_embedding.assert_not_awaited()

--- a/tests/unit/api/test_voice_routes.py
+++ b/tests/unit/api/test_voice_routes.py
@@ -345,6 +345,72 @@ async def test_verify_confidence_invariant_to_centroid_magnitude():
     assert _direct_dot(probe, centroid_small) < _direct_dot(probe, centroid_big)
 
 
+# ---------------------------------------------------------------------------
+# Login triage F2/F7 — real voice-enrollment existence probe.
+#
+# identity-core-api's EnrollmentHealthService previously FAKED VOICE as
+# always-enrolled (it could not query biometric_db), routing un-enrolled users
+# into a voice step that could never pass. GET /voice/{user_id}/exists is the
+# cheap, authoritative probe it now calls. These tests pin its contract.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_voice_exists_true_when_enrollment_present():
+    """exists=True for a user with a stored voiceprint; repo.exists is consulted."""
+    repo = Mock()
+    repo.exists = AsyncMock(return_value=True)
+
+    with patch.object(voice_routes, "get_voice_repository", return_value=repo):
+        res = await voice_routes.voice_exists("11111111-1111-1111-1111-111111111111")
+
+    repo.exists.assert_awaited_once_with("11111111-1111-1111-1111-111111111111")
+    assert res.exists is True
+    assert res.user_id == "11111111-1111-1111-1111-111111111111"
+
+
+@pytest.mark.asyncio
+async def test_voice_exists_false_when_not_enrolled():
+    """A definitive exists=False MUST be returned for an un-enrolled user.
+
+    This is the value identity relies on to STOP offering VOICE to users who
+    never enrolled — the core of the F2/F7 fix.
+    """
+    repo = Mock()
+    repo.exists = AsyncMock(return_value=False)
+
+    with patch.object(voice_routes, "get_voice_repository", return_value=repo):
+        res = await voice_routes.voice_exists("22222222-2222-2222-2222-222222222222")
+
+    assert res.exists is False
+    assert res.user_id == "22222222-2222-2222-2222-222222222222"
+
+
+@pytest.mark.asyncio
+async def test_voice_exists_never_runs_inference():
+    """The probe must NOT call verify/extract — it is a pure store lookup."""
+    repo = Mock()
+    repo.exists = AsyncMock(return_value=True)
+    repo.find_by_user_id = AsyncMock()
+
+    with patch.object(voice_routes, "get_voice_repository", return_value=repo), \
+         patch.object(voice_routes, "_extract_voice_embedding",
+                      AsyncMock(side_effect=AssertionError("must not extract"))):
+        await voice_routes.voice_exists("33333333-3333-3333-3333-333333333333")
+
+    repo.find_by_user_id.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_voice_exists_invalid_user_id_returns_400():
+    """A malformed user_id is a clean 400, not a 500."""
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        await voice_routes.voice_exists("not a uuid !!")
+    assert exc.value.status_code == 400
+
+
 @pytest.mark.asyncio
 async def test_verify_genuine_user_not_false_rejected_for_subunit_centroid():
     """A perfect-direction match with a sub-0.65 norm must still verify.


### PR DESCRIPTION
## Root cause (login triage F2/F7 — voice always fails; F9 — face \"fake-enrolled\" trap)

`identity-core-api` cannot query `biometric_db` (the embeddings live in a separate DB owned by this service). So `EnrollmentHealthService.hasBiometricData(FACE/VOICE)` only checked that the bio service was *reachable* and then `return true` — FAKING enrollment as always-present. `AvailableMethodsResolver` then computed `enrolled = health || !requiresEnrollment = always true` for VOICE/FACE → un-enrolled users got routed into a VOICE step → `verify_voice` found no centroid → \"No voice enrollment found\" → generic \"Doğrulama başarısız\". FACE was masked only because most demo users actually enrolled a face.

## This PR (bio half)

Adds the real, cheap existence probes identity needs so it can stop faking enrollment:

- **`GET /voice/{user_id}/exists`** → `{user_id, exists}` — user-scoped (matches `/voice/verify`, which is not tenant-scoped). Backed by new `PgVectorVoiceRepository.exists`.
- **`GET /face/{user_id}/exists`** → `{user_id, exists}` — optional `?tenant_id=` for verify-path parity. Backed by the existing `PgVectorEmbeddingRepository.exists`.

Both are a single `SELECT EXISTS(...)` against the real embedding store — **no inference, no vector decrypt**. Same `X-API-Key` middleware auth as every other `/api/*` route; existing routes untouched.

## Tests

`tests/unit/api/test_face_exists_route.py` (5) + voice cases added to `test_voice_routes.py` (4): exists=true, definitive exists=false, tenant-scope forwarding (face), no-inference, invalid user_id → 400. All green:

```
tests/unit/api/test_voice_routes.py .............
tests/unit/api/test_face_exists_route.py .....
18 passed
```

## Companion / deploy

The `identity-core-api` PR consumes these (rewrites `EnrollmentHealthService.hasBiometricData` to probe them, behind kill-switch flag `app.auth.enrollment-probe.enabled` default true; fail-open only on transport/5xx). **Prod rollout needs a Hetzner deploy of bio first, then identity.**