### PR TITLE
feat(gpuless): default-OFF kill-switch for proctoring + live-analysis routers (0-caller heavy ML) + WS auth

### DIFF
--- a/app/api/routes/live_analysis.py
+++ b/app/api/routes/live_analysis.py
@@ -11,6 +11,7 @@ Clients send camera frames via WebSocket and receive instant feedback.
 """
 
 import base64
+import hmac
 import io
 import json
 import logging
@@ -19,8 +20,10 @@ from typing import Optional
 
 import cv2
 import numpy as np
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Depends
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Depends, status
 from PIL import Image
+
+from app.core.config import settings
 
 from app.api.schemas.live_analysis import (
     AnalysisMode,
@@ -53,6 +56,45 @@ from app.infrastructure.ml.liveness.temporal_consistency_analyzer import Tempora
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Live Analysis"])
+
+
+def _is_ws_authenticated(websocket: WebSocket) -> bool:
+    """Authenticate a live-analysis WebSocket against the service API key.
+
+    SECURITY (GPU-less hardening 2026-06-12): the HTTP API-key guard registered
+    via ``@app.middleware("http")`` in ``app.main`` ONLY runs for HTTP scopes —
+    WebSocket scopes bypass it entirely, so ``/ws/live-analysis`` was reachable
+    with no key on the Docker network and ran the full per-frame ML stack
+    (incl. optional DeepFace demographics ~400 MB). This mirrors the same
+    API-key mechanism the rest of the service uses (``X-API-Key`` header), with
+    a query-param fallback (``api_key=``) because browser ``WebSocket`` clients
+    cannot set custom headers.
+
+    Fail-closed: when API-key auth is active (the same condition that arms the
+    HTTP middleware) a missing/invalid key returns False so the caller closes
+    the socket with a policy-violation code. When API-key auth is NOT configured
+    (dev/test, ``API_KEY_ENABLED``/``API_KEY_REQUIRE_AUTH`` false) this returns
+    True, matching the HTTP path which also skips the check in that mode.
+    """
+    if not (settings.API_KEY_ENABLED and settings.API_KEY_REQUIRE_AUTH):
+        return True
+
+    expected = settings.API_KEY_SECRET
+    if not expected:
+        # Misconfiguration: auth is required but no secret is set. Fail closed.
+        logger.error("WS auth misconfigured: API_KEY_REQUIRE_AUTH but no API_KEY_SECRET")
+        return False
+
+    header_name = settings.API_KEY_HEADER
+    provided = websocket.headers.get(header_name)
+    if provided is None:
+        # Browser WebSocket clients cannot set custom headers — accept the key
+        # via query param as the documented fallback.
+        provided = websocket.query_params.get("api_key")
+
+    if not provided or not hmac.compare_digest(provided, expected):
+        return False
+    return True
 
 
 class LiveAnalysisSession:
@@ -269,6 +311,18 @@ async def live_analysis_websocket(
         };
         ```
     """
+    # SECURITY (GPU-less hardening 2026-06-12): authenticate BEFORE accept().
+    # The HTTP API-key middleware does not run for WebSocket scopes, so without
+    # this check the full per-frame ML stack was reachable with no key on the
+    # Docker network. Fail-closed: reject with a policy-violation close code.
+    if not _is_ws_authenticated(websocket):
+        logger.warning(
+            f"Live analysis WebSocket rejected: missing/invalid API key "
+            f"(client={websocket.client})"
+        )
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        return
+
     await websocket.accept()
     logger.info(f"Live analysis WebSocket connected: {websocket.client}")
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -622,6 +622,31 @@ class Settings(BaseSettings):
     # Proctoring Service Configuration
     # ============================================================================
 
