### PR TITLE
ci: repo structure-lock

### DIFF
--- a/.github/workflows/structure-check.yml
+++ b/.github/workflows/structure-check.yml
@@ -1,0 +1,19 @@
+# Repo structure-lock gate — mirrors the FIVUCSAS umbrella pilot
+# (Rollingcat-Software/FIVUCSAS#209).
+#
+# Thin caller for the org-shared reusable workflow. It FREEZES this repo's root
+# layout (see .repo-structure.yml) and FAILS the PR when a disallowed/forbidden
+# file appears — e.g. a stray dated tracking doc at the root.
+#
+# Owner step to make it BLOCK merges: add the status check named
+# "repo-structure / structure-check" (the reusable job) as a REQUIRED check in
+# this repo's branch protection / ruleset. See the PR body for context.
+name: structure-check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  repo-structure:
+    uses: Rollingcat-Software/.github/.github/workflows/repo-structure.yml@main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,3 +54,12 @@ repos:
         types: [python]
         args: ['--rcfile=pyproject.toml']
         exclude: ^tests/
+
+  # Repo structure-lock (mirrors FIVUCSAS#209) — fast local feedback mirroring
+  # the CI gate (.github/workflows/structure-check.yml). Freezes the root layout
+  # and blocks stray/dated tracking docs before they are committed. Pin `rev` to
+  # a tag/SHA once the org .github repo cuts one.
+  - repo: https://github.com/Rollingcat-Software/.github
+    rev: main
+    hooks:
+      - id: repo-structure

--- a/.repo-structure.yml
+++ b/.repo-structure.yml
@@ -1,0 +1,102 @@
+# Repo structure-lock policy — Rollingcat-Software/biometric-processor
+#
+# An ArchUnit-style FREEZE of this repo's ROOT layout, mirroring the FIVUCSAS
+# umbrella pilot (Rollingcat-Software/FIVUCSAS#209). The allowlists below were
+# frozen from the current origin/main root; the gate (tools/check_repo_structure.py
+# in the org .github repo, run via the reusable workflow
+# .github/workflows/repo-structure.yml) FAILS CI when:
+#   * a root entry not listed here appears, OR
+#   * any root entry matches a forbidden pattern, OR
+#   * a required file is missing.
+#
+# Dated tracking docs (audits / reviews / sessions / TODOs) belong in GitHub
+# issues, NOT the repo root — that is what forbidden_root_patterns encodes.
+# To intentionally add a NEW root entry, add it here in the SAME PR (the
+# explicit, reviewed "unfreeze"). Parsed by a stdlib-only YAML subset, so keep
+# to simple `- "string"` block lists.
+
+allowed_root_files:
+  - ".dockerignore"
+  - ".env.example"
+  - ".gitignore"
+  - ".pre-commit-config.yaml"
+  - ".repo-structure.yml"
+  - "ARCHITECTURE.md"
+  - "CHANGELOG.md"
+  - "CLAUDE.md"
+  - "DOCKER_SETUP.md"
+  - "Dockerfile"
+  - "Dockerfile.dev"
+  - "Dockerfile.gpu"
+  - "Dockerfile.init"
+  - "Dockerfile.laptop-gpu"
+  - "Dockerfile.liveness-overlay"
+  - "Dockerfile.optimized"
+  - "LICENSE"
+  - "NOTICE"
+  - "Procfile"
+  - "README.md"
+  - "SECURITY.md"
+  - "alembic.ini"
+  - "build.sh"
+  - "cloudbuild.yaml"
+  - "constraints.txt"
+  - "demo_local_fast.py"
+  - "demo_local_optimized.py"
+  - "docker-compose.prod.yml"
+  - "docker-compose.yml"
+  - "fix_database_schema.sql"
+  - "install.ps1"
+  - "list_endpoints.py"
+  - "openapi.json"
+  - "project.toml"
+  - "pyproject.toml"
+  - "pytest.ini"
+  - "railway.json"
+  - "render.yaml"
+  - "requirements-gcp.txt"
+  - "requirements-gpu.txt"
+  - "requirements-known-good-2026-05-29.lock"
+  - "requirements-laptop-gpu.txt"
+  - "requirements-lock.txt"
+  - "requirements-original.txt"
+  - "requirements-railway.txt"
+  - "requirements-render.txt"
+  - "requirements.txt"
+  - "runtime.txt"
+  - "test_api.ps1"
+  - "test_batch_endpoints.sh"
+  - "test_biometric_api.sh"
+  - "test_database_integration.sh"
+  - "test_deployed_from_browser.sh"
+  - "test_proctoring_workflow.sh"
+  - "verify_ports.sh"
+
+allowed_root_dirs:
+  - ".github"
+  - "alembic"
+  - "app"
+  - "demo-ui"
+  - "demo"
+  - "deploy"
+  - "desktop-demo"
+  - "docs"
+  - "infra"
+  - "k8s"
+  - "migrations"
+  - "scripts"
+  - "tests"
+
+# Dated / tracking-doc names that must NEVER reappear at the root.
+# These are Python `re` patterns, matched with re.search against each root entry
+# name. Tracking content goes in GitHub issues instead. Use SINGLE quotes so
+# backslashes stay literal (write \d and \. — not \\d) for the regex engine.
+forbidden_root_patterns:
+  - '.*_(AUDIT|REVIEW|FINDINGS|REGISTER|TRIAGE|SWEEP|STATUS|SESSION|RECONCILIATION)_.*\.md$'
+  - '.*_\d{4}-\d{2}-\d{2}.*\.md$'
+  - '^(TODO|ROADMAP|BACKLOG|OPERATOR_TODO|PERSONAL_TODO).*\.md$'
+
+required_files:
+  - "README.md"
+  - "LICENSE"
+  - ".gitignore"


### PR DESCRIPTION
## What

Adds a repo structure-lock gate, mirroring the FIVUCSAS umbrella pilot (Rollingcat-Software/FIVUCSAS#209). Additive-only — three new files, no source/config changes:

- `.repo-structure.yml` — freezes the **current** root file/dir layout (allowlists frozen from origin/main, so the check is GREEN on current state) and forbids future dated tracking-doc clutter at root (audits/reviews/sessions/TODO/ROADMAP).
- `.github/workflows/structure-check.yml` — thin caller of the org reusable workflow `Rollingcat-Software/.github/.github/workflows/repo-structure.yml@main`; produces the check `repo-structure / structure-check`.
- `.pre-commit-config.yaml` — appends the `repo-structure` local hook for fast local feedback (existing hooks retained).

## Why

Keeps the repo root clean — tracking content belongs in GitHub issues, not stray dated `*.md` files at root.

## Owner follow-up

The owner adds the additive ruleset / required status check (`repo-structure / structure-check`) to branch protection to make this blocking.