### PR TITLE
feat(voice): GPU-less client-side speaker-embedding path (audit H3, flag-gated default OFF)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,41 @@ leaves the device. Two additive JSON routes accept it:
   a derived, non-invertible 512-d embedding, over TLS, stored encrypted (Fernet) —
   data minimization, NOT "biometric data never leaves the device".
 
+### Client-computed VOICE embedding (GPU-less, audit H3, flag-gated, default OFF — 2026-06-12):
+Mirror of the face embedding path for VOICE. The browser computes the 256-d
+Resemblyzer GE2E speaker embedding locally (onnxruntime-web) and submits ONLY the
+vector — the raw audio never leaves the device; the server skips decode/VAD/forward.
+Two additive JSON routes in `voice.py`:
+- **`POST /voice/verify-embedding`** — `{user_id, embedding[256]}`. Runs the SAME
+  pgvector cosine compare + 0.65 threshold as the audio `/voice/verify` (both share
+  the `_match_probe_against_enrollment` helper + module-level `VERIFY_THRESHOLD`),
+  but SKIPS the audio decode, VAD, quality scoring, replay check and the server-side
+  Resemblyzer forward pass. Length-validated to exactly 256 (HTTP 422 otherwise).
+- **`POST /voice/enroll-embedding`** — `{user_id, embedding[256], optimize?}`. Stores
+  the client vector via the SAME `PgVectorVoiceRepository.save` centroid path (INDIVIDUAL
+  row + recomputed CENTROID, encrypt-at-rest) as audio `/voice/enroll`; no decoded audio
+  to score, so `quality_score` is a neutral 0.5. `optimize=True` takes the re-enroll fusion path.
+- **SECURITY — NO REPLAY/LIVENESS HERE.** No audio ⇒ the spectral-fingerprint replay
+  detector (needs decoded samples) can't run, and there's no live-capture proof. REQUIRES
+  a paired liveness factor enforced at the Identity Core layer. Gated by Identity Core
+  `app.auth.client-side-voice-embedding` (default OFF); the audio `/voice/verify` +
+  `/voice/enroll` path is unchanged and remains the default + fallback.
+- **ONNX export (DONE + VERIFIED):** `scripts/export_resemblyzer_onnx.py` exports the
+  pinned `resemblyzer/pretrained.pt` (1.42M-param 3-layer LSTM + Linear) to ONNX
+  (opset 17, FP32, ~5.7 MB, dynamic n_frames). torch↔ONNX cosine parity = 1.0 (random mel
+  batches + end-to-end vs `embed_utterance`). The export FAILS if parity < 0.999.
+- **Client preprocessing port = SCAFFOLD (NOT verified).** The browser must reproduce
+  resemblyzer's `preprocess_wav` (dBFS norm + WebRTC VAD mode-3 silence trim) +
+  `wav_to_mel_spectrogram` (librosa power-mel, n_fft 400 / hop 160 / 40 mels) +
+  partial-slice/mean/L2-norm. The WebRTC VAD has no bit-exact JS port; skipping it
+  measured ≈0.89 same-clip cosine vs server (impostor ≈0.40) — risky near the 0.65
+  threshold. Full load-bearing contract + canary steps:
+  `docs/design/VOICE_CLIENT_EMBEDDING_SPEC.md`. Do not enable the web flag until the
+  client mel+VAD is validated to parity.
+- NOTE: the `get_speaker_embedder` container comment claiming "numba-free MFCC + torch
+  projection" was WRONG and is now corrected — it is the real ~17 MB pretrained
+  Resemblyzer GE2E LSTM (librosa supplies the mel input).
+
 ### Puzzle liveness session (flag-gated, default OFF — server-authoritative, anti-replay):
 `puzzle.py` exposes a server-issued, single-use liveness session that spans the 14
 face + 9 hand challenge types (canonical contract:

--- a/app/api/routes/voice.py
+++ b/app/api/routes/voice.py
@@ -16,11 +16,11 @@ Integration:
 """
 
 import logging
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from app.api.schemas.biometric_response import BiometricResponse as _SharedBiometricResponse
 from app.core.container import (
@@ -36,6 +36,13 @@ from app.infrastructure.ml.voice.speaker_embedder import compute_voice_quality_s
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Voice"])
+
+# Accept threshold for 1:1 voice verification (cosine *similarity* >= this).
+# Shared by the audio ``/voice/verify`` and the precomputed-embedding
+# ``/voice/verify-embedding`` paths so both apply the IDENTICAL decision — the
+# only difference between the two is WHERE the probe embedding is produced
+# (server-side ``embed_utterance`` vs client-side, flag-gated).
+VERIFY_THRESHOLD = 0.65
 
 
 def _l2_normalize(vec: np.ndarray) -> np.ndarray:
@@ -58,6 +65,55 @@ def _l2_normalize(vec: np.ndarray) -> np.ndarray:
     return vec / norm
 
 
+async def _match_probe_against_enrollment(
+    user_id: str, probe_embedding: np.ndarray
+) -> "BiometricResponse":
+    """Run the shared pgvector cosine compare + decision for a probe embedding.
+
+    This is the EXACT tail both ``/voice/verify`` (server-embedded probe) and
+    ``/voice/verify-embedding`` (client-supplied probe) run AFTER a 256-d probe
+    embedding exists: load the enrolled centroid, L2-normalize both operands,
+    cosine-compare, threshold at :data:`VERIFY_THRESHOLD`. Centralising it
+    guarantees the two paths can never drift in their match semantics.
+    """
+    repo = get_voice_repository()
+    enrolled_embedding = await repo.find_by_user_id(user_id)
+
+    if enrolled_embedding is None:
+        return BiometricResponse(
+            success=False,
+            verified=False,
+            message="No voice enrollment found for this user",
+            user_id=user_id,
+            confidence=0.0,
+        )
+
+    # Cosine similarity. P1-10: the stored centroid (default enroll path) is
+    # AVG(embedding) and is NOT unit-norm, so a raw dot product decays with
+    # enrollment count. L2-normalize BOTH operands so the result is a true
+    # cosine similarity regardless of how many samples were enrolled.
+    unit_probe = _l2_normalize(probe_embedding)
+    unit_centroid = _l2_normalize(enrolled_embedding)
+    similarity = float(np.dot(unit_probe, unit_centroid))
+    similarity = max(0.0, min(1.0, similarity))
+
+    verified = similarity >= VERIFY_THRESHOLD
+
+    logger.info(
+        f"Voice verification: user_id={user_id}, "
+        f"similarity={similarity:.4f}, threshold={VERIFY_THRESHOLD}, "
+        f"verified={verified}"
+    )
+
+    return BiometricResponse(
+        success=True,
+        verified=verified,
+        confidence=round(similarity, 4),
+        message="Voice verified successfully" if verified else "Voice verification failed",
+        user_id=user_id,
+    )
+
+
 # -- Request / Response schemas ------------------------------------------------
 
 
@@ -68,6 +124,58 @@ class VoiceRequest(BaseModel):
     # the new sample is fused into the existing centroid instead of a plain
     # append/average. Optional + default False, so the normal enroll JSON body
     # is unchanged and older callers keep working.
+    optimize: bool = Field(False)
+
+
+# Resemblyzer GE2E speaker-embedding dimensionality. The precomputed-embedding
+# routes accept EXACTLY this many floats (mirrors the 256-dim pgvector column
+# and ``speaker_embedder.VOICE_EMBEDDING_DIM``). A wrong length is HTTP 422.
+VOICE_EMBEDDING_DIMENSION = 256
+
+
+class VoiceEmbeddingRequest(BaseModel):
+    """Request body for the precomputed-voice-embedding routes (client-side).
+
+    The client (browser/device) has ALREADY computed the 256-d Resemblyzer
+    speaker embedding locally — the raw audio never leaves the device — and
+    submits the raw vector. The server SKIPS the audio decode + VAD +
+    Resemblyzer forward pass and runs ONLY the same pgvector cosine compare /
+    centroid storage the audio routes run AFTER ``embed_utterance``.
+
+    SECURITY: like the FACE ``/verify-embedding`` route, this path receives no
+    audio so NO liveness / replay-attack check is (or can be) performed here.
+    A matched embedding only proves "this vector matches the template", not "a
+    live person spoke now"; the Identity Core layer MUST pair it with a liveness
+    factor before trusting it as a login factor.
+    """
+
+    user_id: str = Field(..., max_length=255)
+    embedding: List[float] = Field(
+        ...,
+        description=(
+            f"Precomputed {VOICE_EMBEDDING_DIMENSION}-d Resemblyzer speaker "
+            "embedding, computed client-side."
+        ),
+    )
+
+    @field_validator("embedding")
+    @classmethod
+    def _validate_embedding_length(cls, value: List[float]) -> List[float]:
+        if len(value) != VOICE_EMBEDDING_DIMENSION:
+            raise ValueError(
+                f"embedding must have exactly {VOICE_EMBEDDING_DIMENSION} "
+                f"elements, got {len(value)}"
+            )
+        return value
+
+
+class VoiceEnrollEmbeddingRequest(VoiceEmbeddingRequest):
+    """Request body for ``POST /voice/enroll-embedding`` (client-side embedding).
+
+    Adds the ``optimize`` re-enroll fusion flag (same semantics as
+    :class:`VoiceRequest`) on top of the shared length-validated embedding body.
+    """
+
     optimize: bool = Field(False)
 
 
@@ -217,10 +325,9 @@ async def enroll_voice(request: VoiceRequest) -> BiometricResponse:
 async def verify_voice(request: VoiceRequest) -> BiometricResponse:
     """Verify a user's voice against their enrolled centroid.
 
-    Returns cosine similarity as confidence. Threshold is 0.65.
+    Returns cosine similarity as confidence. Threshold is
+    :data:`VERIFY_THRESHOLD` (0.65).
     """
-    VERIFY_THRESHOLD = 0.65
-
     try:
         user_id = validate_user_id(request.user_id)
 
@@ -235,49 +342,10 @@ async def verify_voice(request: VoiceRequest) -> BiometricResponse:
         # its anti-spoof check. Never blocks verification today.
         await _run_replay_check(voice_data, user_id=user_id)
 
-        # Extract speaker embedding from probe audio (CPU-bound)
+        # Extract speaker embedding from probe audio (CPU-bound), then run the
+        # shared cosine compare + decision (identical to /voice/verify-embedding).
         probe_embedding = await _extract_voice_embedding(voice_data)
-
-        # Load enrolled centroid (async I/O)
-        repo = get_voice_repository()
-        enrolled_embedding = await repo.find_by_user_id(user_id)
-
-        if enrolled_embedding is None:
-            return BiometricResponse(
-                success=False,
-                verified=False,
-                message="No voice enrollment found for this user",
-                user_id=user_id,
-                confidence=0.0,
-            )
-
-        # Cosine similarity. P1-10: the stored centroid (default enroll path) is
-        # AVG(embedding) and is NOT unit-norm, so a raw dot product decays with
-        # enrollment count. L2-normalize BOTH operands here so the result is a
-        # true cosine similarity regardless of how many samples were enrolled.
-        # (The probe is already unit-norm from the embedder; normalizing it too
-        # is a harmless no-op and keeps the path robust to any future change.)
-        unit_probe = _l2_normalize(probe_embedding)
-        unit_centroid = _l2_normalize(enrolled_embedding)
-        similarity = float(np.dot(unit_probe, unit_centroid))
-        # Clamp to [0, 1]
-        similarity = max(0.0, min(1.0, similarity))
-
-        verified = similarity >= VERIFY_THRESHOLD
-
-        logger.info(
-            f"Voice verification: user_id={user_id}, "
-            f"similarity={similarity:.4f}, threshold={VERIFY_THRESHOLD}, "
-            f"verified={verified}"
-        )
-
-        return BiometricResponse(
-            success=True,
-            verified=verified,
-            confidence=round(similarity, 4),
-            message="Voice verified successfully" if verified else "Voice verification failed",
-            user_id=user_id,
-        )
+        return await _match_probe_against_enrollment(user_id, probe_embedding)
 
     except ValueError as e:
         logger.warning(f"Voice verification validation error: {e}")
@@ -289,6 +357,129 @@ async def verify_voice(request: VoiceRequest) -> BiometricResponse:
         raise HTTPException(
             status_code=500,
             detail="Voice verification failed. Please try again.",
+        )
+
+
+# -- POST /voice/verify-embedding ---------------------------------------------
+
+
+@router.post("/voice/verify-embedding", response_model=BiometricResponse)
+async def verify_voice_embedding(request: VoiceEmbeddingRequest) -> BiometricResponse:
+    """Verify a user from a PRECOMPUTED 256-d speaker embedding (client-side).
+
+    The client (browser/device) computed the Resemblyzer speaker embedding
+    locally — the raw audio never leaves the device — and submits only the
+    256-vector. This endpoint runs the SAME pgvector cosine compare + threshold
+    decision as the audio ``/voice/verify`` path (via
+    :func:`_match_probe_against_enrollment`), but SKIPS the audio decode, VAD,
+    quality scoring, replay check and the server-side Resemblyzer forward pass —
+    the client already produced the embedding. The schema validates the length
+    to exactly 256 (HTTP 422 otherwise).
+
+    SECURITY — NO REPLAY/LIVENESS CHECK HERE: this path receives no audio, so
+    the spectral-fingerprint replay detector (which needs the decoded samples)
+    cannot run, and there is no live-capture proof. It therefore REQUIRES a
+    paired liveness factor enforced at the Identity Core layer before the result
+    is trusted as a login factor. On its own a matched embedding only proves
+    "this vector matches the template", not "a live person spoke now". Gated by
+    Identity Core ``app.auth.client-side-voice-embedding`` (default OFF); the
+    audio ``/voice/verify`` path is unchanged and remains the default + fallback.
+    """
+    try:
+        user_id = validate_user_id(request.user_id)
+
+        logger.info(
+            "verify-embedding (voice) request (no audio, liveness enforced "
+            f"upstream): user_id={user_id}"
+        )
+
+        probe_embedding = np.asarray(request.embedding, dtype=np.float32)
+        return await _match_probe_against_enrollment(user_id, probe_embedding)
+
+    except ValueError as e:
+        logger.warning(f"Voice embedding verification validation error: {e}")
+        raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Voice embedding verification failed: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail="Voice verification failed. Please try again.",
+        )
+
+
+# -- POST /voice/enroll-embedding ---------------------------------------------
+
+
+@router.post("/voice/enroll-embedding", response_model=BiometricResponse)
+async def enroll_voice_embedding(
+    request: VoiceEnrollEmbeddingRequest,
+) -> BiometricResponse:
+    """Enroll a user from a PRECOMPUTED 256-d speaker embedding (client-side).
+
+    The client computed the Resemblyzer speaker embedding locally — the raw
+    audio never leaves the device — and submits only the 256-vector. This
+    endpoint stores it via the SAME centroid path the audio ``/voice/enroll``
+    uses AFTER ``embed_utterance`` (``PgVectorVoiceRepository.save`` →
+    INDIVIDUAL row + recomputed CENTROID, encrypt-at-rest), but SKIPS the audio
+    decode, VAD, quality scoring and the server-side Resemblyzer forward pass.
+    The schema validates the length to exactly 256 (HTTP 422 otherwise).
+
+    Because there is no decoded audio there is no signal-quality metric to
+    compute, so the stored ``quality_score`` is a neutral 0.5 (the client gated
+    capture quality before computing the embedding). ``optimize=True`` takes the
+    same re-enroll fusion path as the audio route.
+
+    SECURITY: like ``/voice/verify-embedding``, no audio means no liveness /
+    replay check here; the Identity Core layer MUST pair it with a liveness
+    factor. Gated by ``app.auth.client-side-voice-embedding`` (default OFF).
+    """
+    try:
+        user_id = validate_user_id(request.user_id)
+
+        logger.info(
+            "enroll-embedding (voice) request (no audio, liveness enforced "
+            f"upstream): user_id={user_id}, optimize={request.optimize}"
+        )
+
+        embedding = np.asarray(request.embedding, dtype=np.float32)
+
+        # Reuse the EXACT centroid storage tail of the audio enroll path. There
+        # is no decoded audio to score, so persist at a neutral 0.5 quality
+        # (DB column is 0..1; the audio path rescales its 0..100 metric to this).
+        repo = get_voice_repository()
+        await repo.save(
+            user_id=user_id,
+            embedding=embedding,
+            quality_score=0.5,
+            fuse_with_existing=request.optimize,
+        )
+
+        logger.info(
+            f"Voice enrolled (precomputed embedding): user_id={user_id}, "
+            f"dim={len(embedding)}, optimize={request.optimize}"
+        )
+
+        return BiometricResponse(
+            success=True,
+            message="Voice enrolled successfully (precomputed embedding)",
+            user_id=user_id,
+            embedding_dimension=len(embedding),
+            # 0..100 — identity-core-api rescales to 0..1 for user_enrollments.
+            quality_score=50.0,
+        )
+
+    except ValueError as e:
+        logger.warning(f"Voice embedding enrollment validation error: {e}")
+        raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Voice embedding enrollment failed: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail="Voice enrollment failed. Please try again.",
         )
 
 

--- a/app/core/container.py
+++ b/app/core/container.py
@@ -837,9 +837,13 @@ def get_speaker_embedder() -> SpeakerEmbedder:
     """Get speaker embedder instance (singleton).
 
     Returns:
-        SpeakerEmbedder using numba-free MFCC + torch projection (256-dim)
+        SpeakerEmbedder wrapping the pretrained Resemblyzer GE2E speaker encoder
+        — a ~17 MB pretrained 3-layer-LSTM + Linear torch model that emits 256-d
+        L2-normalized speaker embeddings (NOT a from-scratch MFCC projection;
+        the model is the real ``resemblyzer/pretrained.pt``). librosa supplies
+        the mel spectrogram input. See ``app/infrastructure/ml/voice/speaker_embedder.py``.
     """
-    logger.info("Creating speaker embedder (MFCC+torch, numba-free)")
+    logger.info("Creating speaker embedder (Resemblyzer GE2E LSTM, 256-dim)")
     return SpeakerEmbedder()
 
 

--- a/docs/design/VOICE_CLIENT_EMBEDDING_SPEC.md
+++ b/docs/design/VOICE_CLIENT_EMBEDDING_SPEC.md
@@ -1,0 +1,219 @@
+# GPU-less VOICE embedding — preprocessing + model contract (audit H3)
+
+**Status (2026-06-12):** Server endpoints + ONNX export are DONE and VERIFIED.
+The browser preprocessing port is SPEC'd here but NOT yet verified to parity —
+the web-app voice-embedding module ships as a **documented scaffold behind a
+default-OFF flag**. Read "Honesty / completeness" at the bottom before enabling.
+
+This is the load-bearing contract the browser MUST reproduce so a client-computed
+256-d speaker embedding matches the server's. Getting any step wrong silently
+produces a vector that fails to match the enrolled template (or, worse, weakly
+matches the wrong person). Do not enable the client path until each step here is
+validated against the Python reference.
+
+---
+
+## What this replaces
+
+Today VOICE login + enroll send raw base64 audio to the bio service, which runs
+the pretrained **Resemblyzer GE2E speaker encoder** (a ~17 MB torch 3-layer LSTM,
+`resemblyzer/pretrained.pt`) on the CPU-only box to produce a 256-d embedding
+(`app/infrastructure/ml/voice/speaker_embedder.py` → `embed_utterance`).
+
+The GPU-less path moves that embedding into the browser: the audio never leaves
+the device, only the 256-float vector is uploaded, and the server skips the
+decode + VAD + forward pass. Flag-gated, default OFF (flag OFF = today's exact
+server-side behaviour).
+
+- Server endpoints (DONE): `POST /voice/verify-embedding`, `POST /voice/enroll-embedding`
+  (`app/api/routes/voice.py`). They reuse the SAME pgvector cosine compare /
+  centroid storage as `/voice/verify` + `/voice/enroll` run AFTER the embed step,
+  just skipping the embed. Length-validated to exactly 256 (HTTP 422 otherwise).
+- ONNX export (DONE + verified): `scripts/export_resemblyzer_onnx.py`.
+- Identity Core gate: `app.auth.client-side-voice-embedding` (default OFF).
+- Web flag: `VITE_CLIENT_SIDE_VOICE_EMBEDDING` (default OFF).
+
+---
+
+## The model
+
+`VoiceEncoder.forward(mels) -> embeds` (resemblyzer `voice_encoder.py`):
+
+```
+mels  : float32 (batch, n_frames, 40)     # 40-channel mel spectrogram frames
+  -> LSTM(input=40, hidden=256, num_layers=3, batch_first=True)
+  -> take last layer's final hidden state h[-1]          (batch, 256)
+  -> Linear(256 -> 256)
+  -> ReLU
+  -> L2-normalize over dim=1
+embeds: float32 (batch, 256)              # positive, unit-norm partial embeddings
+```
+
+Exported ONNX (`scripts/export_resemblyzer_onnx.py`):
+- input `mels` `(batch, n_frames, 40)` float32, **dynamic** batch + n_frames
+- output `embeds` `(batch, 256)` float32
+- opset 17, FP32, ~5.7 MB, exported from the SAME pinned `pretrained.pt` the
+  server runs (1,423,616 params).
+- **Verified:** torch-vs-ONNX cosine parity = **1.0** on random mel batches AND
+  end-to-end vs `embed_utterance` on a sample wav (run the script with `--wav`).
+
+> The model is exported at **batch=1** (n_frames dynamic) to avoid the
+> TorchScript exporter's variable-length-LSTM-with-batch>1 caveat. The browser
+> runs one partial utterance per inference (or loops over partials), which is the
+> real client shape anyway. onnxruntime-web still accepts any batch on the
+> dynamic axis, but feed batch=1 to stay on the proven path.
+
+### Model delivery (mirror facenet512)
+- Host the FP32 `.onnx` at `app.fivucsas.com/models/` as
+  `resemblyzer-<sha256>.onnx` (same bucket as facenet512). FP32 is the ship
+  format (the model is only 5.7 MB; do NOT INT8-quantize — onnxruntime-web WASM
+  lacks the quant ops, same finding as facenet).
+- In web-app set `DEFAULT_VOICE_MODEL_URL` / `DEFAULT_VOICE_MODEL_SHA256`
+  constants + add a `public/models/manifest.json` entry **only after the file is
+  actually hosted** — adding it before hosting FATALs the build (`fetch-models`),
+  the exact failure facenet hit. While dark, fetch the model at RUNTIME only when
+  the flag is ON.
+- onnxruntime-web execution provider: `['wasm']` (mirror `FacenetEmbedder`),
+  `wasmPaths` pinned to the jsdelivr ORT dist matching the web-app's
+  `onnxruntime-web` version.
+
+---
+
+## The preprocessing the browser MUST reproduce
+
+All constants are from resemblyzer `hparams.py`. **This is where parity is hard.**
+The full reference chain is `preprocess_wav` → `wav_to_mel_spectrogram` →
+`embed_utterance`'s partial slicing → model → mean + L2-norm.
+
+### Step 0 — decode to 16 kHz mono float32 PCM in [-1, 1]
+The web-app already produces this: `useVoiceRecorder` records WebM/Opus and
+converts to **16 kHz mono 16-bit PCM WAV** via `encodeToWav16kMono`
+(`src/features/auth/utils/audioToWav16k.ts`). Decode that WAV to a Float32Array
+in [-1, 1]. `sampling_rate = 16000`.
+
+### Step 1 — `preprocess_wav` (resemblyzer `audio.py`)
+Two operations, in order:
+
+**1a. Volume normalize (increase-only) to -30 dBFS** (`normalize_volume`):
+```
+int16_max = 32767
+rms        = sqrt(mean((wav * int16_max)^2))
+wave_dBFS  = 20 * log10(rms / int16_max)
+dBFS_change = -30 - wave_dBFS
+if dBFS_change < 0: return wav            # increase_only: never attenuate
+return wav * (10 ^ (dBFS_change / 20))
+```
+Trivial to port exactly. Validate to ~1e-6.
+
+**1b. `trim_long_silences` — WebRTC VAD silence trimming. ← THE HARD PART.**
+```
+samples_per_window = (30 * 16000) // 1000 = 480 samples (30 ms)
+trim wav to a multiple of 480
+pcm16 = round(wav * 32767) as int16
+vad = webrtcvad.Vad(mode=3)               # AGGRESSIVE mode
+for each 480-sample (30 ms) window: voice_flags.append(vad.is_speech(window, 16000))
+# moving-average smooth, width = vad_moving_average_width = 8
+audio_mask = round(moving_average(voice_flags, 8)).astype(bool)
+# dilate voiced regions by (vad_max_silence_length + 1) = 7
+audio_mask = binary_dilation(audio_mask, ones(7))
+audio_mask = repeat(audio_mask, 480)      # back to sample resolution
+return wav[audio_mask]
+```
+`webrtcvad` is a C extension wrapping Google's WebRTC GMM-based VAD; there is no
+canonical JS port that is bit-exact. Options for the browser, in order of
+preference:
+  1. **A faithful WASM build of libwebrtc-vad** fed the identical 30 ms / mode-3
+     frames, then reproduce the width-8 moving average + 7-wide dilation in JS.
+     This is the only route that can be byte-exact; it MUST be validated frame-by-
+     frame against the Python `voice_flags` array before trust.
+  2. An energy/spectral VAD approximation — DOES NOT MATCH and measurably shifts
+     the embedding (see "Honesty" below). Only acceptable if re-validated to keep
+     same-speaker cosine comfortably above the 0.65 accept threshold across noisy
+     real clips, which has NOT been done here.
+
+### Step 2 — `wav_to_mel_spectrogram` (resemblyzer `audio.py`)
+**NOT a log-mel — raw power mel.** Exactly `librosa.feature.melspectrogram`:
+```
+n_fft      = int(16000 * 25 / 1000) = 400      # 25 ms window
+hop_length = int(16000 * 10 / 1000) = 160      # 10 ms hop
+n_mels     = 40
+sr         = 16000
+return melspectrogram(y=wav, sr, n_fft, hop_length, n_mels).astype(float32).T
+```
+librosa defaults that MUST be matched (they are load-bearing):
+- `win_length = n_fft = 400`, **Hann** window, `center=True` (reflect-pad by
+  `n_fft//2`), `power=2.0` (power spectrogram).
+- Mel filterbank: `htk=False` (Slaney mel scale), `norm='slueney'` (Slaney area
+  normalization), `fmin=0.0`, `fmax=sr/2=8000`.
+- Output transposed to `(n_frames, 40)`.
+A JS STFT + Slaney mel filterbank must reproduce librosa's exact frame centering,
+window, and mel-filter construction. Validate the mel matrix to a tight tolerance
+against the Python reference on the same wav.
+
+### Step 3 — partial slicing + mean + final L2-norm (`embed_utterance`)
+```
+rate = 1.3, min_coverage = 0.75, partials_n_frames = 160 (1.6 s)
+wav_slices, mel_slices = compute_partial_slices(len(wav), rate, min_coverage)
+pad wav with zeros up to wav_slices[-1].stop if needed
+mel = wav_to_mel_spectrogram(wav)
+mels = stack([mel[s] for s in mel_slices])          # (n_partials, 160, 40)
+partial_embeds = model(mels)                         # (n_partials, 256)  via ONNX
+raw_embed = mean(partial_embeds, axis=0)
+embed = raw_embed / ||raw_embed||_2                  # final 256-d UPLOAD vector
+```
+`compute_partial_slices` is pure index arithmetic (resemblyzer `voice_encoder.py`)
+— port it directly. Run each 160-frame partial through the ONNX model (batch=1),
+average, L2-normalize, and that is the vector to upload.
+
+---
+
+## Reproducing / regenerating the model
+
+The model is a reproducible build artifact (gitignored; only the script is
+committed). Inside the bio Docker image (which has resemblyzer + torch):
+
+```bash
+docker run --rm \
+  -v "$PWD/scripts:/scripts:ro" -v /tmp/voice_out:/out \
+  --entrypoint bash <bio-image> -c \
+  "pip install -q onnx onnxruntime && python /scripts/export_resemblyzer_onnx.py --out /out"
+# end-to-end parity vs embed_utterance on a real clip:
+#   python /scripts/export_resemblyzer_onnx.py --out /out --wav /out/sample.wav
+```
+The script fails (exit 1) if torch↔ONNX cosine parity drops below 0.999, so a
+broken export can never ship. Take the printed sha256, rename to
+`resemblyzer-<sha256>.onnx`, host it, and wire the web-app constants.
+
+---
+
+## Honesty / completeness — what is verified vs scaffold
+
+**Fully working + verified (evidence):**
+- The two bio endpoints `/voice/verify-embedding` + `/voice/enroll-embedding`
+  reuse the exact downstream compare/store logic; covered by unit tests in
+  `tests/unit/api/test_voice_routes.py` (the embedding verify path is asserted to
+  reach an IDENTICAL verdict to the audio path for the same probe + centroid).
+- The ONNX export is byte-faithful to the production torch model: torch↔ONNX
+  cosine = 1.0 on random mel batches AND end-to-end vs `embed_utterance`.
+
+**Scaffold / NOT yet verified (do not trust until done):**
+- The **browser preprocessing port** (Steps 1b + 2). Measured sensitivity: with
+  the synthesized reference clip, skipping the WebRTC VAD trim (the realistic
+  "JS without a webrtcvad WASM build" shortcut) gives same-clip cosine **≈0.89**
+  vs the full server preprocessing — still far above an impostor (**≈0.40**), but
+  the enrolled template was computed server-side WITH the VAD, and the accept
+  threshold is **0.65**. A ~0.11 cross-preprocessing gap on clean audio will be
+  larger on noisy real-world audio and risks false-rejects near the threshold.
+  Therefore the client mel + VAD MUST be validated to parity (Step 1b option 1)
+  before `VITE_CLIENT_SIDE_VOICE_EMBEDDING` is enabled in any real flow.
+
+**Exact steps remaining to canary the end-to-end client path:**
+1. Build/obtain a WASM webrtcvad (mode 3, 30 ms, 16 kHz) and a librosa-parity
+   Slaney mel STFT in JS; validate both against the Python reference on a corpus
+   of real clips (target: same-speaker client-vs-server cosine ≥ ~0.95).
+2. Host `resemblyzer-<sha256>.onnx` at `app.fivucsas.com/models/`, set the
+   web-app constants, add the `manifest.json` entry (only after hosting).
+3. Flip the Identity Core flag `app.auth.client-side-voice-embedding` ON FIRST
+   (identity→web ordering, same caveat as facenet), then
+   `VITE_CLIENT_SIDE_VOICE_EMBEDDING`, canary one tenant, compare verify
+   accept-rates client-vs-server before broadening.

--- a/scripts/export_resemblyzer_onnx.py
+++ b/scripts/export_resemblyzer_onnx.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Export the Resemblyzer VoiceEncoder (GE2E speaker encoder) to ONNX.
+
+This produces the *shippable client model* for the browser-side voice-embedding
+path (compute the 256-d speaker embedding in the browser via onnxruntime-web,
+upload only the vector -- the raw audio never leaves the device). It is built
+from the SAME pretrained weights the server already runs
+(``resemblyzer/pretrained.pt``, the ~17 MB GE2E LSTM encoder baked into the bio
+image) so the exported model matches the production Resemblyzer encoder exactly.
+
+The model itself is tiny and trivially exportable: a 3-layer LSTM
+(input 40-channel mel, hidden 256) -> Linear(256->256) -> ReLU -> L2-normalize.
+``forward(mels)`` maps a batch of mel spectrograms of shape
+``(batch, n_frames, 40)`` to ``(batch, 256)`` unit-norm partial embeddings.
+
+  *** PREPROCESSING IS THE HARD PART, NOT THE MODEL. ***
+The browser MUST reproduce Resemblyzer's exact audio preprocessing to get a
+matching embedding (see ``docs/design/VOICE_CLIENT_EMBEDDING_SPEC.md`` for the
+precise, load-bearing contract). The two costly pieces are:
+  1. ``preprocess_wav`` -- dBFS volume normalization (increase-only to -30 dBFS)
+     + ``trim_long_silences`` (WebRTC VAD mode 3, 30 ms windows, 8-frame moving
+     average, dilation by ``vad_max_silence_length+1``). webrtcvad is a C
+     extension; a JS port is approximate and MUST be validated before trust.
+  2. ``wav_to_mel_spectrogram`` -- librosa.feature.melspectrogram with
+     n_fft=400, hop=160, n_mels=40, sr=16000 (NOT a log-mel; raw power mel).
+  3. ``embed_utterance`` -- split into 1.6 s (160-frame) partials at rate=1.3
+     with min_coverage=0.75, run each through the model, then L2-norm the MEAN
+     of the partial embeddings.
+
+This script exports ONLY the neural net (step: mels -> 256-d). The partial
+slicing + mean + final L2-norm of ``embed_utterance`` and ALL of the audio
+preprocessing must be reproduced in JS (or done with a second small ONNX/DSP
+path). The exported model has a DYNAMIC ``n_frames`` axis so the browser can
+feed either a single 160-frame partial or batch all partials at once.
+
+Pipeline:
+  1. Load the Resemblyzer ``VoiceEncoder`` (loads the pinned ``pretrained.pt``).
+  2. ``torch.onnx.export`` -> ONNX (opset 17, input (B, n_frames, 40) float32,
+     dynamic batch + n_frames).
+  3. Parity-check the ONNX model vs the torch ``forward`` on random + real mel
+     batches (cosine should be >= ~0.9999). Optionally end-to-end vs
+     ``embed_utterance`` on a sample wav if one is provided.
+  4. Print the shipped model's sha256 + byte size.
+
+The model lands OUTSIDE git (default /tmp/voice_out); the repo gitignores
+``*.onnx``/``*.pt``. Only this script is version-controlled -- the model is a
+reproducible build artifact, hosted at app.fivucsas.com/models/ alongside
+facenet512 (see docs/design/VOICE_CLIENT_EMBEDDING_SPEC.md "Model delivery").
+
+Usage (inside the bio Docker image, which has resemblyzer + torch + onnx):
+  python scripts/export_resemblyzer_onnx.py
+  python scripts/export_resemblyzer_onnx.py --out /models
+  python scripts/export_resemblyzer_onnx.py --wav /tmp/sample.wav   # e2e parity
+  python scripts/export_resemblyzer_onnx.py --opset 17
+
+Requires: torch, resemblyzer, onnx, onnxruntime (all in
+requirements-known-good-2026-05-29.lock / the bio image). Run with:
+  docker run --rm -v "$PWD/scripts:/scripts:ro" -v /tmp/voice_out:/out \\
+      --entrypoint python <bio-image> /scripts/export_resemblyzer_onnx.py --out /out
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import sys
+import time
+
+# Resemblyzer's mel input dimensionality + model output size (hparams.py).
+MEL_N_CHANNELS = 40
+EMBEDDING_DIM = 256
+# A single partial utterance is 160 frames (1.6 s); a representative export
+# sample shape. The exported graph keeps n_frames dynamic.
+PARTIAL_N_FRAMES = 160
+MIN_PARITY_COS = 0.999
+
+
+def sha256_of(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def build_encoder():
+    """Load the Resemblyzer VoiceEncoder on CPU (loads the pinned weights)."""
+    import torch
+    from resemblyzer import VoiceEncoder
+
+    encoder = VoiceEncoder(device="cpu", verbose=True)
+    encoder.eval()
+    # forward() uses no_grad-free LSTM; ensure inference mode for export.
+    for p in encoder.parameters():
+        p.requires_grad_(False)
+    return encoder, torch
+
+
+def export_onnx(encoder, torch, out_path: str, opset: int) -> None:
+    """Export VoiceEncoder.forward (mels -> 256-d) to ONNX with dynamic axes."""
+    # (batch=1, n_frames=160, 40) representative input. The TorchScript ONNX
+    # exporter warns that a variable-length LSTM exported with batch>1 can fail
+    # at a different runtime batch size unless h0/c0 are graph inputs; exporting
+    # at batch=1 (with n_frames still dynamic) sidesteps that entirely. The
+    # browser runs one partial utterance per inference (or loops), so batch=1 is
+    # the real client shape anyway.
+    dummy = torch.randn(1, PARTIAL_N_FRAMES, MEL_N_CHANNELS, dtype=torch.float32)
+    # dynamo=False -> the legacy TorchScript ONNX exporter, which has no
+    # onnxscript dependency and handles the dynamic-axes LSTM cleanly. (torch
+    # 2.11's default dynamo exporter needs the optional ``onnxscript`` package,
+    # which is not in the bio image's pinned deps.)
+    torch.onnx.export(
+        encoder,
+        dummy,
+        out_path,
+        export_params=True,
+        opset_version=opset,
+        do_constant_folding=True,
+        input_names=["mels"],
+        output_names=["embeds"],
+        dynamic_axes={
+            "mels": {0: "batch", 1: "n_frames"},
+            "embeds": {0: "batch"},
+        },
+        dynamo=False,
+    )
+
+
+def _cos(a, b) -> float:
+    import numpy as np
+
+    a = np.asarray(a, dtype=np.float64).ravel()
+    b = np.asarray(b, dtype=np.float64).ravel()
+    na, nb = np.linalg.norm(a), np.linalg.norm(b)
+    if na == 0 or nb == 0:
+        return 0.0
+    return float(np.dot(a, b) / (na * nb))
+
+
+def parity_check(onnx_path: str, encoder, torch, wav_path: str | None) -> dict:
+    """Compare ONNX vs torch ``forward`` on random mel batches, plus an optional
+    end-to-end ``embed_utterance`` comparison on a real wav.
+
+    Returns a dict of {case: min_cosine}. The model is deterministic, so parity
+    should be ~1.0 (>= MIN_PARITY_COS); a regression means the export is wrong
+    and the client port MUST NOT be trusted.
+    """
+    import numpy as np
+    import onnxruntime as ort
+
+    sess = ort.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
+    inp = sess.get_inputs()[0].name
+
+    results: dict[str, float] = {}
+
+    # --- random-mel batches (varied n_frames + batch) ------------------------
+    rng = np.random.default_rng(1234)
+    cos_min = 1.0
+    for batch, n_frames in [(1, 160), (3, 160), (1, 80), (5, 200)]:
+        mels = rng.standard_normal((batch, n_frames, MEL_N_CHANNELS)).astype(np.float32)
+        with torch.no_grad():
+            t_out = encoder(torch.from_numpy(mels)).cpu().numpy()
+        o_out = sess.run(None, {inp: mels})[0]
+        for i in range(batch):
+            cos_min = min(cos_min, _cos(t_out[i], o_out[i]))
+    results["random_mels"] = round(cos_min, 6)
+    print(f"[parity] random_mels MIN cos(torch, onnx) = {results['random_mels']}")
+
+    # --- end-to-end on a real wav (optional) ---------------------------------
+    if wav_path:
+        from resemblyzer import preprocess_wav
+        from resemblyzer.audio import wav_to_mel_spectrogram
+
+        wav = preprocess_wav(wav_path)
+        # Reproduce embed_utterance's partial slicing, but run the ONNX model
+        # for the partials and compare to the torch embed_utterance result.
+        ref_embed = encoder.embed_utterance(wav)
+
+        wav_slices, mel_slices = encoder.compute_partial_slices(len(wav), rate=1.3, min_coverage=0.75)
+        max_wave_length = wav_slices[-1].stop
+        if max_wave_length >= len(wav):
+            wav = np.pad(wav, (0, max_wave_length - len(wav)), "constant")
+        mel = wav_to_mel_spectrogram(wav)
+        mels = np.array([mel[s] for s in mel_slices]).astype(np.float32)
+        partial_embeds = sess.run(None, {inp: mels})[0]
+        raw = np.mean(partial_embeds, axis=0)
+        onnx_embed = raw / np.linalg.norm(raw, 2)
+        results["e2e_embed_utterance"] = round(_cos(ref_embed, onnx_embed), 6)
+        print(
+            f"[parity] e2e_embed_utterance cos(torch, onnx) = "
+            f"{results['e2e_embed_utterance']}"
+        )
+
+    return results
+
+
+def report(path: str) -> None:
+    size = os.path.getsize(path)
+    print("\n=== SHIPPABLE MODEL (Resemblyzer VoiceEncoder, FP32) ===")
+    print(f"path   : {path}")
+    print(f"bytes  : {size} ({size / 1e6:.2f} MB)")
+    print(f"sha256 : {sha256_of(path)}")
+    print(
+        "\nNEXT: host this at app.fivucsas.com/models/ as "
+        "resemblyzer-<sha256>.onnx and set DEFAULT_VOICE_MODEL_URL/SHA256 + the "
+        "public/models/manifest.json entry in web-app. See "
+        "docs/design/VOICE_CLIENT_EMBEDDING_SPEC.md."
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--out", default="/tmp/voice_out",
+        help="output dir for the .onnx artifact (default /tmp/voice_out)",
+    )
+    ap.add_argument(
+        "--opset", type=int, default=17,
+        help="ONNX opset version (default 17; LSTM is well-supported >= 14)",
+    )
+    ap.add_argument(
+        "--wav", default=None,
+        help="optional path to a 16 kHz sample wav for end-to-end parity vs "
+             "embed_utterance",
+    )
+    ap.add_argument(
+        "--min-cos", type=float, default=MIN_PARITY_COS,
+        help=f"min acceptable parity cosine (default {MIN_PARITY_COS})",
+    )
+    ap.add_argument(
+        "--no-parity", action="store_true",
+        help="skip the torch<->onnx parity check",
+    )
+    args = ap.parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+    onnx_path = os.path.join(args.out, "resemblyzer_voice_encoder.onnx")
+
+    t0 = time.time()
+    encoder, torch = build_encoder()
+    n_params = sum(p.numel() for p in encoder.parameters())
+    print(f"[build] VoiceEncoder loaded: params={n_params:,} ({time.time() - t0:.1f}s)")
+
+    t0 = time.time()
+    export_onnx(encoder, torch, onnx_path, args.opset)
+    print(
+        f"[onnx] export OK opset{args.opset} -> {onnx_path} "
+        f"({os.path.getsize(onnx_path) / 1e6:.2f} MB, {time.time() - t0:.1f}s)"
+    )
+
+    if not args.no_parity:
+        parity = parity_check(onnx_path, encoder, torch, args.wav)
+        worst = min(parity.values()) if parity else 1.0
+        if worst < args.min_cos:
+            print(
+                f"[parity] FAIL: worst cosine {worst} < {args.min_cos}. "
+                f"The export is NOT faithful -- do not ship.",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"[parity] OK: worst cosine {worst} >= {args.min_cos}")
+
+    report(onnx_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/api/test_voice_routes.py
+++ b/tests/unit/api/test_voice_routes.py
@@ -432,3 +432,174 @@ async def test_verify_genuine_user_not_false_rejected_for_subunit_centroid():
     assert res.confidence == pytest.approx(1.0, abs=1e-3)
     assert res.confidence >= 0.65
     assert res.verified is True
+
+
+# ---------------------------------------------------------------------------
+# GPU-less VOICE (audit H3) — precomputed client-side embedding endpoints.
+#
+# /voice/verify-embedding + /voice/enroll-embedding accept a client-computed
+# 256-d Resemblyzer speaker embedding and run the SAME pgvector cosine compare /
+# centroid storage the audio routes run AFTER embed_utterance — skipping the
+# server-side decode/VAD/forward-pass (the raw audio never leaves the device).
+# Flag-gated at the Identity Core layer (default OFF); these tests pin the bio
+# endpoints' contract.
+# ---------------------------------------------------------------------------
+
+
+async def _run_verify_embedding(
+    probe: np.ndarray, centroid, user_id: str = "u"
+) -> "voice_routes.BiometricResponse":
+    """Drive verify_voice_embedding with a probe vector + stored centroid."""
+    repo = Mock()
+    repo.find_by_user_id = AsyncMock(return_value=centroid)
+    with patch.object(voice_routes, "get_voice_repository", return_value=repo):
+        req = voice_routes.VoiceEmbeddingRequest(
+            user_id=user_id, embedding=probe.tolist()
+        )
+        return await voice_routes.verify_voice_embedding(req)
+
+
+@pytest.mark.asyncio
+async def test_verify_embedding_matches_audio_path_decision():
+    """The embedding path must reach the IDENTICAL verdict as the audio path.
+
+    Same probe + same stored centroid → same confidence + verified, whether the
+    probe came from the server (verify_voice) or the client (verify_voice_embedding).
+    This guarantees the GPU-less path is a true behavioural mirror, not a new
+    decision rule.
+    """
+    probe = _unit_embedding(7)
+    centroid = _avg_centroid(7, 8, 9)
+
+    audio_res = await _run_verify(probe, centroid)
+    emb_res = await _run_verify_embedding(probe, centroid)
+
+    assert emb_res.confidence == pytest.approx(audio_res.confidence, abs=1e-6)
+    assert emb_res.verified == audio_res.verified
+    assert emb_res.success is True
+
+
+@pytest.mark.asyncio
+async def test_verify_embedding_genuine_match_verifies():
+    """A perfect-direction probe verifies via the embedding path (cosine 1.0)."""
+    probe = _unit_embedding(11)
+    centroid = (probe * 0.60).astype(np.float32)  # same direction, sub-unit norm
+
+    res = await _run_verify_embedding(probe, centroid)
+
+    assert res.confidence == pytest.approx(1.0, abs=1e-3)
+    assert res.verified is True
+
+
+@pytest.mark.asyncio
+async def test_verify_embedding_no_enrollment_returns_unverified():
+    """No stored voiceprint → success but verified False (not a 500)."""
+    repo = Mock()
+    repo.find_by_user_id = AsyncMock(return_value=None)
+    with patch.object(voice_routes, "get_voice_repository", return_value=repo):
+        req = voice_routes.VoiceEmbeddingRequest(
+            user_id="u", embedding=_unit_embedding(1).tolist()
+        )
+        res = await voice_routes.verify_voice_embedding(req)
+
+    assert res.success is False
+    assert res.verified is False
+    assert res.confidence == 0.0
+
+
+@pytest.mark.asyncio
+async def test_verify_embedding_never_decodes_audio():
+    """The embedding path must NOT call the audio extractor — it skips embed."""
+    repo = Mock()
+    repo.find_by_user_id = AsyncMock(return_value=_unit_embedding(2))
+    with patch.object(voice_routes, "get_voice_repository", return_value=repo), \
+         patch.object(voice_routes, "_extract_voice_embedding",
+                      AsyncMock(side_effect=AssertionError("must not decode audio"))):
+        req = voice_routes.VoiceEmbeddingRequest(
+            user_id="u", embedding=_unit_embedding(2).tolist()
+        )
+        await voice_routes.verify_voice_embedding(req)
+
+
+@pytest.mark.parametrize("bad_len", [128, 255, 257, 512])
+def test_verify_embedding_rejects_wrong_length(bad_len):
+    """The schema validates the embedding to EXACTLY 256 elements (→ 422)."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        voice_routes.VoiceEmbeddingRequest(
+            user_id="u", embedding=[0.0] * bad_len
+        )
+
+
+@pytest.mark.asyncio
+async def test_verify_embedding_invalid_user_id_returns_400():
+    """A malformed user_id is a clean 400, not a 500."""
+    from fastapi import HTTPException
+
+    req = voice_routes.VoiceEmbeddingRequest(
+        user_id="not a uuid !!", embedding=_unit_embedding(0).tolist()
+    )
+    with pytest.raises(HTTPException) as exc:
+        await voice_routes.verify_voice_embedding(req)
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_enroll_embedding_persists_via_repository_save():
+    """enroll-embedding stores the client vector via the SAME repo.save path.
+
+    It must skip the audio decode entirely and forward the 256-d vector +
+    optimize flag to the centroid storage the audio enroll uses.
+    """
+    repo = Mock()
+    repo.save = AsyncMock(return_value=None)
+
+    embedding = _unit_embedding(5)
+
+    with patch.object(voice_routes, "get_voice_repository", return_value=repo), \
+         patch.object(voice_routes, "_extract_voice_embedding",
+                      AsyncMock(side_effect=AssertionError("must not decode audio"))):
+        req = voice_routes.VoiceEnrollEmbeddingRequest(
+            user_id="55555555-5555-5555-5555-555555555555",
+            embedding=embedding.tolist(),
+            optimize=True,
+        )
+        res = await voice_routes.enroll_voice_embedding(req)
+
+    repo.save.assert_awaited_once()
+    _, kwargs = repo.save.await_args
+    assert kwargs.get("user_id") == "55555555-5555-5555-5555-555555555555"
+    # The 256-d client vector is forwarded verbatim to the centroid store.
+    np.testing.assert_allclose(np.asarray(kwargs.get("embedding")), embedding, rtol=1e-6)
+    assert kwargs.get("fuse_with_existing") is True
+    assert res.success is True
+    assert res.embedding_dimension == 256
+
+
+@pytest.mark.asyncio
+async def test_enroll_embedding_default_does_not_fuse():
+    """Default optimize=False → fuse_with_existing False (plain append/average)."""
+    repo = Mock()
+    repo.save = AsyncMock(return_value=None)
+
+    with patch.object(voice_routes, "get_voice_repository", return_value=repo):
+        req = voice_routes.VoiceEnrollEmbeddingRequest(
+            user_id="66666666-6666-6666-6666-666666666666",
+            embedding=_unit_embedding(6).tolist(),
+        )
+        await voice_routes.enroll_voice_embedding(req)
+
+    _, kwargs = repo.save.await_args
+    assert kwargs.get("fuse_with_existing") is False
+
+
+@pytest.mark.parametrize("bad_len", [128, 255, 257])
+def test_enroll_embedding_rejects_wrong_length(bad_len):
+    """The enroll schema also validates the embedding to EXACTLY 256 (→ 422)."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        voice_routes.VoiceEnrollEmbeddingRequest(
+            user_id="u", embedding=[0.0] * bad_len
+        )


### PR DESCRIPTION
## Summary

Audit item **H3** — move the VOICE speaker embedding off the CPU-only server. Today VOICE login + enroll send raw base64 audio to the bio service, which runs the pretrained **Resemblyzer GE2E** speaker encoder (a real ~17 MB torch 3-layer LSTM, **not** the "numba-free MFCC projection" the old container comment wrongly claimed) on the CX43. This adds the GPU-less path: the browser computes the 256-d embedding locally and uploads only the vector — the raw audio never leaves the device.

**Reversible + flag-gated, default OFF.** The audio `/voice/verify` + `/voice/enroll` path is completely unchanged and remains the default + fallback. The client path is gated at the Identity Core layer by `app.auth.client-side-voice-embedding` (default OFF); with the flag OFF the server behaviour is byte-identical to today.

## Endpoints (mirror the face `/verify-embedding` + `/enroll-embedding` routes)

- **`POST /voice/verify-embedding`** `{user_id, embedding[256]}` — runs the SAME pgvector cosine compare + 0.65 threshold as audio `/voice/verify` (both now share a `_match_probe_against_enrollment` helper + module-level `VERIFY_THRESHOLD`), skipping decode/VAD/quality/replay/forward-pass. Length-validated to exactly 256 (HTTP 422 otherwise).
- **`POST /voice/enroll-embedding`** `{user_id, embedding[256], optimize?}` — stores via the SAME `PgVectorVoiceRepository.save` centroid path (INDIVIDUAL row + recomputed CENTROID, encrypt-at-rest) as audio `/voice/enroll`; neutral 0.5 quality (no audio to score). `optimize=True` takes the re-enroll fusion path.

Refactored the audio verify to share the same compare tail so the two paths can never drift in their match semantics.

**SECURITY:** no audio means the spectral-fingerprint replay detector can't run and there is no live-capture proof. These paths REQUIRE a paired liveness factor enforced at the Identity Core layer — documented inline + in the spec.

## ONNX export — VERIFIED

`scripts/export_resemblyzer_onnx.py` exports the pinned `resemblyzer/pretrained.pt` (1,423,616 params) to ONNX (opset 17, FP32, ~5.7 MB, dynamic `n_frames`). Run inside the bio image. **torch↔ONNX cosine parity = 1.0** on random mel batches AND end-to-end vs `embed_utterance` on a sample wav; the script exits non-zero if parity < 0.999, so a broken export can never ship.

## Completeness — honest

- **Fully working + verified:** the two bio endpoints (unit tests assert the embedding verify path reaches an IDENTICAL verdict to the audio path) and the ONNX export (cosine 1.0).
- **Scaffold (NOT yet verified):** the browser preprocessing port (`preprocess_wav` WebRTC-VAD silence trim + librosa power-mel + partial slicing). WebRTC VAD has no bit-exact JS port; skipping it measured ≈0.89 same-clip cosine vs the full server preprocessing (impostor ≈0.40) — risky near the 0.65 accept threshold. Full load-bearing contract + verified-vs-scaffold status + canary steps in `docs/design/VOICE_CLIENT_EMBEDDING_SPEC.md`. **Do not enable the web flag until the client mel+VAD is validated to parity.**

## Tests

`tests/unit/api/test_voice_routes.py` +16 cases (verdict parity with the audio path, 256-length validation, no-audio-decode assertion, `repo.save` forwarding, optimize flag). **27/27 voice route tests pass** in the bio image.

Paired PRs: web-app (client module, default OFF) + identity-core-api (voice policy + handler routing + compose passthrough).