+    # Router mount kill-switch (GPU-less hardening 2026-06-12).
+    # NOTE: the proctoring + live-analysis routers run the HEAVIEST per-frame ML
+    # in the service (YOLOv8 object detection + MediaPipe gaze + texture/FFT +
+    # optical-flow deepfake + full MTCNN+Facenet512 face-verify + UniFace
+    # MiniFASNet liveness, plus optional DeepFace demographics ~400 MB). They have
+    # ZERO production callers (verified: no /proctor, /live-analysis, or
+    # /ws/live-analysis references in identity-core-api or web-app), yet were
+    # mounted UNCONDITIONALLY — un-gated per-frame heavy ML reachable on a
+    # CPU-only box (Hetzner CX43, bio container capped 4 CPU/4 GiB).
+    # OFF by default so prod no longer carries this surface. Flip to True to
+    # restore (mirrors DEMOGRAPHICS_ROUTER_ENABLED / FLASH_CHALLENGE_ROUTE_ENABLED).
+    # The dead PROCTOR_ENABLED flag below only feeds a debug summary dict
+    # (dependencies/proctor.py:get_proctor_config_summary) — it gates nothing and
+    # is retained for back-compat; the operator off-intent is now enforced here.
+    PROCTORING_ROUTER_ENABLED: bool = Field(
+        default=False,
+        description=(
+            "Enable the /api/v1/proctoring/* (HTTP + WebSocket) and "
+            "/api/v1/ws/live-analysis routers. OFF by default — these have zero "
+            "production callers and run heavy per-frame ML (YOLO/MediaPipe/"
+            "deepfake/Facenet512/MiniFASNet) unsuited to the CPU-only box. Set "
+            "PROCTORING_ROUTER_ENABLED=true to restore."
+        ),
+    )
+
     # Feature Flags
     PROCTOR_ENABLED: bool = Field(default=True)
     PROCTOR_GAZE_ENABLED: bool = Field(default=True)

--- a/app/main.py
+++ b/app/main.py
@@ -341,14 +341,33 @@ app.include_router(similarity_matrix.router, prefix=API_PREFIX)
 app.include_router(embeddings_io.router, prefix=API_PREFIX)
 app.include_router(webhooks.router, prefix=API_PREFIX)
 
-# Proctoring routes
-app.include_router(proctor.router, prefix=API_PREFIX)
-
-# WebSocket routes (proctoring real-time streaming)
-app.include_router(proctor_ws.router, prefix=API_PREFIX)
-
-# WebSocket routes (live camera analysis)
-app.include_router(live_analysis.router, prefix=API_PREFIX)
+# Proctoring + live-analysis routes (GPU-less hardening 2026-06-12).
+# These three routers run the heaviest per-frame ML in the service (YOLOv8 +
+# MediaPipe gaze + texture/FFT+optical-flow deepfake + MTCNN+Facenet512 +
+# UniFace MiniFASNet liveness, plus optional DeepFace demographics ~400 MB) and
+# have ZERO production callers (no /proctor, /live-analysis, or
+# /ws/live-analysis references in identity-core-api or web-app). They are gated
+# behind PROCTORING_ROUTER_ENABLED (default OFF) so this un-gated heavy ML is
+# not mounted on the CPU-only box. Flip the flag True to restore — mirrors the
+# DEMOGRAPHICS_ROUTER_ENABLED (above) and FLASH_CHALLENGE_ROUTE_ENABLED (below)
+# patterns. The /ws/live-analysis WebSocket additionally lacked any auth on
+# accept (the @app.middleware HTTP API-key guard never runs for WS scopes); an
+# API-key check on accept now lives in live_analysis.py as defence in depth.
+if settings.PROCTORING_ROUTER_ENABLED:
+    app.include_router(proctor.router, prefix=API_PREFIX)
+    app.include_router(proctor_ws.router, prefix=API_PREFIX)
+    app.include_router(live_analysis.router, prefix=API_PREFIX)
+    logger.info(
+        "Proctoring + live-analysis routers enabled "
+        "(PROCTORING_ROUTER_ENABLED=true)"
+    )
+else:
+    logger.info(
+        "Proctoring + live-analysis routers DISABLED "
+        "(PROCTORING_ROUTER_ENABLED=false). These have zero production callers "
+        "and run heavy per-frame ML; set PROCTORING_ROUTER_ENABLED=true to "
+        "mount /api/v1/proctoring/* and /api/v1/ws/live-analysis."
+    )
 
 # Admin routes
 app.include_router(admin.router, prefix=API_PREFIX)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,8 +160,14 @@ services:
       MULTI_IMAGE_MIN_IMAGES: ${MULTI_IMAGE_MIN_IMAGES:-2}
       MULTI_IMAGE_MAX_IMAGES: ${MULTI_IMAGE_MAX_IMAGES:-5}
 
