### PR TITLE
chore: link inline TODO/FIXME to tracking issues

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -930,7 +930,7 @@ class Settings(BaseSettings):
     # Audit 2026-04-19 remediation (ML-M1, ML-M5, ML-H4)
     # ---------------------------------------------------------------
     # ML-M1: SHA256 integrity check for DeepFace Facenet512 weights.
-    # TODO: populate with known-good hash once the model file is available.
+    # TODO(#166): populate with known-good hash once the model file is available.
     #   sha256sum ~/.deepface/weights/facenet512_weights.h5
     # When empty string, startup logs a WARNING and skips the check (does not raise).
     DEEPFACE_FACENET512_SHA256: str = Field(

--- a/app/infrastructure/ml/extractors/deepface_extractor.py
+++ b/app/infrastructure/ml/extractors/deepface_extractor.py
@@ -59,7 +59,7 @@ def _verify_model_integrity(model_name: str) -> None:
           and the file exists, the digest MUST match or startup is aborted.
         * If no pinned hash is configured, the check logs a WARNING and returns
           without raising — we do not want to break deploys before the hash
-          has been recorded. TODO: pin the hash.
+          has been recorded. TODO(#167): pin the hash.
         * If the weight file cannot be located (e.g. custom DEEPFACE_HOME), we
           log a warning but do not raise.
     """


### PR DESCRIPTION
Annotates 2 inline code markers with their tracking issue numbers (`TODO(#N):`). Markers kept in place; no behavior change.