-      # Proctoring
-      PROCTORING_ENABLED: ${PROCTORING_ENABLED:-true}
+      # Proctoring + live-analysis router kill-switch (GPU-less hardening).
+      # OFF by default — these routers have zero production callers and run the
+      # heaviest per-frame ML in the service on a CPU-only box. Flip to true to
+      # restore. NOTE: the old PROCTORING_ENABLED env var was a NO-OP (the code
+      # reads PROCTOR_ENABLED, which itself only fed a debug dict), so the
+      # operator's off-intent was silently dropped. PROCTORING_ROUTER_ENABLED is
+      # the real router-mount switch (see app/core/config.py + app/main.py).
+      PROCTORING_ROUTER_ENABLED: ${PROCTORING_ROUTER_ENABLED:-false}
       PROCTORING_MAX_SESSION_DURATION: ${PROCTORING_MAX_SESSION_DURATION:-7200}
       PROCTORING_FRAME_RATE_LIMIT: ${PROCTORING_FRAME_RATE_LIMIT:-5}
 

--- a/tests/unit/test_proctoring_router_gating.py
+++ b/tests/unit/test_proctoring_router_gating.py
@@ -1,0 +1,214 @@
+"""Tests for the proctoring + live-analysis router kill-switch.
+
+GPU-less hardening (2026-06-12): the proctoring HTTP/WebSocket routers and the
+``/ws/live-analysis`` WebSocket run the HEAVIEST per-frame ML in the service
+(YOLOv8 object detection + MediaPipe gaze + texture/FFT+optical-flow deepfake +
+MTCNN+Facenet512 face-verify + UniFace MiniFASNet liveness, plus optional
+DeepFace demographics ~400 MB) yet had ZERO production callers (no /proctor,
+/live-analysis, or /ws/live-analysis references in identity-core-api or
+web-app). They were mounted UNCONDITIONALLY on a CPU-only box.
+
+They are now gated behind ``PROCTORING_ROUTER_ENABLED`` (default False),
+mirroring the existing ``DEMOGRAPHICS_ROUTER_ENABLED`` pattern. The
+``/ws/live-analysis`` WebSocket additionally now authenticates on accept via
+the same API-key mechanism the rest of the service uses, because the HTTP
+``@app.middleware`` API-key guard never runs for WebSocket scopes.
+
+Implementation note: we don't import ``app.main`` directly (it wires up the
+full container, GPU detection, lifespan handlers, and real ML preloading).
+Instead we replicate the small gating block under test on a fresh ``FastAPI``
+instance, mirroring ``test_demographics_gating.py``.
+"""
+
+import importlib
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+API_PREFIX = "/api/v1"
+
+
+def _try_import(module: str):
+    """Import a heavy-ML route module, skipping cleanly if deps are missing.
+
+    Importing the proctoring / live-analysis routers transitively pulls cv2,
+    DeepFace, etc. via ``app.core.container``. In a stripped-down dev env those
+    may be missing — skip the route-registration tests while the Settings-default
+    tests below keep running.
+    """
+    try:
+        return importlib.import_module(module)
+    except ImportError as e:  # pragma: no cover - exercised only in light envs
+        pytest.skip(f"heavy ML deps not installed: {e}")
+
+
+def _build_app(*, proctoring_enabled: bool) -> FastAPI:
+    """Build a minimal FastAPI app with the same gating logic as main.py."""
+    app = FastAPI()
+    if proctoring_enabled:
+        proctor = _try_import("app.api.routes.proctor")
+        proctor_ws = _try_import("app.api.routes.proctor_ws")
+        live_analysis = _try_import("app.api.routes.live_analysis")
+        app.include_router(proctor.router, prefix=API_PREFIX)
+        app.include_router(proctor_ws.router, prefix=API_PREFIX)
+        app.include_router(live_analysis.router, prefix=API_PREFIX)
+    return app
+
+
+class TestProctoringRouterGating:
+    """Proctoring + live-analysis routers must be off by default."""
+
+    def test_routers_absent_when_disabled(self):
+        """With the flag OFF, proctoring + live-analysis routes must 404."""
+        app = _build_app(proctoring_enabled=False)
+        client = TestClient(app)
+
+        # Proctoring HTTP route — must not exist.
+        resp = client.post(f"{API_PREFIX}/proctoring/sessions")
+        assert resp.status_code == 404, (
+            f"expected 404 (route not registered) but got {resp.status_code}: "
+            f"{resp.text[:200]}"
+        )
+
+        # OpenAPI schema must NOT advertise the paths either.
+        schema = client.get("/openapi.json").json()
+        paths = schema.get("paths", {})
+        assert f"{API_PREFIX}/proctoring/sessions" not in paths
+        assert f"{API_PREFIX}/ws/live-analysis" not in paths
+
+    def test_routers_present_when_enabled(self):
+        """With the flag ON, proctoring + live-analysis routes are registered.
+
+        We assert against the app's route table directly rather than driving a
+        TestClient: building the OpenAPI schema / hitting a handler would resolve
+        the proctor session-repository dependency, which raises unless a postgres
+        DATABASE_URL is configured (in-memory storage was removed for prod
+        safety). Inspecting ``app.routes`` proves the gating block mounted the
+        routers without needing a live DB, which is exactly what's under test.
+        """
+        app = _build_app(proctoring_enabled=True)
+        mounted = {getattr(r, "path", None) for r in app.routes}
+
+        assert f"{API_PREFIX}/proctoring/sessions" in mounted, (
+            "proctoring HTTP route should be registered when "
+            "PROCTORING_ROUTER_ENABLED=true"
+        )
+        assert f"{API_PREFIX}/ws/live-analysis" in mounted, (
+            "live-analysis WebSocket route should be registered when "
+            "PROCTORING_ROUTER_ENABLED=true"
+        )
+
+
+class TestProctoringRouterDefault:
+    """The Settings default for PROCTORING_ROUTER_ENABLED must be False."""
+
+    def test_default_is_false(self):
+        """Settings() default must NOT enable the proctoring routers."""
+        from app.core.config import Settings
+
+        s = Settings(_env_file=None)
+        assert s.PROCTORING_ROUTER_ENABLED is False, (
+            "PROCTORING_ROUTER_ENABLED must default to False — zero production "
+            "callers + heaviest per-frame ML on a CPU-only box"
+        )
+
+    def test_explicit_true_is_respected(self):
+        """Operators can opt in via env/kwarg."""
+        from app.core.config import Settings
+
+        s = Settings(_env_file=None, PROCTORING_ROUTER_ENABLED=True)
+        assert s.PROCTORING_ROUTER_ENABLED is True
+
+
+class TestLiveAnalysisWebSocketAuth:
+    """The /ws/live-analysis WebSocket must authenticate on accept.
+
+    The HTTP API-key middleware does not run for WebSocket scopes, so the
+    socket was reachable with no key on the Docker network. ``_is_ws_authenticated``
+    closes that gap, fail-closed, using the same API-key mechanism as the rest
+    of the service.
+    """
+
+    def _auth_fn(self):
+        live_analysis = _try_import("app.api.routes.live_analysis")
+        return live_analysis._is_ws_authenticated
+
+    def _fake_ws(self, *, headers=None, query=None):
+        """Minimal duck-typed stand-in for starlette's WebSocket."""
+
+        class _FakeWS:
+            def __init__(self, headers, query):
+                self.headers = headers or {}
+                self.query_params = query or {}
+                self.client = ("127.0.0.1", 0)
+
+        return _FakeWS(headers, query)
+
+    def test_open_when_api_key_auth_disabled(self, monkeypatch):
+        """When API-key auth is not configured, WS auth passes (matches HTTP)."""
+        from app.core.config import settings
+
+        auth = self._auth_fn()
+        monkeypatch.setattr(settings, "API_KEY_ENABLED", False, raising=False)
+        monkeypatch.setattr(settings, "API_KEY_REQUIRE_AUTH", False, raising=False)
+        assert auth(self._fake_ws()) is True
+
+    def test_rejected_without_key_when_required(self, monkeypatch):
+        """With API-key auth armed, a keyless socket is rejected (fail-closed)."""
+        from app.core.config import settings
+
+        auth = self._auth_fn()
+        monkeypatch.setattr(settings, "API_KEY_ENABLED", True, raising=False)
+        monkeypatch.setattr(settings, "API_KEY_REQUIRE_AUTH", True, raising=False)
+        monkeypatch.setattr(settings, "API_KEY_SECRET", "s3cret", raising=False)
+        monkeypatch.setattr(settings, "API_KEY_HEADER", "X-API-Key", raising=False)
+        assert auth(self._fake_ws()) is False
+
+    def test_accepts_valid_key_via_header(self, monkeypatch):
+        """A correct X-API-Key header is accepted."""
+        from app.core.config import settings
+
+        auth = self._auth_fn()
+        monkeypatch.setattr(settings, "API_KEY_ENABLED", True, raising=False)
+        monkeypatch.setattr(settings, "API_KEY_REQUIRE_AUTH", True, raising=False)
+        monkeypatch.setattr(settings, "API_KEY_SECRET", "s3cret", raising=False)
+        monkeypatch.setattr(settings, "API_KEY_HEADER", "X-API-Key", raising=False)
+        ws = self._fake_ws(headers={"X-API-Key": "s3cret"})
+        assert auth(ws) is True
+
+    def test_accepts_valid_key_via_query_param(self, monkeypatch):
+        """Browser WS clients can pass the key via ?api_key= fallback."""
+        from app.core.config import settings
+
+        auth = self._auth_fn()
+        monkeypatch.setattr(settings, "API_KEY_ENABLED", True, raising=False)
+        monkeypatch.setattr(settings, "API_KEY_REQUIRE_AUTH", True, raising=False)
+        monkeypatch.setattr(settings, "API_KEY_SECRET", "s3cret", raising=False)
+        monkeypatch.setattr(settings, "API_KEY_HEADER", "X-API-Key", raising=False)
+        ws = self._fake_ws(query={"api_key": "s3cret"})
+        assert auth(ws) is True
+
+    def test_rejects_wrong_key(self, monkeypatch):
+        """An incorrect key is rejected."""
+        from app.core.config import settings
+
+        auth = self._auth_fn()
+        monkeypatch.setattr(settings, "API_KEY_ENABLED", True, raising=False)
+        monkeypatch.setattr(settings, "API_KEY_REQUIRE_AUTH", True, raising=False)
+        monkeypatch.setattr(settings, "API_KEY_SECRET", "s3cret", raising=False)
+        monkeypatch.setattr(settings, "API_KEY_HEADER", "X-API-Key", raising=False)
+        ws = self._fake_ws(headers={"X-API-Key": "wrong"})
+        assert auth(ws) is False
+
+    def test_fail_closed_when_secret_missing(self, monkeypatch):
+        """Auth required but no secret configured -> reject (misconfiguration)."""
+        from app.core.config import settings
+
+        auth = self._auth_fn()
+        monkeypatch.setattr(settings, "API_KEY_ENABLED", True, raising=False)
+        monkeypatch.setattr(settings, "API_KEY_REQUIRE_AUTH", True, raising=False)
+        monkeypatch.setattr(settings, "API_KEY_SECRET", "", raising=False)
+        ws = self._fake_ws(headers={"X-API-Key": "anything"})
+        assert auth(ws) is False


### PR DESCRIPTION
## Why

The prod box is **CPU-only** (Hetzner CX43, bio container capped 4 CPU / 4 GiB). A GPU-less audit found two server-side heavy-ML subsystems that ran **per-frame ML, were un-gated, reachable, and had ZERO production callers** — verified: no `/proctor`, `/live-analysis`, or `/ws/live-analysis` references anywhere in **identity-core-api** or **web-app**. Gating them OFF is safe: 0 callers means no functionality is lost.

The per-frame stack these routers run: YOLOv8 object detection + MediaPipe gaze + texture/FFT + optical-flow deepfake + full MTCNN+Facenet512 face-verify + UniFace MiniFASNet liveness, plus optional DeepFace demographics (~400 MB).

## H4 — Proctoring (heaviest; kill-switch was a no-op typo)

- `app/main.py` mounted the `proctor`, `proctor_ws`, and `live_analysis` routers **unconditionally**.
- The intended kill-switch was broken: compose/`.env` set `PROCTORING_ENABLED` but the code reads `PROCTOR_ENABLED` (default `True`), and that flag only feeds a debug dict (`dependencies/proctor.py` `get_proctor_config_summary`) — it gates nothing. `model_config` has `extra:"ignore"`, so the wrong env key was silently dropped and the operator's off-intent never took effect.

**Fix:** added a real router-mount kill-switch `PROCTORING_ROUTER_ENABLED` (`config.py`, **default False**), mirroring the existing `DEMOGRAPHICS_ROUTER_ENABLED` and `FLASH_CHALLENGE_ROUTE_ENABLED` patterns. Gated all three router registrations behind it in `main.py` (default OFF = not mounted). Repointed `docker-compose.yml` from the dead `PROCTORING_ENABLED` to the working `PROCTORING_ROUTER_ENABLED` (default `false`). Kept the per-feature `PROCTOR_*_ENABLED` flags as-is.

## H5 — `/ws/live-analysis` WebSocket (un-gated AND unauthenticated)

- `websocket.accept()` had **no token/API-key check** — the HTTP `@app.middleware` API-key guard does not run for WebSocket scopes, so the socket was reachable with **no key** on the Docker network and ran the full ML stack (incl. optional DeepFace demographics) per frame.

**Fix:** gated the `live_analysis` router under the same `PROCTORING_ROUTER_ENABLED` kill-switch, AND added WS authentication on accept using the **same API-key mechanism as the rest of the service** (`X-API-Key` header, with an `?api_key=` query-param fallback for browser WebSocket clients that can't set headers). Fail-closed: the socket is closed with `WS_1008_POLICY_VIOLATION` if the key is absent/invalid. The check is armed under the same condition as the HTTP middleware (`API_KEY_ENABLED` + `API_KEY_REQUIRE_AUTH`), so it's active in prod and inert in dev/test.

## Reversibility

Set `PROCTORING_ROUTER_ENABLED=true` to restore all three routers (no redeploy of code needed — env flip only). No functionality is lost: **0 production callers**. Net effect: removes un-gated per-frame heavy ML from a CPU-only box.

## Tests

`tests/unit/test_proctoring_router_gating.py` (mirrors `test_demographics_gating.py`):
- routers absent when flag OFF (404 + not in OpenAPI), present when ON
- `Settings` default for `PROCTORING_ROUTER_ENABLED` is `False`; explicit `True` respected
- WS auth helper: open when API-key auth disabled; reject keyless / wrong key when armed; accept valid key via header and via `?api_key=`; fail-closed when secret missing

14/14 pass locally (incl. existing demographics-gating regressions).